### PR TITLE
update url in grammar.js to accept variables in curly brackets and accented characters

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -20,7 +20,7 @@ module.exports = grammar(json, {
     method: (_) => /(?:GET|POST|PATCH|DELETE|PUT)/,
 
     url: (_) =>
-      /((www|http:|https:)\/\/(?:w{1,3}\.)?[^\s.]+(?:\.[a-z]+)*(?::\d+)?|\{\{\w+\}\})([\w.,@?^=%&amp;:\/~+#-\{\}\u00C0-\u00FF]*[\w@?^=%&amp;\/~+#-])?/,
+      /((www|http:|https:)\/\/(?:w{1,3}\.)?[^\s.]+(?:\.[a-z]+)*(?::\d+)?|\{\{\w+\}\})([\w.,@?^=%&amp;:\/~+#\{\}\u00C0-\u00FF-]*[\w@?^=%&amp;\/~+#\u00C0-\u00FF-])?/,
 
     header: ($) =>
       seq(

--- a/grammar.js
+++ b/grammar.js
@@ -12,12 +12,12 @@ module.exports = grammar(json, {
   ],
 
   rules: {
-    document: ($, original) => optional(original),
+    document: ($, original) => repeat(original),
 
     request: ($) =>
       seq(field("method", $.method), $._whitespace, field("url", $.url)),
 
-    method: (_) => /(?:GET|POST|PATCH|DELETE|PUT)/,
+    method: (_) => /(GET|POST|PATCH|DELETE|PUT)/,
 
     url: (_) =>
       /((www|http:|https:)\/\/(?:w{1,3}\.)?[^\s.]+(?:\.[a-z]+)*(?::\d+)?|\{\{\w+\}\})([\w.,@?^=%&amp;:\/~+#\{\}\u00C0-\u00FF-]*[\w@?^=%&amp;\/~+#\u00C0-\u00FF-])?/,

--- a/grammar.js
+++ b/grammar.js
@@ -20,7 +20,7 @@ module.exports = grammar(json, {
     method: (_) => /(?:GET|POST|PATCH|DELETE|PUT)/,
 
     url: (_) =>
-      /(www|http:|https:)\/\/(?:w{1,3}\.)?[^\s.]+(?:\.[a-z]+)*(?::\d+)?([\w.,@?^=%&amp;:\/~+#-]*[\w@?^=%&amp;\/~+#-])?/,
+      /((www|http:|https:)\/\/(?:w{1,3}\.)?[^\s.]+(?:\.[a-z]+)*(?::\d+)?|\{\{\w+\}\})([\w.,@?^=%&amp;:\/~+#-\{\}\u00C0-\u00FF]*[\w@?^=%&amp;\/~+#-])?/,
 
     header: ($) =>
       seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2,16 +2,11 @@
   "name": "http",
   "rules": {
     "document": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_value"
-        },
-        {
-          "type": "BLANK"
-        }
-      ]
+      "type": "REPEAT",
+      "content": {
+        "type": "SYMBOL",
+        "name": "_value"
+      }
     },
     "_value": {
       "type": "CHOICE",
@@ -679,11 +674,11 @@
     },
     "method": {
       "type": "PATTERN",
-      "value": "(?:GET|POST|PATCH|DELETE|PUT)"
+      "value": "(GET|POST|PATCH|DELETE|PUT)"
     },
     "url": {
       "type": "PATTERN",
-      "value": "(www|http:|https:)\\/\\/(?:w{1,3}\\.)?[^\\s.]+(?:\\.[a-z]+)*(?::\\d+)?([\\w.,@?^=%&amp;:\\/~+#-]*[\\w@?^=%&amp;\\/~+#-])?"
+      "value": "((www|http:|https:)\\/\\/(?:w{1,3}\\.)?[^\\s.]+(?:\\.[a-z]+)*(?::\\d+)?|\\{\\{\\w+\\}\\})([\\w.,@?^=%&amp;:\\/~+#\\{\\}\\u00C0-\\u00FF-]*[\\w@?^=%&amp;\\/~+#\\u00C0-\\u00FF-])?"
     },
     "header": {
       "type": "SEQ",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -53,7 +53,7 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": false,
       "types": [
         {

--- a/src/parser.c
+++ b/src/parser.c
@@ -6,9 +6,9 @@
 #endif
 
 #define LANGUAGE_VERSION 13
-#define STATE_COUNT 51
-#define LARGE_STATE_COUNT 2
-#define SYMBOL_COUNT 38
+#define STATE_COUNT 70
+#define LARGE_STATE_COUNT 4
+#define SYMBOL_COUNT 39
 #define ALIAS_COUNT 0
 #define TOKEN_COUNT 23
 #define EXTERNAL_TOKEN_COUNT 0
@@ -51,9 +51,10 @@ enum {
   sym_json_file = 32,
   sym_external_body = 33,
   aux_sym__whitespace = 34,
-  aux_sym_object_repeat1 = 35,
-  aux_sym_array_repeat1 = 36,
-  aux_sym_string_content_repeat1 = 37,
+  aux_sym_document_repeat1 = 35,
+  aux_sym_object_repeat1 = 36,
+  aux_sym_array_repeat1 = 37,
+  aux_sym_string_content_repeat1 = 38,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -92,6 +93,7 @@ static const char * const ts_symbol_names[] = {
   [sym_json_file] = "json_file",
   [sym_external_body] = "external_body",
   [aux_sym__whitespace] = "_whitespace",
+  [aux_sym_document_repeat1] = "document_repeat1",
   [aux_sym_object_repeat1] = "object_repeat1",
   [aux_sym_array_repeat1] = "array_repeat1",
   [aux_sym_string_content_repeat1] = "string_content_repeat1",
@@ -133,6 +135,7 @@ static const TSSymbol ts_symbol_map[] = {
   [sym_json_file] = sym_json_file,
   [sym_external_body] = sym_external_body,
   [aux_sym__whitespace] = aux_sym__whitespace,
+  [aux_sym_document_repeat1] = aux_sym_document_repeat1,
   [aux_sym_object_repeat1] = aux_sym_object_repeat1,
   [aux_sym_array_repeat1] = aux_sym_array_repeat1,
   [aux_sym_string_content_repeat1] = aux_sym_string_content_repeat1,
@@ -280,6 +283,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = false,
     .named = false,
   },
+  [aux_sym_document_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
   [aux_sym_object_repeat1] = {
     .visible = false,
     .named = false,
@@ -363,127 +370,127 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   switch (state) {
     case 0:
       if (eof) ADVANCE(32);
-      if (lookahead == '"') ADVANCE(39);
-      if (lookahead == '#') ADVANCE(164);
+      if (lookahead == '"') ADVANCE(40);
+      if (lookahead == '#') ADVANCE(146);
       if (lookahead == '+') ADVANCE(9);
-      if (lookahead == ',') ADVANCE(34);
-      if (lookahead == '-') ADVANCE(84);
-      if (lookahead == '.') ADVANCE(154);
-      if (lookahead == '0') ADVANCE(57);
-      if (lookahead == ':') ADVANCE(36);
-      if (lookahead == '<') ADVANCE(161);
-      if (lookahead == 'D') ADVANCE(94);
-      if (lookahead == 'G') ADVANCE(95);
-      if (lookahead == 'P') ADVANCE(88);
-      if (lookahead == '[') ADVANCE(37);
+      if (lookahead == ',') ADVANCE(35);
+      if (lookahead == '-') ADVANCE(82);
+      if (lookahead == '.') ADVANCE(10);
+      if (lookahead == '0') ADVANCE(58);
+      if (lookahead == ':') ADVANCE(37);
+      if (lookahead == '<') ADVANCE(143);
+      if (lookahead == 'D') ADVANCE(91);
+      if (lookahead == 'G') ADVANCE(92);
+      if (lookahead == 'P') ADVANCE(85);
+      if (lookahead == '[') ADVANCE(38);
       if (lookahead == '\\') ADVANCE(23);
-      if (lookahead == ']') ADVANCE(38);
-      if (lookahead == 'f') ADVANCE(124);
-      if (lookahead == 'n') ADVANCE(145);
-      if (lookahead == 't') ADVANCE(137);
-      if (lookahead == '{') ADVANCE(33);
-      if (lookahead == '}') ADVANCE(35);
-      if (lookahead == '/' ||
-          lookahead == '_') ADVANCE(158);
+      if (lookahead == ']') ADVANCE(39);
+      if (lookahead == 'f') ADVANCE(121);
+      if (lookahead == 'h') ADVANCE(131);
+      if (lookahead == 'n') ADVANCE(133);
+      if (lookahead == 't') ADVANCE(128);
+      if (lookahead == 'w') ADVANCE(135);
+      if (lookahead == '{') ADVANCE(34);
+      if (lookahead == '}') ADVANCE(36);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(29)
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(59);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(60);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 1:
       if (lookahead == '\n') SKIP(5)
-      if (lookahead == '"') ADVANCE(39);
-      if (lookahead == '#') ADVANCE(53);
-      if (lookahead == '<') ADVANCE(162);
-      if (lookahead == 'D') ADVANCE(44);
-      if (lookahead == 'G') ADVANCE(45);
-      if (lookahead == 'P') ADVANCE(41);
+      if (lookahead == '"') ADVANCE(40);
+      if (lookahead == '#') ADVANCE(54);
+      if (lookahead == '<') ADVANCE(144);
+      if (lookahead == 'D') ADVANCE(45);
+      if (lookahead == 'G') ADVANCE(46);
+      if (lookahead == 'P') ADVANCE(42);
       if (lookahead == '\\') ADVANCE(23);
       if (lookahead == '\t' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(40);
+          lookahead == ' ') ADVANCE(41);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(54);
-      if (lookahead != 0) ADVANCE(55);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(55);
+      if (lookahead != 0) ADVANCE(56);
       END_STATE();
     case 2:
       if (lookahead == '\n') SKIP(2)
-      if (lookahead == 11) ADVANCE(153);
-      if (lookahead == '\r') ADVANCE(152);
-      if (lookahead == '#') ADVANCE(153);
-      if (lookahead == '<') ADVANCE(163);
-      if (lookahead == 'D') ADVANCE(100);
-      if (lookahead == 'G') ADVANCE(101);
-      if (lookahead == 'P') ADVANCE(90);
+      if (lookahead == 11) ADVANCE(140);
+      if (lookahead == '\r') ADVANCE(139);
+      if (lookahead == '#') ADVANCE(140);
+      if (lookahead == '<') ADVANCE(145);
+      if (lookahead == 'D') ADVANCE(97);
+      if (lookahead == 'G') ADVANCE(98);
+      if (lookahead == 'P') ADVANCE(87);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(152);
+          lookahead == ' ') ADVANCE(139);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
-      if (lookahead != 0) ADVANCE(153);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
+      if (lookahead != 0) ADVANCE(140);
       END_STATE();
     case 3:
-      if (lookahead == 11) ADVANCE(165);
-      if (lookahead == '#') ADVANCE(164);
-      if (lookahead == '<') ADVANCE(161);
-      if (lookahead == 'D') ADVANCE(94);
-      if (lookahead == 'G') ADVANCE(95);
-      if (lookahead == 'P') ADVANCE(88);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(166);
-      if (lookahead == '\n' ||
-          lookahead == '\r') SKIP(3)
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(158);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
-      END_STATE();
-    case 4:
-      if (lookahead == 11) ADVANCE(165);
-      if (lookahead == '#') ADVANCE(164);
-      if (lookahead == '<') ADVANCE(161);
-      if (lookahead == 'D') ADVANCE(97);
-      if (lookahead == 'G') ADVANCE(98);
-      if (lookahead == 'P') ADVANCE(89);
-      if (lookahead == 'h') ADVANCE(142);
-      if (lookahead == 'w') ADVANCE(148);
+      if (lookahead == 11) ADVANCE(147);
+      if (lookahead == '#') ADVANCE(146);
+      if (lookahead == '<') ADVANCE(143);
+      if (lookahead == 'D') ADVANCE(91);
+      if (lookahead == 'G') ADVANCE(92);
+      if (lookahead == 'P') ADVANCE(85);
+      if (lookahead == 'h') ADVANCE(131);
+      if (lookahead == 'w') ADVANCE(135);
       if (lookahead == '{') ADVANCE(15);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(166);
+          lookahead == ' ') ADVANCE(148);
       if (lookahead == '\n' ||
-          lookahead == '\r') SKIP(4)
+          lookahead == '\r') SKIP(3)
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      END_STATE();
+    case 4:
+      if (lookahead == 11) ADVANCE(147);
+      if (lookahead == '#') ADVANCE(146);
+      if (lookahead == '<') ADVANCE(143);
+      if (lookahead == 'D') ADVANCE(94);
+      if (lookahead == 'G') ADVANCE(95);
+      if (lookahead == 'P') ADVANCE(86);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(148);
+      if (lookahead == '\n' ||
+          lookahead == '\r') SKIP(4)
+      if (lookahead == '.' ||
+          lookahead == '/' ||
+          lookahead == '_') ADVANCE(141);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 5:
-      if (lookahead == '"') ADVANCE(39);
-      if (lookahead == '#') ADVANCE(164);
-      if (lookahead == '<') ADVANCE(161);
-      if (lookahead == 'D') ADVANCE(97);
-      if (lookahead == 'G') ADVANCE(98);
-      if (lookahead == 'P') ADVANCE(89);
+      if (lookahead == '"') ADVANCE(40);
+      if (lookahead == '#') ADVANCE(146);
+      if (lookahead == '<') ADVANCE(143);
+      if (lookahead == 'D') ADVANCE(91);
+      if (lookahead == 'G') ADVANCE(92);
+      if (lookahead == 'P') ADVANCE(85);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(5)
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 6:
       if (lookahead == '.') ADVANCE(22);
       if (lookahead == ',' ||
           lookahead == ':' ||
           lookahead == '{' ||
-          lookahead == '}') ADVANCE(79);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(78);
+          lookahead == '}') ADVANCE(77);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(76);
       if (lookahead == '#' ||
           lookahead == '%' ||
           lookahead == '&' ||
@@ -493,12 +500,12 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == '^' ||
           lookahead == '_' ||
           lookahead == '~' ||
-          (192 <= lookahead && lookahead <= 255)) ADVANCE(79);
+          (192 <= lookahead && lookahead <= 255)) ADVANCE(77);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '\r' &&
-          lookahead != ' ') ADVANCE(79);
+          lookahead != ' ') ADVANCE(77);
       END_STATE();
     case 7:
       if (lookahead == '/') ADVANCE(8);
@@ -507,15 +514,15 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '/') ADVANCE(14);
       END_STATE();
     case 9:
-      if (lookahead == '0') ADVANCE(58);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(59);
+      if (lookahead == '0') ADVANCE(59);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(60);
       END_STATE();
     case 10:
       if (lookahead == 'j') ADVANCE(13);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(60);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(61);
       END_STATE();
     case 11:
-      if (lookahead == 'n') ADVANCE(159);
+      if (lookahead == 'n') ADVANCE(142);
       END_STATE();
     case 12:
       if (lookahead == 'o') ADVANCE(11);
@@ -524,13 +531,13 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == 's') ADVANCE(12);
       END_STATE();
     case 14:
-      if (lookahead == 'w') ADVANCE(74);
+      if (lookahead == 'w') ADVANCE(72);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '\r' &&
           lookahead != ' ' &&
-          lookahead != '.') ADVANCE(79);
+          lookahead != '.') ADVANCE(77);
       END_STATE();
     case 15:
       if (lookahead == '{') ADVANCE(28);
@@ -543,16 +550,16 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(16);
       END_STATE();
     case 17:
-      if (lookahead == '}') ADVANCE(82);
+      if (lookahead == '}') ADVANCE(80);
       END_STATE();
     case 18:
       if (lookahead == '+' ||
           lookahead == '-') ADVANCE(26);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(63);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(64);
       END_STATE();
     case 19:
       if (lookahead == '0' ||
-          lookahead == '1') ADVANCE(61);
+          lookahead == '1') ADVANCE(62);
       END_STATE();
     case 20:
       if (lookahead == ',' ||
@@ -560,8 +567,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == ':' ||
           lookahead == '{' ||
           lookahead == '}') ADVANCE(22);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(81);
-      if (sym_url_character_set_1(lookahead)) ADVANCE(82);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(79);
+      if (sym_url_character_set_1(lookahead)) ADVANCE(80);
       END_STATE();
     case 21:
       if (lookahead == ',' ||
@@ -569,524 +576,6 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == ':' ||
           lookahead == '{' ||
           lookahead == '}') ADVANCE(22);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(80);
-      if (lookahead == '#' ||
-          lookahead == '%' ||
-          lookahead == '&' ||
-          ('+' <= lookahead && lookahead <= ';') ||
-          lookahead == '=' ||
-          ('?' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '^' ||
-          lookahead == '_' ||
-          lookahead == '~' ||
-          (192 <= lookahead && lookahead <= 255)) ADVANCE(82);
-      END_STATE();
-    case 22:
-      if (lookahead == ',' ||
-          lookahead == '.' ||
-          lookahead == ':' ||
-          lookahead == '{' ||
-          lookahead == '}') ADVANCE(22);
-      if (sym_url_character_set_1(lookahead)) ADVANCE(82);
-      END_STATE();
-    case 23:
-      if (lookahead == '"' ||
-          lookahead == '/' ||
-          lookahead == '\\' ||
-          lookahead == 'b' ||
-          lookahead == 'n' ||
-          lookahead == 'r' ||
-          lookahead == 't' ||
-          lookahead == 'u') ADVANCE(56);
-      END_STATE();
-    case 24:
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(62);
-      END_STATE();
-    case 25:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(60);
-      END_STATE();
-    case 26:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(63);
-      END_STATE();
-    case 27:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(64);
-      END_STATE();
-    case 28:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(16);
-      END_STATE();
-    case 29:
-      if (eof) ADVANCE(32);
-      if (lookahead == '"') ADVANCE(39);
-      if (lookahead == '#') ADVANCE(164);
-      if (lookahead == '+') ADVANCE(9);
-      if (lookahead == ',') ADVANCE(34);
-      if (lookahead == '-') ADVANCE(84);
-      if (lookahead == '.') ADVANCE(154);
-      if (lookahead == '0') ADVANCE(57);
-      if (lookahead == ':') ADVANCE(36);
-      if (lookahead == '<') ADVANCE(161);
-      if (lookahead == 'D') ADVANCE(94);
-      if (lookahead == 'G') ADVANCE(95);
-      if (lookahead == 'P') ADVANCE(88);
-      if (lookahead == '[') ADVANCE(37);
-      if (lookahead == ']') ADVANCE(38);
-      if (lookahead == 'f') ADVANCE(124);
-      if (lookahead == 'n') ADVANCE(145);
-      if (lookahead == 't') ADVANCE(137);
-      if (lookahead == '{') ADVANCE(33);
-      if (lookahead == '}') ADVANCE(35);
-      if (lookahead == '/' ||
-          lookahead == '_') ADVANCE(158);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') SKIP(29)
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(59);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
-      END_STATE();
-    case 30:
-      if (eof) ADVANCE(32);
-      if (lookahead == '"') ADVANCE(39);
-      if (lookahead == '#') ADVANCE(164);
-      if (lookahead == '+') ADVANCE(9);
-      if (lookahead == ',') ADVANCE(34);
-      if (lookahead == '-') ADVANCE(85);
-      if (lookahead == '.') ADVANCE(10);
-      if (lookahead == '0') ADVANCE(57);
-      if (lookahead == ':') ADVANCE(36);
-      if (lookahead == '<') ADVANCE(161);
-      if (lookahead == 'D') ADVANCE(97);
-      if (lookahead == 'G') ADVANCE(98);
-      if (lookahead == 'P') ADVANCE(89);
-      if (lookahead == ']') ADVANCE(38);
-      if (lookahead == '}') ADVANCE(35);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') SKIP(30)
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(59);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
-      END_STATE();
-    case 31:
-      if (eof) ADVANCE(32);
-      if (lookahead == '"') ADVANCE(39);
-      if (lookahead == '#') ADVANCE(164);
-      if (lookahead == '+') ADVANCE(9);
-      if (lookahead == '-') ADVANCE(85);
-      if (lookahead == '.') ADVANCE(25);
-      if (lookahead == '0') ADVANCE(57);
-      if (lookahead == '<') ADVANCE(161);
-      if (lookahead == 'D') ADVANCE(97);
-      if (lookahead == 'G') ADVANCE(98);
-      if (lookahead == 'P') ADVANCE(89);
-      if (lookahead == '[') ADVANCE(37);
-      if (lookahead == ']') ADVANCE(38);
-      if (lookahead == 'f') ADVANCE(125);
-      if (lookahead == 'n') ADVANCE(146);
-      if (lookahead == 't') ADVANCE(138);
-      if (lookahead == '{') ADVANCE(33);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') SKIP(31)
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(59);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
-      END_STATE();
-    case 32:
-      ACCEPT_TOKEN(ts_builtin_sym_end);
-      END_STATE();
-    case 33:
-      ACCEPT_TOKEN(anon_sym_LBRACE);
-      END_STATE();
-    case 34:
-      ACCEPT_TOKEN(anon_sym_COMMA);
-      END_STATE();
-    case 35:
-      ACCEPT_TOKEN(anon_sym_RBRACE);
-      END_STATE();
-    case 36:
-      ACCEPT_TOKEN(anon_sym_COLON);
-      END_STATE();
-    case 37:
-      ACCEPT_TOKEN(anon_sym_LBRACK);
-      END_STATE();
-    case 38:
-      ACCEPT_TOKEN(anon_sym_RBRACK);
-      END_STATE();
-    case 39:
-      ACCEPT_TOKEN(anon_sym_DQUOTE);
-      END_STATE();
-    case 40:
-      ACCEPT_TOKEN(aux_sym_string_content_token1);
-      if (lookahead == '#') ADVANCE(53);
-      if (lookahead == '<') ADVANCE(162);
-      if (lookahead == 'D') ADVANCE(44);
-      if (lookahead == 'G') ADVANCE(45);
-      if (lookahead == 'P') ADVANCE(41);
-      if (lookahead == '\t' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(40);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(54);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '"' &&
-          lookahead != '\\') ADVANCE(55);
-      END_STATE();
-    case 41:
-      ACCEPT_TOKEN(aux_sym_string_content_token1);
-      if (lookahead == 'A') ADVANCE(51);
-      if (lookahead == 'O') ADVANCE(49);
-      if (lookahead == 'U') ADVANCE(50);
-      if (lookahead == '-' ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(54);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '"' &&
-          lookahead != '\\') ADVANCE(55);
-      END_STATE();
-    case 42:
-      ACCEPT_TOKEN(aux_sym_string_content_token1);
-      if (lookahead == 'C') ADVANCE(47);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(54);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '"' &&
-          lookahead != '\\') ADVANCE(55);
-      END_STATE();
-    case 43:
-      ACCEPT_TOKEN(aux_sym_string_content_token1);
-      if (lookahead == 'E') ADVANCE(54);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(54);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '"' &&
-          lookahead != '\\') ADVANCE(55);
-      END_STATE();
-    case 44:
-      ACCEPT_TOKEN(aux_sym_string_content_token1);
-      if (lookahead == 'E') ADVANCE(48);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(54);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '"' &&
-          lookahead != '\\') ADVANCE(55);
-      END_STATE();
-    case 45:
-      ACCEPT_TOKEN(aux_sym_string_content_token1);
-      if (lookahead == 'E') ADVANCE(50);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(54);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '"' &&
-          lookahead != '\\') ADVANCE(55);
-      END_STATE();
-    case 46:
-      ACCEPT_TOKEN(aux_sym_string_content_token1);
-      if (lookahead == 'E') ADVANCE(52);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(54);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '"' &&
-          lookahead != '\\') ADVANCE(55);
-      END_STATE();
-    case 47:
-      ACCEPT_TOKEN(aux_sym_string_content_token1);
-      if (lookahead == 'H') ADVANCE(54);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(54);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '"' &&
-          lookahead != '\\') ADVANCE(55);
-      END_STATE();
-    case 48:
-      ACCEPT_TOKEN(aux_sym_string_content_token1);
-      if (lookahead == 'L') ADVANCE(46);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(54);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '"' &&
-          lookahead != '\\') ADVANCE(55);
-      END_STATE();
-    case 49:
-      ACCEPT_TOKEN(aux_sym_string_content_token1);
-      if (lookahead == 'S') ADVANCE(50);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(54);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '"' &&
-          lookahead != '\\') ADVANCE(55);
-      END_STATE();
-    case 50:
-      ACCEPT_TOKEN(aux_sym_string_content_token1);
-      if (lookahead == 'T') ADVANCE(54);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(54);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '"' &&
-          lookahead != '\\') ADVANCE(55);
-      END_STATE();
-    case 51:
-      ACCEPT_TOKEN(aux_sym_string_content_token1);
-      if (lookahead == 'T') ADVANCE(42);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(54);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '"' &&
-          lookahead != '\\') ADVANCE(55);
-      END_STATE();
-    case 52:
-      ACCEPT_TOKEN(aux_sym_string_content_token1);
-      if (lookahead == 'T') ADVANCE(43);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(54);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '"' &&
-          lookahead != '\\') ADVANCE(55);
-      END_STATE();
-    case 53:
-      ACCEPT_TOKEN(aux_sym_string_content_token1);
-      if (lookahead == '"' ||
-          lookahead == '\\') ADVANCE(164);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(53);
-      END_STATE();
-    case 54:
-      ACCEPT_TOKEN(aux_sym_string_content_token1);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(54);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '"' &&
-          lookahead != '\\') ADVANCE(55);
-      END_STATE();
-    case 55:
-      ACCEPT_TOKEN(aux_sym_string_content_token1);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '"' &&
-          lookahead != '\\') ADVANCE(55);
-      END_STATE();
-    case 56:
-      ACCEPT_TOKEN(sym_escape_sequence);
-      END_STATE();
-    case 57:
-      ACCEPT_TOKEN(sym_number);
-      if (lookahead == '.') ADVANCE(60);
-      if (lookahead == 'B' ||
-          lookahead == 'b') ADVANCE(19);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(18);
-      if (lookahead == 'O' ||
-          lookahead == 'o') ADVANCE(24);
-      if (lookahead == 'X' ||
-          lookahead == 'x') ADVANCE(27);
-      END_STATE();
-    case 58:
-      ACCEPT_TOKEN(sym_number);
-      if (lookahead == '.') ADVANCE(60);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(18);
-      END_STATE();
-    case 59:
-      ACCEPT_TOKEN(sym_number);
-      if (lookahead == '.') ADVANCE(60);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(18);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(59);
-      END_STATE();
-    case 60:
-      ACCEPT_TOKEN(sym_number);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(18);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(60);
-      END_STATE();
-    case 61:
-      ACCEPT_TOKEN(sym_number);
-      if (lookahead == '0' ||
-          lookahead == '1') ADVANCE(61);
-      END_STATE();
-    case 62:
-      ACCEPT_TOKEN(sym_number);
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(62);
-      END_STATE();
-    case 63:
-      ACCEPT_TOKEN(sym_number);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(63);
-      END_STATE();
-    case 64:
-      ACCEPT_TOKEN(sym_number);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(64);
-      END_STATE();
-    case 65:
-      ACCEPT_TOKEN(sym_true);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(158);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
-      END_STATE();
-    case 66:
-      ACCEPT_TOKEN(sym_true);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
-      END_STATE();
-    case 67:
-      ACCEPT_TOKEN(sym_false);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(158);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
-      END_STATE();
-    case 68:
-      ACCEPT_TOKEN(sym_false);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
-      END_STATE();
-    case 69:
-      ACCEPT_TOKEN(sym_null);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(158);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
-      END_STATE();
-    case 70:
-      ACCEPT_TOKEN(sym_null);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
-      END_STATE();
-    case 71:
-      ACCEPT_TOKEN(sym_method);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(158);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
-      END_STATE();
-    case 72:
-      ACCEPT_TOKEN(sym_method);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
-      END_STATE();
-    case 73:
-      ACCEPT_TOKEN(sym_method);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(153);
-      END_STATE();
-    case 74:
-      ACCEPT_TOKEN(sym_url);
-      if (lookahead == '.') ADVANCE(6);
-      if (lookahead == ':') ADVANCE(77);
-      if (lookahead == 'w') ADVANCE(75);
-      if (lookahead == ',' ||
-          lookahead == '{' ||
-          lookahead == '}') ADVANCE(79);
-      if (sym_url_character_set_1(lookahead)) ADVANCE(79);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ') ADVANCE(79);
-      END_STATE();
-    case 75:
-      ACCEPT_TOKEN(sym_url);
-      if (lookahead == '.') ADVANCE(6);
-      if (lookahead == ':') ADVANCE(77);
-      if (lookahead == 'w') ADVANCE(76);
-      if (lookahead == ',' ||
-          lookahead == '{' ||
-          lookahead == '}') ADVANCE(79);
-      if (sym_url_character_set_1(lookahead)) ADVANCE(79);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ') ADVANCE(79);
-      END_STATE();
-    case 76:
-      ACCEPT_TOKEN(sym_url);
-      if (lookahead == '.') ADVANCE(6);
-      if (lookahead == ':') ADVANCE(77);
-      if (lookahead == ',' ||
-          lookahead == '{' ||
-          lookahead == '}') ADVANCE(79);
-      if (sym_url_character_set_1(lookahead)) ADVANCE(79);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ') ADVANCE(79);
-      END_STATE();
-    case 77:
-      ACCEPT_TOKEN(sym_url);
-      if (lookahead == '.') ADVANCE(21);
-      if (lookahead == ':') ADVANCE(77);
-      if (lookahead == ',' ||
-          lookahead == '{' ||
-          lookahead == '}') ADVANCE(79);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(77);
-      if (sym_url_character_set_1(lookahead)) ADVANCE(79);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ') ADVANCE(79);
-      END_STATE();
-    case 78:
-      ACCEPT_TOKEN(sym_url);
-      if (lookahead == '.') ADVANCE(21);
-      if (lookahead == ':') ADVANCE(77);
-      if (lookahead == ',' ||
-          lookahead == '{' ||
-          lookahead == '}') ADVANCE(79);
       if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(78);
       if (lookahead == '#' ||
           lookahead == '%' ||
@@ -1097,35 +586,492 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == '^' ||
           lookahead == '_' ||
           lookahead == '~' ||
-          (192 <= lookahead && lookahead <= 255)) ADVANCE(79);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ') ADVANCE(79);
+          (192 <= lookahead && lookahead <= 255)) ADVANCE(80);
       END_STATE();
-    case 79:
-      ACCEPT_TOKEN(sym_url);
-      if (lookahead == '.') ADVANCE(21);
-      if (lookahead == ':') ADVANCE(77);
+    case 22:
       if (lookahead == ',' ||
-          lookahead == '{' ||
-          lookahead == '}') ADVANCE(79);
-      if (sym_url_character_set_1(lookahead)) ADVANCE(79);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ') ADVANCE(79);
-      END_STATE();
-    case 80:
-      ACCEPT_TOKEN(sym_url);
-      if (lookahead == '.') ADVANCE(21);
-      if (lookahead == ':') ADVANCE(20);
-      if (lookahead == ',' ||
+          lookahead == '.' ||
+          lookahead == ':' ||
           lookahead == '{' ||
           lookahead == '}') ADVANCE(22);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(80);
+      if (sym_url_character_set_1(lookahead)) ADVANCE(80);
+      END_STATE();
+    case 23:
+      if (lookahead == '"' ||
+          lookahead == '/' ||
+          lookahead == '\\' ||
+          lookahead == 'b' ||
+          lookahead == 'n' ||
+          lookahead == 'r' ||
+          lookahead == 't' ||
+          lookahead == 'u') ADVANCE(57);
+      END_STATE();
+    case 24:
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(63);
+      END_STATE();
+    case 25:
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(61);
+      END_STATE();
+    case 26:
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(64);
+      END_STATE();
+    case 27:
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(65);
+      END_STATE();
+    case 28:
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(16);
+      END_STATE();
+    case 29:
+      if (eof) ADVANCE(32);
+      if (lookahead == '"') ADVANCE(40);
+      if (lookahead == '#') ADVANCE(146);
+      if (lookahead == '+') ADVANCE(9);
+      if (lookahead == ',') ADVANCE(35);
+      if (lookahead == '-') ADVANCE(82);
+      if (lookahead == '.') ADVANCE(10);
+      if (lookahead == '0') ADVANCE(58);
+      if (lookahead == ':') ADVANCE(37);
+      if (lookahead == '<') ADVANCE(143);
+      if (lookahead == 'D') ADVANCE(91);
+      if (lookahead == 'G') ADVANCE(92);
+      if (lookahead == 'P') ADVANCE(85);
+      if (lookahead == '[') ADVANCE(38);
+      if (lookahead == ']') ADVANCE(39);
+      if (lookahead == 'f') ADVANCE(121);
+      if (lookahead == 'h') ADVANCE(131);
+      if (lookahead == 'n') ADVANCE(133);
+      if (lookahead == 't') ADVANCE(128);
+      if (lookahead == 'w') ADVANCE(135);
+      if (lookahead == '{') ADVANCE(34);
+      if (lookahead == '}') ADVANCE(36);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(29)
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(60);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      END_STATE();
+    case 30:
+      if (eof) ADVANCE(32);
+      if (lookahead == '"') ADVANCE(40);
+      if (lookahead == '#') ADVANCE(146);
+      if (lookahead == '+') ADVANCE(9);
+      if (lookahead == ',') ADVANCE(35);
+      if (lookahead == '-') ADVANCE(82);
+      if (lookahead == '.') ADVANCE(10);
+      if (lookahead == '0') ADVANCE(58);
+      if (lookahead == ':') ADVANCE(37);
+      if (lookahead == '<') ADVANCE(143);
+      if (lookahead == 'D') ADVANCE(91);
+      if (lookahead == 'G') ADVANCE(92);
+      if (lookahead == 'P') ADVANCE(85);
+      if (lookahead == ']') ADVANCE(39);
+      if (lookahead == '}') ADVANCE(36);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(30)
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(60);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      END_STATE();
+    case 31:
+      if (eof) ADVANCE(32);
+      if (lookahead == '"') ADVANCE(40);
+      if (lookahead == '#') ADVANCE(146);
+      if (lookahead == '+') ADVANCE(9);
+      if (lookahead == '-') ADVANCE(82);
+      if (lookahead == '.') ADVANCE(25);
+      if (lookahead == '0') ADVANCE(58);
+      if (lookahead == '<') ADVANCE(143);
+      if (lookahead == 'D') ADVANCE(91);
+      if (lookahead == 'G') ADVANCE(92);
+      if (lookahead == 'P') ADVANCE(85);
+      if (lookahead == '[') ADVANCE(38);
+      if (lookahead == ']') ADVANCE(39);
+      if (lookahead == 'f') ADVANCE(121);
+      if (lookahead == 'n') ADVANCE(133);
+      if (lookahead == 't') ADVANCE(128);
+      if (lookahead == '{') ADVANCE(33);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(31)
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(60);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      END_STATE();
+    case 32:
+      ACCEPT_TOKEN(ts_builtin_sym_end);
+      END_STATE();
+    case 33:
+      ACCEPT_TOKEN(anon_sym_LBRACE);
+      END_STATE();
+    case 34:
+      ACCEPT_TOKEN(anon_sym_LBRACE);
+      if (lookahead == '{') ADVANCE(28);
+      END_STATE();
+    case 35:
+      ACCEPT_TOKEN(anon_sym_COMMA);
+      END_STATE();
+    case 36:
+      ACCEPT_TOKEN(anon_sym_RBRACE);
+      END_STATE();
+    case 37:
+      ACCEPT_TOKEN(anon_sym_COLON);
+      END_STATE();
+    case 38:
+      ACCEPT_TOKEN(anon_sym_LBRACK);
+      END_STATE();
+    case 39:
+      ACCEPT_TOKEN(anon_sym_RBRACK);
+      END_STATE();
+    case 40:
+      ACCEPT_TOKEN(anon_sym_DQUOTE);
+      END_STATE();
+    case 41:
+      ACCEPT_TOKEN(aux_sym_string_content_token1);
+      if (lookahead == '#') ADVANCE(54);
+      if (lookahead == '<') ADVANCE(144);
+      if (lookahead == 'D') ADVANCE(45);
+      if (lookahead == 'G') ADVANCE(46);
+      if (lookahead == 'P') ADVANCE(42);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(41);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(55);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '"' &&
+          lookahead != '\\') ADVANCE(56);
+      END_STATE();
+    case 42:
+      ACCEPT_TOKEN(aux_sym_string_content_token1);
+      if (lookahead == 'A') ADVANCE(52);
+      if (lookahead == 'O') ADVANCE(50);
+      if (lookahead == 'U') ADVANCE(51);
+      if (lookahead == '-' ||
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(55);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '"' &&
+          lookahead != '\\') ADVANCE(56);
+      END_STATE();
+    case 43:
+      ACCEPT_TOKEN(aux_sym_string_content_token1);
+      if (lookahead == 'C') ADVANCE(48);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(55);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '"' &&
+          lookahead != '\\') ADVANCE(56);
+      END_STATE();
+    case 44:
+      ACCEPT_TOKEN(aux_sym_string_content_token1);
+      if (lookahead == 'E') ADVANCE(55);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(55);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '"' &&
+          lookahead != '\\') ADVANCE(56);
+      END_STATE();
+    case 45:
+      ACCEPT_TOKEN(aux_sym_string_content_token1);
+      if (lookahead == 'E') ADVANCE(49);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(55);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '"' &&
+          lookahead != '\\') ADVANCE(56);
+      END_STATE();
+    case 46:
+      ACCEPT_TOKEN(aux_sym_string_content_token1);
+      if (lookahead == 'E') ADVANCE(51);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(55);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '"' &&
+          lookahead != '\\') ADVANCE(56);
+      END_STATE();
+    case 47:
+      ACCEPT_TOKEN(aux_sym_string_content_token1);
+      if (lookahead == 'E') ADVANCE(53);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(55);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '"' &&
+          lookahead != '\\') ADVANCE(56);
+      END_STATE();
+    case 48:
+      ACCEPT_TOKEN(aux_sym_string_content_token1);
+      if (lookahead == 'H') ADVANCE(55);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(55);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '"' &&
+          lookahead != '\\') ADVANCE(56);
+      END_STATE();
+    case 49:
+      ACCEPT_TOKEN(aux_sym_string_content_token1);
+      if (lookahead == 'L') ADVANCE(47);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(55);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '"' &&
+          lookahead != '\\') ADVANCE(56);
+      END_STATE();
+    case 50:
+      ACCEPT_TOKEN(aux_sym_string_content_token1);
+      if (lookahead == 'S') ADVANCE(51);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(55);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '"' &&
+          lookahead != '\\') ADVANCE(56);
+      END_STATE();
+    case 51:
+      ACCEPT_TOKEN(aux_sym_string_content_token1);
+      if (lookahead == 'T') ADVANCE(55);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(55);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '"' &&
+          lookahead != '\\') ADVANCE(56);
+      END_STATE();
+    case 52:
+      ACCEPT_TOKEN(aux_sym_string_content_token1);
+      if (lookahead == 'T') ADVANCE(43);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(55);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '"' &&
+          lookahead != '\\') ADVANCE(56);
+      END_STATE();
+    case 53:
+      ACCEPT_TOKEN(aux_sym_string_content_token1);
+      if (lookahead == 'T') ADVANCE(44);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(55);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '"' &&
+          lookahead != '\\') ADVANCE(56);
+      END_STATE();
+    case 54:
+      ACCEPT_TOKEN(aux_sym_string_content_token1);
+      if (lookahead == '"' ||
+          lookahead == '\\') ADVANCE(146);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(54);
+      END_STATE();
+    case 55:
+      ACCEPT_TOKEN(aux_sym_string_content_token1);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(55);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '"' &&
+          lookahead != '\\') ADVANCE(56);
+      END_STATE();
+    case 56:
+      ACCEPT_TOKEN(aux_sym_string_content_token1);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '"' &&
+          lookahead != '\\') ADVANCE(56);
+      END_STATE();
+    case 57:
+      ACCEPT_TOKEN(sym_escape_sequence);
+      END_STATE();
+    case 58:
+      ACCEPT_TOKEN(sym_number);
+      if (lookahead == '.') ADVANCE(61);
+      if (lookahead == 'B' ||
+          lookahead == 'b') ADVANCE(19);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(18);
+      if (lookahead == 'O' ||
+          lookahead == 'o') ADVANCE(24);
+      if (lookahead == 'X' ||
+          lookahead == 'x') ADVANCE(27);
+      END_STATE();
+    case 59:
+      ACCEPT_TOKEN(sym_number);
+      if (lookahead == '.') ADVANCE(61);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(18);
+      END_STATE();
+    case 60:
+      ACCEPT_TOKEN(sym_number);
+      if (lookahead == '.') ADVANCE(61);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(18);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(60);
+      END_STATE();
+    case 61:
+      ACCEPT_TOKEN(sym_number);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(18);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(61);
+      END_STATE();
+    case 62:
+      ACCEPT_TOKEN(sym_number);
+      if (lookahead == '0' ||
+          lookahead == '1') ADVANCE(62);
+      END_STATE();
+    case 63:
+      ACCEPT_TOKEN(sym_number);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(63);
+      END_STATE();
+    case 64:
+      ACCEPT_TOKEN(sym_number);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(64);
+      END_STATE();
+    case 65:
+      ACCEPT_TOKEN(sym_number);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(65);
+      END_STATE();
+    case 66:
+      ACCEPT_TOKEN(sym_true);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      END_STATE();
+    case 67:
+      ACCEPT_TOKEN(sym_false);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      END_STATE();
+    case 68:
+      ACCEPT_TOKEN(sym_null);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      END_STATE();
+    case 69:
+      ACCEPT_TOKEN(sym_method);
+      if (lookahead == '.' ||
+          lookahead == '/' ||
+          lookahead == '_') ADVANCE(141);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+      END_STATE();
+    case 70:
+      ACCEPT_TOKEN(sym_method);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      END_STATE();
+    case 71:
+      ACCEPT_TOKEN(sym_method);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(140);
+      END_STATE();
+    case 72:
+      ACCEPT_TOKEN(sym_url);
+      if (lookahead == '.') ADVANCE(6);
+      if (lookahead == ':') ADVANCE(75);
+      if (lookahead == 'w') ADVANCE(73);
+      if (lookahead == ',' ||
+          lookahead == '{' ||
+          lookahead == '}') ADVANCE(77);
+      if (sym_url_character_set_1(lookahead)) ADVANCE(77);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ' ') ADVANCE(77);
+      END_STATE();
+    case 73:
+      ACCEPT_TOKEN(sym_url);
+      if (lookahead == '.') ADVANCE(6);
+      if (lookahead == ':') ADVANCE(75);
+      if (lookahead == 'w') ADVANCE(74);
+      if (lookahead == ',' ||
+          lookahead == '{' ||
+          lookahead == '}') ADVANCE(77);
+      if (sym_url_character_set_1(lookahead)) ADVANCE(77);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ' ') ADVANCE(77);
+      END_STATE();
+    case 74:
+      ACCEPT_TOKEN(sym_url);
+      if (lookahead == '.') ADVANCE(6);
+      if (lookahead == ':') ADVANCE(75);
+      if (lookahead == ',' ||
+          lookahead == '{' ||
+          lookahead == '}') ADVANCE(77);
+      if (sym_url_character_set_1(lookahead)) ADVANCE(77);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ' ') ADVANCE(77);
+      END_STATE();
+    case 75:
+      ACCEPT_TOKEN(sym_url);
+      if (lookahead == '.') ADVANCE(21);
+      if (lookahead == ':') ADVANCE(75);
+      if (lookahead == ',' ||
+          lookahead == '{' ||
+          lookahead == '}') ADVANCE(77);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(75);
+      if (sym_url_character_set_1(lookahead)) ADVANCE(77);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ' ') ADVANCE(77);
+      END_STATE();
+    case 76:
+      ACCEPT_TOKEN(sym_url);
+      if (lookahead == '.') ADVANCE(21);
+      if (lookahead == ':') ADVANCE(75);
+      if (lookahead == ',' ||
+          lookahead == '{' ||
+          lookahead == '}') ADVANCE(77);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(76);
       if (lookahead == '#' ||
           lookahead == '%' ||
           lookahead == '&' ||
@@ -1135,714 +1081,601 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == '^' ||
           lookahead == '_' ||
           lookahead == '~' ||
-          (192 <= lookahead && lookahead <= 255)) ADVANCE(82);
+          (192 <= lookahead && lookahead <= 255)) ADVANCE(77);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ' ') ADVANCE(77);
+      END_STATE();
+    case 77:
+      ACCEPT_TOKEN(sym_url);
+      if (lookahead == '.') ADVANCE(21);
+      if (lookahead == ':') ADVANCE(75);
+      if (lookahead == ',' ||
+          lookahead == '{' ||
+          lookahead == '}') ADVANCE(77);
+      if (sym_url_character_set_1(lookahead)) ADVANCE(77);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ' ') ADVANCE(77);
+      END_STATE();
+    case 78:
+      ACCEPT_TOKEN(sym_url);
+      if (lookahead == '.') ADVANCE(21);
+      if (lookahead == ':') ADVANCE(20);
+      if (lookahead == ',' ||
+          lookahead == '{' ||
+          lookahead == '}') ADVANCE(22);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(78);
+      if (lookahead == '#' ||
+          lookahead == '%' ||
+          lookahead == '&' ||
+          ('+' <= lookahead && lookahead <= ';') ||
+          lookahead == '=' ||
+          ('?' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '^' ||
+          lookahead == '_' ||
+          lookahead == '~' ||
+          (192 <= lookahead && lookahead <= 255)) ADVANCE(80);
+      END_STATE();
+    case 79:
+      ACCEPT_TOKEN(sym_url);
+      if (lookahead == ',' ||
+          lookahead == '.' ||
+          lookahead == ':' ||
+          lookahead == '{' ||
+          lookahead == '}') ADVANCE(22);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(79);
+      if (sym_url_character_set_1(lookahead)) ADVANCE(80);
+      END_STATE();
+    case 80:
+      ACCEPT_TOKEN(sym_url);
+      if (lookahead == ',' ||
+          lookahead == '.' ||
+          lookahead == ':' ||
+          lookahead == '{' ||
+          lookahead == '}') ADVANCE(22);
+      if (sym_url_character_set_1(lookahead)) ADVANCE(80);
       END_STATE();
     case 81:
-      ACCEPT_TOKEN(sym_url);
-      if (lookahead == ',' ||
-          lookahead == '.' ||
-          lookahead == ':' ||
-          lookahead == '{' ||
-          lookahead == '}') ADVANCE(22);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(81);
-      if (sym_url_character_set_1(lookahead)) ADVANCE(82);
-      END_STATE();
-    case 82:
-      ACCEPT_TOKEN(sym_url);
-      if (lookahead == ',' ||
-          lookahead == '.' ||
-          lookahead == ':' ||
-          lookahead == '{' ||
-          lookahead == '}') ADVANCE(22);
-      if (sym_url_character_set_1(lookahead)) ADVANCE(82);
-      END_STATE();
-    case 83:
       ACCEPT_TOKEN(sym_name);
       if (lookahead == '/') ADVANCE(8);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      END_STATE();
+    case 82:
+      ACCEPT_TOKEN(sym_name);
+      if (lookahead == '0') ADVANCE(59);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(60);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      END_STATE();
+    case 83:
+      ACCEPT_TOKEN(sym_name);
+      if (lookahead == ':') ADVANCE(7);
+      if (lookahead == 's') ADVANCE(84);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 84:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == '0') ADVANCE(58);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(158);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(59);
+      if (lookahead == ':') ADVANCE(7);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 85:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == '0') ADVANCE(58);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(59);
+      if (lookahead == 'A') ADVANCE(113);
+      if (lookahead == 'O') ADVANCE(109);
+      if (lookahead == 'U') ADVANCE(112);
       if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 86:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == ':') ADVANCE(7);
-      if (lookahead == 's') ADVANCE(87);
+      if (lookahead == 'A') ADVANCE(115);
+      if (lookahead == 'O') ADVANCE(110);
+      if (lookahead == 'U') ADVANCE(114);
+      if (lookahead == '.' ||
+          lookahead == '/' ||
+          lookahead == '_') ADVANCE(141);
       if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 87:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == ':') ADVANCE(7);
+      if (lookahead == 'A') ADVANCE(117);
+      if (lookahead == 'O') ADVANCE(111);
+      if (lookahead == 'U') ADVANCE(116);
       if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(140);
       END_STATE();
     case 88:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'A') ADVANCE(116);
-      if (lookahead == 'O') ADVANCE(112);
-      if (lookahead == 'U') ADVANCE(115);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(158);
+      if (lookahead == 'C') ADVANCE(103);
       if (lookahead == '-' ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 89:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'A') ADVANCE(118);
-      if (lookahead == 'O') ADVANCE(113);
-      if (lookahead == 'U') ADVANCE(117);
+      if (lookahead == 'C') ADVANCE(104);
+      if (lookahead == '.' ||
+          lookahead == '/' ||
+          lookahead == '_') ADVANCE(141);
       if (lookahead == '-' ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 90:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'A') ADVANCE(120);
-      if (lookahead == 'O') ADVANCE(114);
-      if (lookahead == 'U') ADVANCE(119);
+      if (lookahead == 'C') ADVANCE(105);
       if (lookahead == '-' ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(153);
+          lookahead != '\n') ADVANCE(140);
       END_STATE();
     case 91:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'C') ADVANCE(106);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(158);
+      if (lookahead == 'E') ADVANCE(106);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 92:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'C') ADVANCE(107);
+      if (lookahead == 'E') ADVANCE(112);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 93:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'C') ADVANCE(108);
+      if (lookahead == 'E') ADVANCE(70);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(153);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 94:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'E') ADVANCE(109);
+      if (lookahead == 'E') ADVANCE(107);
       if (lookahead == '.' ||
           lookahead == '/' ||
-          lookahead == '_') ADVANCE(158);
+          lookahead == '_') ADVANCE(141);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 95:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'E') ADVANCE(115);
+      if (lookahead == 'E') ADVANCE(114);
       if (lookahead == '.' ||
           lookahead == '/' ||
-          lookahead == '_') ADVANCE(158);
+          lookahead == '_') ADVANCE(141);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 96:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'E') ADVANCE(71);
+      if (lookahead == 'E') ADVANCE(69);
       if (lookahead == '.' ||
           lookahead == '/' ||
-          lookahead == '_') ADVANCE(158);
+          lookahead == '_') ADVANCE(141);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 97:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'E') ADVANCE(110);
+      if (lookahead == 'E') ADVANCE(108);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(140);
       END_STATE();
     case 98:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'E') ADVANCE(117);
+      if (lookahead == 'E') ADVANCE(116);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(140);
       END_STATE();
     case 99:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'E') ADVANCE(72);
+      if (lookahead == 'E') ADVANCE(71);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(140);
       END_STATE();
     case 100:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'E') ADVANCE(111);
+      if (lookahead == 'E') ADVANCE(118);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(153);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 101:
       ACCEPT_TOKEN(sym_name);
       if (lookahead == 'E') ADVANCE(119);
+      if (lookahead == '.' ||
+          lookahead == '/' ||
+          lookahead == '_') ADVANCE(141);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(153);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 102:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'E') ADVANCE(73);
+      if (lookahead == 'E') ADVANCE(120);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(153);
+          lookahead != '\n') ADVANCE(140);
       END_STATE();
     case 103:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'E') ADVANCE(121);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(158);
+      if (lookahead == 'H') ADVANCE(70);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 104:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'E') ADVANCE(122);
+      if (lookahead == 'H') ADVANCE(69);
+      if (lookahead == '.' ||
+          lookahead == '/' ||
+          lookahead == '_') ADVANCE(141);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 105:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'E') ADVANCE(123);
+      if (lookahead == 'H') ADVANCE(71);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(153);
+          lookahead != '\n') ADVANCE(140);
       END_STATE();
     case 106:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'H') ADVANCE(71);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(158);
+      if (lookahead == 'L') ADVANCE(100);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 107:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'H') ADVANCE(72);
+      if (lookahead == 'L') ADVANCE(101);
+      if (lookahead == '.' ||
+          lookahead == '/' ||
+          lookahead == '_') ADVANCE(141);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 108:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'H') ADVANCE(73);
+      if (lookahead == 'L') ADVANCE(102);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(153);
+          lookahead != '\n') ADVANCE(140);
       END_STATE();
     case 109:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'L') ADVANCE(103);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(158);
+      if (lookahead == 'S') ADVANCE(112);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 110:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'L') ADVANCE(104);
+      if (lookahead == 'S') ADVANCE(114);
+      if (lookahead == '.' ||
+          lookahead == '/' ||
+          lookahead == '_') ADVANCE(141);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 111:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'L') ADVANCE(105);
+      if (lookahead == 'S') ADVANCE(116);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(153);
+          lookahead != '\n') ADVANCE(140);
       END_STATE();
     case 112:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'S') ADVANCE(115);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(158);
+      if (lookahead == 'T') ADVANCE(70);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 113:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'S') ADVANCE(117);
+      if (lookahead == 'T') ADVANCE(88);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 114:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'S') ADVANCE(119);
+      if (lookahead == 'T') ADVANCE(69);
+      if (lookahead == '.' ||
+          lookahead == '/' ||
+          lookahead == '_') ADVANCE(141);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(153);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 115:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'T') ADVANCE(71);
+      if (lookahead == 'T') ADVANCE(89);
       if (lookahead == '.' ||
           lookahead == '/' ||
-          lookahead == '_') ADVANCE(158);
+          lookahead == '_') ADVANCE(141);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 116:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'T') ADVANCE(91);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(158);
+      if (lookahead == 'T') ADVANCE(71);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(140);
       END_STATE();
     case 117:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'T') ADVANCE(72);
+      if (lookahead == 'T') ADVANCE(90);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(140);
       END_STATE();
     case 118:
-      ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'T') ADVANCE(92);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
-      END_STATE();
-    case 119:
-      ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'T') ADVANCE(73);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(153);
-      END_STATE();
-    case 120:
       ACCEPT_TOKEN(sym_name);
       if (lookahead == 'T') ADVANCE(93);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(153);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
-    case 121:
+    case 119:
       ACCEPT_TOKEN(sym_name);
       if (lookahead == 'T') ADVANCE(96);
       if (lookahead == '.' ||
           lookahead == '/' ||
-          lookahead == '_') ADVANCE(158);
+          lookahead == '_') ADVANCE(141);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
-    case 122:
+    case 120:
       ACCEPT_TOKEN(sym_name);
       if (lookahead == 'T') ADVANCE(99);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
-      END_STATE();
-    case 123:
-      ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'T') ADVANCE(102);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(153);
+          lookahead != '\n') ADVANCE(140);
       END_STATE();
-    case 124:
+    case 121:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'a') ADVANCE(130);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(158);
+      if (lookahead == 'a') ADVANCE(124);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(149);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
-    case 125:
-      ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'a') ADVANCE(132);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(150);
-      END_STATE();
-    case 126:
-      ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'e') ADVANCE(65);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(158);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
-      END_STATE();
-    case 127:
-      ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'e') ADVANCE(67);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(158);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
-      END_STATE();
-    case 128:
+    case 122:
       ACCEPT_TOKEN(sym_name);
       if (lookahead == 'e') ADVANCE(66);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      END_STATE();
+    case 123:
+      ACCEPT_TOKEN(sym_name);
+      if (lookahead == 'e') ADVANCE(67);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      END_STATE();
+    case 124:
+      ACCEPT_TOKEN(sym_name);
+      if (lookahead == 'l') ADVANCE(129);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      END_STATE();
+    case 125:
+      ACCEPT_TOKEN(sym_name);
+      if (lookahead == 'l') ADVANCE(68);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      END_STATE();
+    case 126:
+      ACCEPT_TOKEN(sym_name);
+      if (lookahead == 'l') ADVANCE(125);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      END_STATE();
+    case 127:
+      ACCEPT_TOKEN(sym_name);
+      if (lookahead == 'p') ADVANCE(83);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      END_STATE();
+    case 128:
+      ACCEPT_TOKEN(sym_name);
+      if (lookahead == 'r') ADVANCE(132);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 129:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'e') ADVANCE(68);
+      if (lookahead == 's') ADVANCE(123);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 130:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'l') ADVANCE(139);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(158);
+      if (lookahead == 't') ADVANCE(127);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 131:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'l') ADVANCE(69);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(158);
+      if (lookahead == 't') ADVANCE(130);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 132:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'l') ADVANCE(140);
+      if (lookahead == 'u') ADVANCE(122);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 133:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'l') ADVANCE(70);
+      if (lookahead == 'u') ADVANCE(126);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 134:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'l') ADVANCE(131);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(158);
+      if (lookahead == 'w') ADVANCE(81);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 135:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'l') ADVANCE(133);
+      if (lookahead == 'w') ADVANCE(134);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 136:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'p') ADVANCE(86);
+      if (lookahead == '.' ||
+          lookahead == '/' ||
+          lookahead == '_') ADVANCE(141);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 137:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'r') ADVANCE(143);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(158);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 138:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'r') ADVANCE(144);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(140);
       END_STATE();
     case 139:
-      ACCEPT_TOKEN(sym_name);
-      if (lookahead == 's') ADVANCE(127);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(158);
+      ACCEPT_TOKEN(sym_value);
+      if (lookahead == 11) ADVANCE(140);
+      if (lookahead == '\r') ADVANCE(139);
+      if (lookahead == '#') ADVANCE(140);
+      if (lookahead == '<') ADVANCE(145);
+      if (lookahead == 'D') ADVANCE(97);
+      if (lookahead == 'G') ADVANCE(98);
+      if (lookahead == 'P') ADVANCE(87);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(139);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(140);
       END_STATE();
     case 140:
-      ACCEPT_TOKEN(sym_name);
-      if (lookahead == 's') ADVANCE(129);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(sym_value);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(140);
       END_STATE();
     case 141:
-      ACCEPT_TOKEN(sym_name);
-      if (lookahead == 't') ADVANCE(136);
-      if (lookahead == '-' ||
+      ACCEPT_TOKEN(aux_sym_json_file_token1);
+      if (('-' <= lookahead && lookahead <= '/') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(141);
       END_STATE();
     case 142:
-      ACCEPT_TOKEN(sym_name);
-      if (lookahead == 't') ADVANCE(141);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      ACCEPT_TOKEN(anon_sym_DOTjson);
       END_STATE();
     case 143:
-      ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'u') ADVANCE(126);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(158);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
-      END_STATE();
-    case 144:
-      ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'u') ADVANCE(128);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
-      END_STATE();
-    case 145:
-      ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'u') ADVANCE(134);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(158);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
-      END_STATE();
-    case 146:
-      ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'u') ADVANCE(135);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
-      END_STATE();
-    case 147:
-      ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'w') ADVANCE(83);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
-      END_STATE();
-    case 148:
-      ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'w') ADVANCE(147);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
-      END_STATE();
-    case 149:
-      ACCEPT_TOKEN(sym_name);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(158);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
-      END_STATE();
-    case 150:
-      ACCEPT_TOKEN(sym_name);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
-      END_STATE();
-    case 151:
-      ACCEPT_TOKEN(sym_name);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(153);
-      END_STATE();
-    case 152:
-      ACCEPT_TOKEN(sym_value);
-      if (lookahead == 11) ADVANCE(153);
-      if (lookahead == '\r') ADVANCE(152);
-      if (lookahead == '#') ADVANCE(153);
-      if (lookahead == '<') ADVANCE(163);
-      if (lookahead == 'D') ADVANCE(100);
-      if (lookahead == 'G') ADVANCE(101);
-      if (lookahead == 'P') ADVANCE(90);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(152);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(153);
-      END_STATE();
-    case 153:
-      ACCEPT_TOKEN(sym_value);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(153);
-      END_STATE();
-    case 154:
-      ACCEPT_TOKEN(aux_sym_json_file_token1);
-      if (lookahead == 'j') ADVANCE(157);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(60);
-      if (('-' <= lookahead && lookahead <= '/') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(158);
-      END_STATE();
-    case 155:
-      ACCEPT_TOKEN(aux_sym_json_file_token1);
-      if (lookahead == 'n') ADVANCE(160);
-      if (('-' <= lookahead && lookahead <= '/') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(158);
-      END_STATE();
-    case 156:
-      ACCEPT_TOKEN(aux_sym_json_file_token1);
-      if (lookahead == 'o') ADVANCE(155);
-      if (('-' <= lookahead && lookahead <= '/') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(158);
-      END_STATE();
-    case 157:
-      ACCEPT_TOKEN(aux_sym_json_file_token1);
-      if (lookahead == 's') ADVANCE(156);
-      if (('-' <= lookahead && lookahead <= '/') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(158);
-      END_STATE();
-    case 158:
-      ACCEPT_TOKEN(aux_sym_json_file_token1);
-      if (('-' <= lookahead && lookahead <= '/') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(158);
-      END_STATE();
-    case 159:
-      ACCEPT_TOKEN(anon_sym_DOTjson);
-      END_STATE();
-    case 160:
-      ACCEPT_TOKEN(anon_sym_DOTjson);
-      if (('-' <= lookahead && lookahead <= '/') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(158);
-      END_STATE();
-    case 161:
       ACCEPT_TOKEN(anon_sym_LT);
       END_STATE();
-    case 162:
+    case 144:
       ACCEPT_TOKEN(anon_sym_LT);
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != '"' &&
-          lookahead != '\\') ADVANCE(55);
+          lookahead != '\\') ADVANCE(56);
       END_STATE();
-    case 163:
+    case 145:
       ACCEPT_TOKEN(anon_sym_LT);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(153);
+          lookahead != '\n') ADVANCE(140);
       END_STATE();
-    case 164:
+    case 146:
       ACCEPT_TOKEN(sym_comment);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(164);
+          lookahead != '\n') ADVANCE(146);
       END_STATE();
-    case 165:
+    case 147:
       ACCEPT_TOKEN(aux_sym__whitespace_token1);
       END_STATE();
-    case 166:
+    case 148:
       ACCEPT_TOKEN(aux_sym__whitespace_token1);
-      if (lookahead == 11) ADVANCE(165);
+      if (lookahead == 11) ADVANCE(147);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(166);
+          lookahead == ' ') ADVANCE(148);
       END_STATE();
     default:
       return false;
@@ -1855,52 +1688,71 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [2] = {.lex_state = 31},
   [3] = {.lex_state = 31},
   [4] = {.lex_state = 31},
-  [5] = {.lex_state = 30},
-  [6] = {.lex_state = 30},
-  [7] = {.lex_state = 1},
-  [8] = {.lex_state = 30},
-  [9] = {.lex_state = 30},
-  [10] = {.lex_state = 30},
-  [11] = {.lex_state = 1},
-  [12] = {.lex_state = 30},
-  [13] = {.lex_state = 30},
-  [14] = {.lex_state = 30},
-  [15] = {.lex_state = 30},
-  [16] = {.lex_state = 3},
-  [17] = {.lex_state = 30},
-  [18] = {.lex_state = 30},
+  [5] = {.lex_state = 31},
+  [6] = {.lex_state = 31},
+  [7] = {.lex_state = 31},
+  [8] = {.lex_state = 31},
+  [9] = {.lex_state = 31},
+  [10] = {.lex_state = 31},
+  [11] = {.lex_state = 31},
+  [12] = {.lex_state = 31},
+  [13] = {.lex_state = 31},
+  [14] = {.lex_state = 31},
+  [15] = {.lex_state = 31},
+  [16] = {.lex_state = 31},
+  [17] = {.lex_state = 31},
+  [18] = {.lex_state = 1},
   [19] = {.lex_state = 1},
-  [20] = {.lex_state = 4},
+  [20] = {.lex_state = 30},
   [21] = {.lex_state = 30},
-  [22] = {.lex_state = 1},
-  [23] = {.lex_state = 2},
-  [24] = {.lex_state = 3},
-  [25] = {.lex_state = 30},
-  [26] = {.lex_state = 2},
-  [27] = {.lex_state = 30},
+  [22] = {.lex_state = 30},
+  [23] = {.lex_state = 30},
+  [24] = {.lex_state = 4},
+  [25] = {.lex_state = 1},
+  [26] = {.lex_state = 30},
+  [27] = {.lex_state = 1},
   [28] = {.lex_state = 30},
   [29] = {.lex_state = 30},
-  [30] = {.lex_state = 4},
+  [30] = {.lex_state = 2},
   [31] = {.lex_state = 30},
-  [32] = {.lex_state = 3},
-  [33] = {.lex_state = 3},
-  [34] = {.lex_state = 4},
+  [32] = {.lex_state = 30},
+  [33] = {.lex_state = 30},
+  [34] = {.lex_state = 30},
   [35] = {.lex_state = 30},
-  [36] = {.lex_state = 30},
+  [36] = {.lex_state = 2},
   [37] = {.lex_state = 30},
-  [38] = {.lex_state = 3},
-  [39] = {.lex_state = 3},
-  [40] = {.lex_state = 2},
+  [38] = {.lex_state = 1},
+  [39] = {.lex_state = 30},
+  [40] = {.lex_state = 30},
   [41] = {.lex_state = 30},
   [42] = {.lex_state = 30},
   [43] = {.lex_state = 30},
-  [44] = {.lex_state = 30},
+  [44] = {.lex_state = 4},
   [45] = {.lex_state = 30},
-  [46] = {.lex_state = 30},
-  [47] = {(TSStateId)(-1)},
-  [48] = {(TSStateId)(-1)},
-  [49] = {(TSStateId)(-1)},
-  [50] = {(TSStateId)(-1)},
+  [46] = {.lex_state = 3},
+  [47] = {.lex_state = 30},
+  [48] = {.lex_state = 30},
+  [49] = {.lex_state = 3},
+  [50] = {.lex_state = 30},
+  [51] = {.lex_state = 4},
+  [52] = {.lex_state = 4},
+  [53] = {.lex_state = 30},
+  [54] = {.lex_state = 30},
+  [55] = {.lex_state = 30},
+  [56] = {.lex_state = 3},
+  [57] = {.lex_state = 2},
+  [58] = {.lex_state = 4},
+  [59] = {.lex_state = 4},
+  [60] = {.lex_state = 30},
+  [61] = {.lex_state = 30},
+  [62] = {.lex_state = 30},
+  [63] = {.lex_state = 30},
+  [64] = {.lex_state = 30},
+  [65] = {.lex_state = 30},
+  [66] = {(TSStateId)(-1)},
+  [67] = {(TSStateId)(-1)},
+  [68] = {(TSStateId)(-1)},
+  [69] = {(TSStateId)(-1)},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -1922,21 +1774,22 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_false] = ACTIONS(1),
     [sym_null] = ACTIONS(1),
     [sym_method] = ACTIONS(3),
+    [sym_url] = ACTIONS(1),
     [sym_name] = ACTIONS(5),
-    [aux_sym_json_file_token1] = ACTIONS(1),
     [anon_sym_DOTjson] = ACTIONS(1),
     [anon_sym_LT] = ACTIONS(7),
     [sym_comment] = ACTIONS(9),
   },
   [1] = {
-    [sym_document] = STATE(43),
-    [sym__value] = STATE(42),
-    [sym_object] = STATE(12),
-    [sym_array] = STATE(12),
-    [sym_string] = STATE(12),
+    [sym_document] = STATE(62),
+    [sym__value] = STATE(10),
+    [sym_object] = STATE(9),
+    [sym_array] = STATE(9),
+    [sym_string] = STATE(9),
     [sym_request] = STATE(1),
     [sym_header] = STATE(1),
     [sym_external_body] = STATE(1),
+    [aux_sym_document_repeat1] = STATE(2),
     [ts_builtin_sym_end] = ACTIONS(11),
     [anon_sym_LBRACE] = ACTIONS(13),
     [anon_sym_LBRACK] = ACTIONS(15),
@@ -1945,6 +1798,50 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_true] = ACTIONS(21),
     [sym_false] = ACTIONS(21),
     [sym_null] = ACTIONS(21),
+    [sym_method] = ACTIONS(3),
+    [sym_name] = ACTIONS(5),
+    [anon_sym_LT] = ACTIONS(7),
+    [sym_comment] = ACTIONS(9),
+  },
+  [2] = {
+    [sym__value] = STATE(10),
+    [sym_object] = STATE(9),
+    [sym_array] = STATE(9),
+    [sym_string] = STATE(9),
+    [sym_request] = STATE(2),
+    [sym_header] = STATE(2),
+    [sym_external_body] = STATE(2),
+    [aux_sym_document_repeat1] = STATE(3),
+    [ts_builtin_sym_end] = ACTIONS(23),
+    [anon_sym_LBRACE] = ACTIONS(13),
+    [anon_sym_LBRACK] = ACTIONS(15),
+    [anon_sym_DQUOTE] = ACTIONS(17),
+    [sym_number] = ACTIONS(19),
+    [sym_true] = ACTIONS(21),
+    [sym_false] = ACTIONS(21),
+    [sym_null] = ACTIONS(21),
+    [sym_method] = ACTIONS(3),
+    [sym_name] = ACTIONS(5),
+    [anon_sym_LT] = ACTIONS(7),
+    [sym_comment] = ACTIONS(9),
+  },
+  [3] = {
+    [sym__value] = STATE(10),
+    [sym_object] = STATE(9),
+    [sym_array] = STATE(9),
+    [sym_string] = STATE(9),
+    [sym_request] = STATE(3),
+    [sym_header] = STATE(3),
+    [sym_external_body] = STATE(3),
+    [aux_sym_document_repeat1] = STATE(3),
+    [ts_builtin_sym_end] = ACTIONS(25),
+    [anon_sym_LBRACE] = ACTIONS(27),
+    [anon_sym_LBRACK] = ACTIONS(30),
+    [anon_sym_DQUOTE] = ACTIONS(33),
+    [sym_number] = ACTIONS(36),
+    [sym_true] = ACTIONS(39),
+    [sym_false] = ACTIONS(39),
+    [sym_null] = ACTIONS(39),
     [sym_method] = ACTIONS(3),
     [sym_name] = ACTIONS(5),
     [anon_sym_LT] = ACTIONS(7),
@@ -1962,81 +1859,19 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
     ACTIONS(9), 1,
       sym_comment,
-    ACTIONS(13), 1,
+    ACTIONS(42), 1,
       anon_sym_LBRACE,
-    ACTIONS(15), 1,
+    ACTIONS(44), 1,
       anon_sym_LBRACK,
-    ACTIONS(17), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(19), 1,
-      sym_number,
-    ACTIONS(23), 1,
+    ACTIONS(46), 1,
       anon_sym_RBRACK,
-    STATE(28), 1,
-      sym__value,
-    ACTIONS(21), 3,
-      sym_true,
-      sym_false,
-      sym_null,
-    STATE(2), 3,
-      sym_request,
-      sym_header,
-      sym_external_body,
-    STATE(12), 3,
-      sym_object,
-      sym_array,
-      sym_string,
-  [46] = 12,
-    ACTIONS(3), 1,
-      sym_method,
-    ACTIONS(5), 1,
-      sym_name,
-    ACTIONS(7), 1,
-      anon_sym_LT,
-    ACTIONS(9), 1,
-      sym_comment,
-    ACTIONS(13), 1,
-      anon_sym_LBRACE,
-    ACTIONS(15), 1,
-      anon_sym_LBRACK,
-    ACTIONS(17), 1,
+    ACTIONS(48), 1,
       anon_sym_DQUOTE,
-    ACTIONS(19), 1,
+    ACTIONS(50), 1,
       sym_number,
-    STATE(37), 1,
+    STATE(33), 1,
       sym__value,
-    ACTIONS(21), 3,
-      sym_true,
-      sym_false,
-      sym_null,
-    STATE(3), 3,
-      sym_request,
-      sym_header,
-      sym_external_body,
-    STATE(12), 3,
-      sym_object,
-      sym_array,
-      sym_string,
-  [89] = 12,
-    ACTIONS(3), 1,
-      sym_method,
-    ACTIONS(5), 1,
-      sym_name,
-    ACTIONS(7), 1,
-      anon_sym_LT,
-    ACTIONS(9), 1,
-      sym_comment,
-    ACTIONS(13), 1,
-      anon_sym_LBRACE,
-    ACTIONS(15), 1,
-      anon_sym_LBRACK,
-    ACTIONS(17), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(19), 1,
-      sym_number,
-    STATE(35), 1,
-      sym__value,
-    ACTIONS(21), 3,
+    ACTIONS(52), 3,
       sym_true,
       sym_false,
       sym_null,
@@ -2044,11 +1879,11 @@ static const uint16_t ts_small_parse_table[] = {
       sym_request,
       sym_header,
       sym_external_body,
-    STATE(12), 3,
+    STATE(29), 3,
       sym_object,
       sym_array,
       sym_string,
-  [132] = 6,
+  [46] = 13,
     ACTIONS(3), 1,
       sym_method,
     ACTIONS(5), 1,
@@ -2057,17 +1892,31 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
     ACTIONS(9), 1,
       sym_comment,
+    ACTIONS(42), 1,
+      anon_sym_LBRACE,
+    ACTIONS(44), 1,
+      anon_sym_LBRACK,
+    ACTIONS(48), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(50), 1,
+      sym_number,
+    ACTIONS(54), 1,
+      anon_sym_RBRACK,
+    STATE(39), 1,
+      sym__value,
+    ACTIONS(52), 3,
+      sym_true,
+      sym_false,
+      sym_null,
     STATE(5), 3,
       sym_request,
       sym_header,
       sym_external_body,
-    ACTIONS(25), 5,
-      ts_builtin_sym_end,
-      anon_sym_COMMA,
-      anon_sym_RBRACE,
-      anon_sym_COLON,
-      anon_sym_RBRACK,
-  [157] = 10,
+    STATE(29), 3,
+      sym_object,
+      sym_array,
+      sym_string,
+  [92] = 12,
     ACTIONS(3), 1,
       sym_method,
     ACTIONS(5), 1,
@@ -2076,44 +1925,60 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
     ACTIONS(9), 1,
       sym_comment,
-    ACTIONS(17), 1,
+    ACTIONS(42), 1,
+      anon_sym_LBRACE,
+    ACTIONS(44), 1,
+      anon_sym_LBRACK,
+    ACTIONS(48), 1,
       anon_sym_DQUOTE,
-    ACTIONS(27), 1,
-      anon_sym_RBRACE,
-    ACTIONS(29), 1,
+    ACTIONS(50), 1,
       sym_number,
-    STATE(29), 1,
-      sym_pair,
-    STATE(41), 1,
-      sym_string,
+    STATE(55), 1,
+      sym__value,
+    ACTIONS(52), 3,
+      sym_true,
+      sym_false,
+      sym_null,
     STATE(6), 3,
       sym_request,
       sym_header,
       sym_external_body,
-  [190] = 10,
+    STATE(29), 3,
+      sym_object,
+      sym_array,
+      sym_string,
+  [135] = 12,
     ACTIONS(3), 1,
       sym_method,
     ACTIONS(5), 1,
       sym_name,
-    ACTIONS(31), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(33), 1,
-      aux_sym_string_content_token1,
-    ACTIONS(35), 1,
-      sym_escape_sequence,
-    ACTIONS(37), 1,
+    ACTIONS(7), 1,
       anon_sym_LT,
-    ACTIONS(39), 1,
+    ACTIONS(9), 1,
       sym_comment,
-    STATE(19), 1,
-      aux_sym_string_content_repeat1,
-    STATE(44), 1,
-      sym_string_content,
+    ACTIONS(42), 1,
+      anon_sym_LBRACE,
+    ACTIONS(44), 1,
+      anon_sym_LBRACK,
+    ACTIONS(48), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(50), 1,
+      sym_number,
+    STATE(53), 1,
+      sym__value,
+    ACTIONS(52), 3,
+      sym_true,
+      sym_false,
+      sym_null,
     STATE(7), 3,
       sym_request,
       sym_header,
       sym_external_body,
-  [223] = 6,
+    STATE(29), 3,
+      sym_object,
+      sym_array,
+      sym_string,
+  [178] = 7,
     ACTIONS(3), 1,
       sym_method,
     ACTIONS(5), 1,
@@ -2122,17 +1987,21 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
     ACTIONS(9), 1,
       sym_comment,
+    ACTIONS(58), 3,
+      sym_true,
+      sym_false,
+      sym_null,
     STATE(8), 3,
       sym_request,
       sym_header,
       sym_external_body,
-    ACTIONS(41), 5,
+    ACTIONS(56), 5,
       ts_builtin_sym_end,
-      anon_sym_COMMA,
-      anon_sym_RBRACE,
-      anon_sym_COLON,
-      anon_sym_RBRACK,
-  [248] = 6,
+      anon_sym_LBRACE,
+      anon_sym_LBRACK,
+      anon_sym_DQUOTE,
+      sym_number,
+  [208] = 7,
     ACTIONS(3), 1,
       sym_method,
     ACTIONS(5), 1,
@@ -2141,16 +2010,21 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
     ACTIONS(9), 1,
       sym_comment,
+    ACTIONS(62), 3,
+      sym_true,
+      sym_false,
+      sym_null,
     STATE(9), 3,
       sym_request,
       sym_header,
       sym_external_body,
-    ACTIONS(43), 4,
+    ACTIONS(60), 5,
       ts_builtin_sym_end,
-      anon_sym_COMMA,
-      anon_sym_RBRACE,
-      anon_sym_RBRACK,
-  [272] = 6,
+      anon_sym_LBRACE,
+      anon_sym_LBRACK,
+      anon_sym_DQUOTE,
+      sym_number,
+  [238] = 7,
     ACTIONS(3), 1,
       sym_method,
     ACTIONS(5), 1,
@@ -2159,36 +2033,21 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
     ACTIONS(9), 1,
       sym_comment,
+    ACTIONS(66), 3,
+      sym_true,
+      sym_false,
+      sym_null,
     STATE(10), 3,
       sym_request,
       sym_header,
       sym_external_body,
-    ACTIONS(45), 4,
+    ACTIONS(64), 5,
       ts_builtin_sym_end,
-      anon_sym_COMMA,
-      anon_sym_RBRACE,
-      anon_sym_RBRACK,
-  [296] = 8,
-    ACTIONS(3), 1,
-      sym_method,
-    ACTIONS(5), 1,
-      sym_name,
-    ACTIONS(37), 1,
-      anon_sym_LT,
-    ACTIONS(39), 1,
-      sym_comment,
-    ACTIONS(47), 1,
+      anon_sym_LBRACE,
+      anon_sym_LBRACK,
       anon_sym_DQUOTE,
-    ACTIONS(49), 1,
-      aux_sym_string_content_token1,
-    ACTIONS(52), 1,
-      sym_escape_sequence,
-    STATE(11), 4,
-      sym_request,
-      sym_header,
-      sym_external_body,
-      aux_sym_string_content_repeat1,
-  [324] = 6,
+      sym_number,
+  [268] = 7,
     ACTIONS(3), 1,
       sym_method,
     ACTIONS(5), 1,
@@ -2197,16 +2056,44 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
     ACTIONS(9), 1,
       sym_comment,
+    ACTIONS(70), 3,
+      sym_true,
+      sym_false,
+      sym_null,
+    STATE(11), 3,
+      sym_request,
+      sym_header,
+      sym_external_body,
+    ACTIONS(68), 5,
+      ts_builtin_sym_end,
+      anon_sym_LBRACE,
+      anon_sym_LBRACK,
+      anon_sym_DQUOTE,
+      sym_number,
+  [298] = 7,
+    ACTIONS(3), 1,
+      sym_method,
+    ACTIONS(5), 1,
+      sym_name,
+    ACTIONS(7), 1,
+      anon_sym_LT,
+    ACTIONS(9), 1,
+      sym_comment,
+    ACTIONS(74), 3,
+      sym_true,
+      sym_false,
+      sym_null,
     STATE(12), 3,
       sym_request,
       sym_header,
       sym_external_body,
-    ACTIONS(55), 4,
+    ACTIONS(72), 5,
       ts_builtin_sym_end,
-      anon_sym_COMMA,
-      anon_sym_RBRACE,
-      anon_sym_RBRACK,
-  [348] = 6,
+      anon_sym_LBRACE,
+      anon_sym_LBRACK,
+      anon_sym_DQUOTE,
+      sym_number,
+  [328] = 7,
     ACTIONS(3), 1,
       sym_method,
     ACTIONS(5), 1,
@@ -2215,16 +2102,21 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
     ACTIONS(9), 1,
       sym_comment,
+    ACTIONS(78), 3,
+      sym_true,
+      sym_false,
+      sym_null,
     STATE(13), 3,
       sym_request,
       sym_header,
       sym_external_body,
-    ACTIONS(57), 4,
+    ACTIONS(76), 5,
       ts_builtin_sym_end,
-      anon_sym_COMMA,
-      anon_sym_RBRACE,
-      anon_sym_RBRACK,
-  [372] = 6,
+      anon_sym_LBRACE,
+      anon_sym_LBRACK,
+      anon_sym_DQUOTE,
+      sym_number,
+  [358] = 7,
     ACTIONS(3), 1,
       sym_method,
     ACTIONS(5), 1,
@@ -2233,16 +2125,21 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
     ACTIONS(9), 1,
       sym_comment,
+    ACTIONS(82), 3,
+      sym_true,
+      sym_false,
+      sym_null,
     STATE(14), 3,
       sym_request,
       sym_header,
       sym_external_body,
-    ACTIONS(59), 4,
+    ACTIONS(80), 5,
       ts_builtin_sym_end,
-      anon_sym_COMMA,
-      anon_sym_RBRACE,
-      anon_sym_RBRACK,
-  [396] = 9,
+      anon_sym_LBRACE,
+      anon_sym_LBRACK,
+      anon_sym_DQUOTE,
+      sym_number,
+  [388] = 7,
     ACTIONS(3), 1,
       sym_method,
     ACTIONS(5), 1,
@@ -2251,40 +2148,44 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
     ACTIONS(9), 1,
       sym_comment,
-    ACTIONS(17), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(29), 1,
-      sym_number,
-    STATE(36), 1,
-      sym_pair,
-    STATE(41), 1,
-      sym_string,
+    ACTIONS(86), 3,
+      sym_true,
+      sym_false,
+      sym_null,
     STATE(15), 3,
       sym_request,
       sym_header,
       sym_external_body,
-  [426] = 9,
+    ACTIONS(84), 5,
+      ts_builtin_sym_end,
+      anon_sym_LBRACE,
+      anon_sym_LBRACK,
+      anon_sym_DQUOTE,
+      sym_number,
+  [418] = 7,
     ACTIONS(3), 1,
       sym_method,
     ACTIONS(5), 1,
       sym_name,
-    ACTIONS(37), 1,
+    ACTIONS(7), 1,
       anon_sym_LT,
-    ACTIONS(39), 1,
+    ACTIONS(9), 1,
       sym_comment,
-    ACTIONS(61), 1,
-      aux_sym_json_file_token1,
-    ACTIONS(63), 1,
-      aux_sym__whitespace_token1,
-    STATE(24), 1,
-      aux_sym__whitespace,
-    STATE(49), 1,
-      sym_json_file,
+    ACTIONS(90), 3,
+      sym_true,
+      sym_false,
+      sym_null,
     STATE(16), 3,
       sym_request,
       sym_header,
       sym_external_body,
-  [456] = 6,
+    ACTIONS(88), 5,
+      ts_builtin_sym_end,
+      anon_sym_LBRACE,
+      anon_sym_LBRACK,
+      anon_sym_DQUOTE,
+      sym_number,
+  [448] = 7,
     ACTIONS(3), 1,
       sym_method,
     ACTIONS(5), 1,
@@ -2293,73 +2194,67 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
     ACTIONS(9), 1,
       sym_comment,
+    ACTIONS(94), 3,
+      sym_true,
+      sym_false,
+      sym_null,
     STATE(17), 3,
       sym_request,
       sym_header,
       sym_external_body,
-    ACTIONS(65), 4,
+    ACTIONS(92), 5,
       ts_builtin_sym_end,
-      anon_sym_COMMA,
-      anon_sym_RBRACE,
-      anon_sym_RBRACK,
-  [480] = 6,
+      anon_sym_LBRACE,
+      anon_sym_LBRACK,
+      anon_sym_DQUOTE,
+      sym_number,
+  [478] = 10,
     ACTIONS(3), 1,
       sym_method,
     ACTIONS(5), 1,
       sym_name,
-    ACTIONS(7), 1,
+    ACTIONS(96), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(98), 1,
+      aux_sym_string_content_token1,
+    ACTIONS(100), 1,
+      sym_escape_sequence,
+    ACTIONS(102), 1,
       anon_sym_LT,
-    ACTIONS(9), 1,
+    ACTIONS(104), 1,
       sym_comment,
+    STATE(27), 1,
+      aux_sym_string_content_repeat1,
+    STATE(64), 1,
+      sym_string_content,
     STATE(18), 3,
       sym_request,
       sym_header,
       sym_external_body,
-    ACTIONS(67), 4,
-      ts_builtin_sym_end,
-      anon_sym_COMMA,
-      anon_sym_RBRACE,
-      anon_sym_RBRACK,
-  [504] = 9,
+  [511] = 10,
     ACTIONS(3), 1,
       sym_method,
     ACTIONS(5), 1,
       sym_name,
-    ACTIONS(33), 1,
+    ACTIONS(98), 1,
       aux_sym_string_content_token1,
-    ACTIONS(35), 1,
+    ACTIONS(100), 1,
       sym_escape_sequence,
-    ACTIONS(37), 1,
+    ACTIONS(102), 1,
       anon_sym_LT,
-    ACTIONS(39), 1,
+    ACTIONS(104), 1,
       sym_comment,
-    ACTIONS(69), 1,
+    ACTIONS(106), 1,
       anon_sym_DQUOTE,
-    STATE(11), 1,
+    STATE(27), 1,
       aux_sym_string_content_repeat1,
+    STATE(61), 1,
+      sym_string_content,
     STATE(19), 3,
       sym_request,
       sym_header,
       sym_external_body,
-  [534] = 7,
-    ACTIONS(3), 1,
-      sym_method,
-    ACTIONS(5), 1,
-      sym_name,
-    ACTIONS(37), 1,
-      anon_sym_LT,
-    ACTIONS(39), 1,
-      sym_comment,
-    ACTIONS(71), 1,
-      sym_url,
-    ACTIONS(73), 1,
-      aux_sym__whitespace_token1,
-    STATE(20), 4,
-      sym_request,
-      sym_header,
-      sym_external_body,
-      aux_sym__whitespace,
-  [559] = 8,
+  [544] = 10,
     ACTIONS(3), 1,
       sym_method,
     ACTIONS(5), 1,
@@ -2368,71 +2263,62 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
     ACTIONS(9), 1,
       sym_comment,
-    ACTIONS(76), 1,
-      anon_sym_COMMA,
-    ACTIONS(78), 1,
+    ACTIONS(48), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(108), 1,
       anon_sym_RBRACE,
-    STATE(27), 1,
-      aux_sym_object_repeat1,
+    ACTIONS(110), 1,
+      sym_number,
+    STATE(28), 1,
+      sym_pair,
+    STATE(60), 1,
+      sym_string,
+    STATE(20), 3,
+      sym_request,
+      sym_header,
+      sym_external_body,
+  [577] = 10,
+    ACTIONS(3), 1,
+      sym_method,
+    ACTIONS(5), 1,
+      sym_name,
+    ACTIONS(7), 1,
+      anon_sym_LT,
+    ACTIONS(9), 1,
+      sym_comment,
+    ACTIONS(48), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(110), 1,
+      sym_number,
+    ACTIONS(112), 1,
+      anon_sym_RBRACE,
+    STATE(35), 1,
+      sym_pair,
+    STATE(60), 1,
+      sym_string,
     STATE(21), 3,
       sym_request,
       sym_header,
       sym_external_body,
-  [586] = 7,
+  [610] = 6,
     ACTIONS(3), 1,
       sym_method,
     ACTIONS(5), 1,
       sym_name,
-    ACTIONS(37), 1,
+    ACTIONS(7), 1,
       anon_sym_LT,
-    ACTIONS(39), 1,
+    ACTIONS(9), 1,
       sym_comment,
-    ACTIONS(82), 1,
-      sym_escape_sequence,
-    ACTIONS(80), 2,
-      anon_sym_DQUOTE,
-      aux_sym_string_content_token1,
     STATE(22), 3,
       sym_request,
       sym_header,
       sym_external_body,
-  [611] = 7,
-    ACTIONS(3), 1,
-      sym_method,
-    ACTIONS(5), 1,
-      sym_name,
-    ACTIONS(37), 1,
-      anon_sym_LT,
-    ACTIONS(39), 1,
-      sym_comment,
-    ACTIONS(71), 1,
-      sym_value,
-    ACTIONS(84), 1,
-      aux_sym__whitespace_token1,
-    STATE(23), 4,
-      sym_request,
-      sym_header,
-      sym_external_body,
-      aux_sym__whitespace,
-  [636] = 7,
-    ACTIONS(3), 1,
-      sym_method,
-    ACTIONS(5), 1,
-      sym_name,
-    ACTIONS(37), 1,
-      anon_sym_LT,
-    ACTIONS(39), 1,
-      sym_comment,
-    ACTIONS(71), 1,
-      aux_sym_json_file_token1,
-    ACTIONS(87), 1,
-      aux_sym__whitespace_token1,
-    STATE(24), 4,
-      sym_request,
-      sym_header,
-      sym_external_body,
-      aux_sym__whitespace,
-  [661] = 7,
+    ACTIONS(84), 4,
+      anon_sym_COMMA,
+      anon_sym_RBRACE,
+      anon_sym_COLON,
+      anon_sym_RBRACK,
+  [634] = 6,
     ACTIONS(3), 1,
       sym_method,
     ACTIONS(5), 1,
@@ -2441,308 +2327,99 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
     ACTIONS(9), 1,
       sym_comment,
-    ACTIONS(90), 1,
+    STATE(23), 3,
+      sym_request,
+      sym_header,
+      sym_external_body,
+    ACTIONS(56), 4,
       anon_sym_COMMA,
-    ACTIONS(93), 1,
+      anon_sym_RBRACE,
+      anon_sym_COLON,
       anon_sym_RBRACK,
+  [658] = 9,
+    ACTIONS(3), 1,
+      sym_method,
+    ACTIONS(5), 1,
+      sym_name,
+    ACTIONS(102), 1,
+      anon_sym_LT,
+    ACTIONS(104), 1,
+      sym_comment,
+    ACTIONS(114), 1,
+      aux_sym_json_file_token1,
+    ACTIONS(116), 1,
+      aux_sym__whitespace_token1,
+    STATE(44), 1,
+      aux_sym__whitespace,
+    STATE(69), 1,
+      sym_json_file,
+    STATE(24), 3,
+      sym_request,
+      sym_header,
+      sym_external_body,
+  [688] = 8,
+    ACTIONS(3), 1,
+      sym_method,
+    ACTIONS(5), 1,
+      sym_name,
+    ACTIONS(102), 1,
+      anon_sym_LT,
+    ACTIONS(104), 1,
+      sym_comment,
+    ACTIONS(118), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(120), 1,
+      aux_sym_string_content_token1,
+    ACTIONS(123), 1,
+      sym_escape_sequence,
     STATE(25), 4,
       sym_request,
       sym_header,
       sym_external_body,
-      aux_sym_array_repeat1,
-  [686] = 8,
+      aux_sym_string_content_repeat1,
+  [716] = 9,
     ACTIONS(3), 1,
       sym_method,
     ACTIONS(5), 1,
       sym_name,
-    ACTIONS(37), 1,
+    ACTIONS(7), 1,
       anon_sym_LT,
-    ACTIONS(39), 1,
+    ACTIONS(9), 1,
       sym_comment,
-    ACTIONS(95), 1,
-      sym_value,
-    ACTIONS(97), 1,
-      aux_sym__whitespace_token1,
-    STATE(23), 1,
-      aux_sym__whitespace,
+    ACTIONS(48), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(110), 1,
+      sym_number,
+    STATE(54), 1,
+      sym_pair,
+    STATE(60), 1,
+      sym_string,
     STATE(26), 3,
       sym_request,
       sym_header,
       sym_external_body,
-  [713] = 7,
+  [746] = 9,
     ACTIONS(3), 1,
       sym_method,
     ACTIONS(5), 1,
       sym_name,
-    ACTIONS(7), 1,
-      anon_sym_LT,
-    ACTIONS(9), 1,
-      sym_comment,
-    ACTIONS(99), 1,
-      anon_sym_COMMA,
+    ACTIONS(98), 1,
+      aux_sym_string_content_token1,
+    ACTIONS(100), 1,
+      sym_escape_sequence,
     ACTIONS(102), 1,
-      anon_sym_RBRACE,
-    STATE(27), 4,
-      sym_request,
-      sym_header,
-      sym_external_body,
-      aux_sym_object_repeat1,
-  [738] = 8,
-    ACTIONS(3), 1,
-      sym_method,
-    ACTIONS(5), 1,
-      sym_name,
-    ACTIONS(7), 1,
       anon_sym_LT,
-    ACTIONS(9), 1,
-      sym_comment,
     ACTIONS(104), 1,
-      anon_sym_COMMA,
-    ACTIONS(106), 1,
-      anon_sym_RBRACK,
-    STATE(31), 1,
-      aux_sym_array_repeat1,
-    STATE(28), 3,
-      sym_request,
-      sym_header,
-      sym_external_body,
-  [765] = 8,
-    ACTIONS(3), 1,
-      sym_method,
-    ACTIONS(5), 1,
-      sym_name,
-    ACTIONS(7), 1,
-      anon_sym_LT,
-    ACTIONS(9), 1,
-      sym_comment,
-    ACTIONS(76), 1,
-      anon_sym_COMMA,
-    ACTIONS(108), 1,
-      anon_sym_RBRACE,
-    STATE(21), 1,
-      aux_sym_object_repeat1,
-    STATE(29), 3,
-      sym_request,
-      sym_header,
-      sym_external_body,
-  [792] = 8,
-    ACTIONS(3), 1,
-      sym_method,
-    ACTIONS(5), 1,
-      sym_name,
-    ACTIONS(37), 1,
-      anon_sym_LT,
-    ACTIONS(39), 1,
-      sym_comment,
-    ACTIONS(110), 1,
-      sym_url,
-    ACTIONS(112), 1,
-      aux_sym__whitespace_token1,
-    STATE(20), 1,
-      aux_sym__whitespace,
-    STATE(30), 3,
-      sym_request,
-      sym_header,
-      sym_external_body,
-  [819] = 8,
-    ACTIONS(3), 1,
-      sym_method,
-    ACTIONS(5), 1,
-      sym_name,
-    ACTIONS(7), 1,
-      anon_sym_LT,
-    ACTIONS(9), 1,
-      sym_comment,
-    ACTIONS(104), 1,
-      anon_sym_COMMA,
-    ACTIONS(114), 1,
-      anon_sym_RBRACK,
-    STATE(25), 1,
-      aux_sym_array_repeat1,
-    STATE(31), 3,
-      sym_request,
-      sym_header,
-      sym_external_body,
-  [846] = 7,
-    ACTIONS(3), 1,
-      sym_method,
-    ACTIONS(5), 1,
-      sym_name,
-    ACTIONS(37), 1,
-      anon_sym_LT,
-    ACTIONS(39), 1,
-      sym_comment,
-    ACTIONS(63), 1,
-      aux_sym__whitespace_token1,
-    STATE(16), 1,
-      aux_sym__whitespace,
-    STATE(32), 3,
-      sym_request,
-      sym_header,
-      sym_external_body,
-  [870] = 7,
-    ACTIONS(3), 1,
-      sym_method,
-    ACTIONS(5), 1,
-      sym_name,
-    ACTIONS(37), 1,
-      anon_sym_LT,
-    ACTIONS(39), 1,
-      sym_comment,
-    ACTIONS(116), 1,
-      aux_sym__whitespace_token1,
-    STATE(26), 1,
-      aux_sym__whitespace,
-    STATE(33), 3,
-      sym_request,
-      sym_header,
-      sym_external_body,
-  [894] = 7,
-    ACTIONS(3), 1,
-      sym_method,
-    ACTIONS(5), 1,
-      sym_name,
-    ACTIONS(37), 1,
-      anon_sym_LT,
-    ACTIONS(39), 1,
-      sym_comment,
-    ACTIONS(118), 1,
-      sym_url,
-    ACTIONS(120), 1,
-      aux_sym__whitespace_token1,
-    STATE(34), 3,
-      sym_request,
-      sym_header,
-      sym_external_body,
-  [918] = 6,
-    ACTIONS(3), 1,
-      sym_method,
-    ACTIONS(5), 1,
-      sym_name,
-    ACTIONS(7), 1,
-      anon_sym_LT,
-    ACTIONS(9), 1,
-      sym_comment,
-    ACTIONS(122), 2,
-      anon_sym_COMMA,
-      anon_sym_RBRACE,
-    STATE(35), 3,
-      sym_request,
-      sym_header,
-      sym_external_body,
-  [940] = 6,
-    ACTIONS(3), 1,
-      sym_method,
-    ACTIONS(5), 1,
-      sym_name,
-    ACTIONS(7), 1,
-      anon_sym_LT,
-    ACTIONS(9), 1,
-      sym_comment,
-    ACTIONS(102), 2,
-      anon_sym_COMMA,
-      anon_sym_RBRACE,
-    STATE(36), 3,
-      sym_request,
-      sym_header,
-      sym_external_body,
-  [962] = 6,
-    ACTIONS(3), 1,
-      sym_method,
-    ACTIONS(5), 1,
-      sym_name,
-    ACTIONS(7), 1,
-      anon_sym_LT,
-    ACTIONS(9), 1,
-      sym_comment,
-    ACTIONS(93), 2,
-      anon_sym_COMMA,
-      anon_sym_RBRACK,
-    STATE(37), 3,
-      sym_request,
-      sym_header,
-      sym_external_body,
-  [984] = 7,
-    ACTIONS(3), 1,
-      sym_method,
-    ACTIONS(5), 1,
-      sym_name,
-    ACTIONS(37), 1,
-      anon_sym_LT,
-    ACTIONS(39), 1,
-      sym_comment,
-    ACTIONS(118), 1,
-      aux_sym_json_file_token1,
-    ACTIONS(120), 1,
-      aux_sym__whitespace_token1,
-    STATE(38), 3,
-      sym_request,
-      sym_header,
-      sym_external_body,
-  [1008] = 7,
-    ACTIONS(3), 1,
-      sym_method,
-    ACTIONS(5), 1,
-      sym_name,
-    ACTIONS(37), 1,
-      anon_sym_LT,
-    ACTIONS(39), 1,
-      sym_comment,
-    ACTIONS(112), 1,
-      aux_sym__whitespace_token1,
-    STATE(30), 1,
-      aux_sym__whitespace,
-    STATE(39), 3,
-      sym_request,
-      sym_header,
-      sym_external_body,
-  [1032] = 6,
-    ACTIONS(3), 1,
-      sym_method,
-    ACTIONS(5), 1,
-      sym_name,
-    ACTIONS(37), 1,
-      anon_sym_LT,
-    ACTIONS(39), 1,
-      sym_comment,
-    ACTIONS(118), 2,
-      sym_value,
-      aux_sym__whitespace_token1,
-    STATE(40), 3,
-      sym_request,
-      sym_header,
-      sym_external_body,
-  [1054] = 6,
-    ACTIONS(3), 1,
-      sym_method,
-    ACTIONS(5), 1,
-      sym_name,
-    ACTIONS(7), 1,
-      anon_sym_LT,
-    ACTIONS(9), 1,
-      sym_comment,
-    ACTIONS(124), 1,
-      anon_sym_COLON,
-    STATE(41), 3,
-      sym_request,
-      sym_header,
-      sym_external_body,
-  [1075] = 6,
-    ACTIONS(3), 1,
-      sym_method,
-    ACTIONS(5), 1,
-      sym_name,
-    ACTIONS(7), 1,
-      anon_sym_LT,
-    ACTIONS(9), 1,
       sym_comment,
     ACTIONS(126), 1,
-      ts_builtin_sym_end,
-    STATE(42), 3,
+      anon_sym_DQUOTE,
+    STATE(25), 1,
+      aux_sym_string_content_repeat1,
+    STATE(27), 3,
       sym_request,
       sym_header,
       sym_external_body,
-  [1096] = 6,
+  [776] = 8,
     ACTIONS(3), 1,
       sym_method,
     ACTIONS(5), 1,
@@ -2752,12 +2429,16 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(9), 1,
       sym_comment,
     ACTIONS(128), 1,
-      ts_builtin_sym_end,
-    STATE(43), 3,
+      anon_sym_COMMA,
+    ACTIONS(130), 1,
+      anon_sym_RBRACE,
+    STATE(34), 1,
+      aux_sym_object_repeat1,
+    STATE(28), 3,
       sym_request,
       sym_header,
       sym_external_body,
-  [1117] = 6,
+  [803] = 6,
     ACTIONS(3), 1,
       sym_method,
     ACTIONS(5), 1,
@@ -2766,9 +2447,233 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
     ACTIONS(9), 1,
       sym_comment,
-    ACTIONS(130), 1,
+    ACTIONS(60), 3,
+      anon_sym_COMMA,
+      anon_sym_RBRACE,
+      anon_sym_RBRACK,
+    STATE(29), 3,
+      sym_request,
+      sym_header,
+      sym_external_body,
+  [826] = 8,
+    ACTIONS(3), 1,
+      sym_method,
+    ACTIONS(5), 1,
+      sym_name,
+    ACTIONS(102), 1,
+      anon_sym_LT,
+    ACTIONS(104), 1,
+      sym_comment,
+    ACTIONS(132), 1,
+      sym_value,
+    ACTIONS(134), 1,
+      aux_sym__whitespace_token1,
+    STATE(36), 1,
+      aux_sym__whitespace,
+    STATE(30), 3,
+      sym_request,
+      sym_header,
+      sym_external_body,
+  [853] = 8,
+    ACTIONS(3), 1,
+      sym_method,
+    ACTIONS(5), 1,
+      sym_name,
+    ACTIONS(7), 1,
+      anon_sym_LT,
+    ACTIONS(9), 1,
+      sym_comment,
+    ACTIONS(136), 1,
+      anon_sym_COMMA,
+    ACTIONS(138), 1,
+      anon_sym_RBRACK,
+    STATE(48), 1,
+      aux_sym_array_repeat1,
+    STATE(31), 3,
+      sym_request,
+      sym_header,
+      sym_external_body,
+  [880] = 8,
+    ACTIONS(3), 1,
+      sym_method,
+    ACTIONS(5), 1,
+      sym_name,
+    ACTIONS(7), 1,
+      anon_sym_LT,
+    ACTIONS(9), 1,
+      sym_comment,
+    ACTIONS(128), 1,
+      anon_sym_COMMA,
+    ACTIONS(140), 1,
+      anon_sym_RBRACE,
+    STATE(45), 1,
+      aux_sym_object_repeat1,
+    STATE(32), 3,
+      sym_request,
+      sym_header,
+      sym_external_body,
+  [907] = 8,
+    ACTIONS(3), 1,
+      sym_method,
+    ACTIONS(5), 1,
+      sym_name,
+    ACTIONS(7), 1,
+      anon_sym_LT,
+    ACTIONS(9), 1,
+      sym_comment,
+    ACTIONS(136), 1,
+      anon_sym_COMMA,
+    ACTIONS(142), 1,
+      anon_sym_RBRACK,
+    STATE(31), 1,
+      aux_sym_array_repeat1,
+    STATE(33), 3,
+      sym_request,
+      sym_header,
+      sym_external_body,
+  [934] = 8,
+    ACTIONS(3), 1,
+      sym_method,
+    ACTIONS(5), 1,
+      sym_name,
+    ACTIONS(7), 1,
+      anon_sym_LT,
+    ACTIONS(9), 1,
+      sym_comment,
+    ACTIONS(128), 1,
+      anon_sym_COMMA,
+    ACTIONS(144), 1,
+      anon_sym_RBRACE,
+    STATE(45), 1,
+      aux_sym_object_repeat1,
+    STATE(34), 3,
+      sym_request,
+      sym_header,
+      sym_external_body,
+  [961] = 8,
+    ACTIONS(3), 1,
+      sym_method,
+    ACTIONS(5), 1,
+      sym_name,
+    ACTIONS(7), 1,
+      anon_sym_LT,
+    ACTIONS(9), 1,
+      sym_comment,
+    ACTIONS(128), 1,
+      anon_sym_COMMA,
+    ACTIONS(146), 1,
+      anon_sym_RBRACE,
+    STATE(32), 1,
+      aux_sym_object_repeat1,
+    STATE(35), 3,
+      sym_request,
+      sym_header,
+      sym_external_body,
+  [988] = 7,
+    ACTIONS(3), 1,
+      sym_method,
+    ACTIONS(5), 1,
+      sym_name,
+    ACTIONS(102), 1,
+      anon_sym_LT,
+    ACTIONS(104), 1,
+      sym_comment,
+    ACTIONS(148), 1,
+      sym_value,
+    ACTIONS(150), 1,
+      aux_sym__whitespace_token1,
+    STATE(36), 4,
+      sym_request,
+      sym_header,
+      sym_external_body,
+      aux_sym__whitespace,
+  [1013] = 8,
+    ACTIONS(3), 1,
+      sym_method,
+    ACTIONS(5), 1,
+      sym_name,
+    ACTIONS(7), 1,
+      anon_sym_LT,
+    ACTIONS(9), 1,
+      sym_comment,
+    ACTIONS(136), 1,
+      anon_sym_COMMA,
+    ACTIONS(153), 1,
+      anon_sym_RBRACK,
+    STATE(48), 1,
+      aux_sym_array_repeat1,
+    STATE(37), 3,
+      sym_request,
+      sym_header,
+      sym_external_body,
+  [1040] = 7,
+    ACTIONS(3), 1,
+      sym_method,
+    ACTIONS(5), 1,
+      sym_name,
+    ACTIONS(102), 1,
+      anon_sym_LT,
+    ACTIONS(104), 1,
+      sym_comment,
+    ACTIONS(157), 1,
+      sym_escape_sequence,
+    ACTIONS(155), 2,
       anon_sym_DQUOTE,
-    STATE(44), 3,
+      aux_sym_string_content_token1,
+    STATE(38), 3,
+      sym_request,
+      sym_header,
+      sym_external_body,
+  [1065] = 8,
+    ACTIONS(3), 1,
+      sym_method,
+    ACTIONS(5), 1,
+      sym_name,
+    ACTIONS(7), 1,
+      anon_sym_LT,
+    ACTIONS(9), 1,
+      sym_comment,
+    ACTIONS(136), 1,
+      anon_sym_COMMA,
+    ACTIONS(159), 1,
+      anon_sym_RBRACK,
+    STATE(37), 1,
+      aux_sym_array_repeat1,
+    STATE(39), 3,
+      sym_request,
+      sym_header,
+      sym_external_body,
+  [1092] = 6,
+    ACTIONS(3), 1,
+      sym_method,
+    ACTIONS(5), 1,
+      sym_name,
+    ACTIONS(7), 1,
+      anon_sym_LT,
+    ACTIONS(9), 1,
+      sym_comment,
+    ACTIONS(68), 3,
+      anon_sym_COMMA,
+      anon_sym_RBRACE,
+      anon_sym_RBRACK,
+    STATE(40), 3,
+      sym_request,
+      sym_header,
+      sym_external_body,
+  [1115] = 6,
+    ACTIONS(3), 1,
+      sym_method,
+    ACTIONS(5), 1,
+      sym_name,
+    ACTIONS(7), 1,
+      anon_sym_LT,
+    ACTIONS(9), 1,
+      sym_comment,
+    ACTIONS(72), 3,
+      anon_sym_COMMA,
+      anon_sym_RBRACE,
+      anon_sym_RBRACK,
+    STATE(41), 3,
       sym_request,
       sym_header,
       sym_external_body,
@@ -2781,13 +2686,15 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
     ACTIONS(9), 1,
       sym_comment,
-    ACTIONS(132), 1,
-      anon_sym_COLON,
-    STATE(45), 3,
+    ACTIONS(88), 3,
+      anon_sym_COMMA,
+      anon_sym_RBRACE,
+      anon_sym_RBRACK,
+    STATE(42), 3,
       sym_request,
       sym_header,
       sym_external_body,
-  [1159] = 6,
+  [1161] = 6,
     ACTIONS(3), 1,
       sym_method,
     ACTIONS(5), 1,
@@ -2796,148 +2703,561 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
     ACTIONS(9), 1,
       sym_comment,
-    ACTIONS(134), 1,
-      anon_sym_DOTjson,
+    ACTIONS(92), 3,
+      anon_sym_COMMA,
+      anon_sym_RBRACE,
+      anon_sym_RBRACK,
+    STATE(43), 3,
+      sym_request,
+      sym_header,
+      sym_external_body,
+  [1184] = 7,
+    ACTIONS(3), 1,
+      sym_method,
+    ACTIONS(5), 1,
+      sym_name,
+    ACTIONS(102), 1,
+      anon_sym_LT,
+    ACTIONS(104), 1,
+      sym_comment,
+    ACTIONS(148), 1,
+      aux_sym_json_file_token1,
+    ACTIONS(161), 1,
+      aux_sym__whitespace_token1,
+    STATE(44), 4,
+      sym_request,
+      sym_header,
+      sym_external_body,
+      aux_sym__whitespace,
+  [1209] = 7,
+    ACTIONS(3), 1,
+      sym_method,
+    ACTIONS(5), 1,
+      sym_name,
+    ACTIONS(7), 1,
+      anon_sym_LT,
+    ACTIONS(9), 1,
+      sym_comment,
+    ACTIONS(164), 1,
+      anon_sym_COMMA,
+    ACTIONS(167), 1,
+      anon_sym_RBRACE,
+    STATE(45), 4,
+      sym_request,
+      sym_header,
+      sym_external_body,
+      aux_sym_object_repeat1,
+  [1234] = 8,
+    ACTIONS(3), 1,
+      sym_method,
+    ACTIONS(5), 1,
+      sym_name,
+    ACTIONS(102), 1,
+      anon_sym_LT,
+    ACTIONS(104), 1,
+      sym_comment,
+    ACTIONS(169), 1,
+      sym_url,
+    ACTIONS(171), 1,
+      aux_sym__whitespace_token1,
+    STATE(49), 1,
+      aux_sym__whitespace,
     STATE(46), 3,
       sym_request,
       sym_header,
       sym_external_body,
-  [1180] = 1,
-    ACTIONS(136), 1,
+  [1261] = 6,
+    ACTIONS(3), 1,
+      sym_method,
+    ACTIONS(5), 1,
+      sym_name,
+    ACTIONS(7), 1,
+      anon_sym_LT,
+    ACTIONS(9), 1,
+      sym_comment,
+    ACTIONS(80), 3,
+      anon_sym_COMMA,
+      anon_sym_RBRACE,
+      anon_sym_RBRACK,
+    STATE(47), 3,
+      sym_request,
+      sym_header,
+      sym_external_body,
+  [1284] = 7,
+    ACTIONS(3), 1,
+      sym_method,
+    ACTIONS(5), 1,
+      sym_name,
+    ACTIONS(7), 1,
+      anon_sym_LT,
+    ACTIONS(9), 1,
+      sym_comment,
+    ACTIONS(173), 1,
+      anon_sym_COMMA,
+    ACTIONS(176), 1,
+      anon_sym_RBRACK,
+    STATE(48), 4,
+      sym_request,
+      sym_header,
+      sym_external_body,
+      aux_sym_array_repeat1,
+  [1309] = 7,
+    ACTIONS(3), 1,
+      sym_method,
+    ACTIONS(5), 1,
+      sym_name,
+    ACTIONS(102), 1,
+      anon_sym_LT,
+    ACTIONS(104), 1,
+      sym_comment,
+    ACTIONS(148), 1,
+      sym_url,
+    ACTIONS(178), 1,
+      aux_sym__whitespace_token1,
+    STATE(49), 4,
+      sym_request,
+      sym_header,
+      sym_external_body,
+      aux_sym__whitespace,
+  [1334] = 6,
+    ACTIONS(3), 1,
+      sym_method,
+    ACTIONS(5), 1,
+      sym_name,
+    ACTIONS(7), 1,
+      anon_sym_LT,
+    ACTIONS(9), 1,
+      sym_comment,
+    ACTIONS(76), 3,
+      anon_sym_COMMA,
+      anon_sym_RBRACE,
+      anon_sym_RBRACK,
+    STATE(50), 3,
+      sym_request,
+      sym_header,
+      sym_external_body,
+  [1357] = 7,
+    ACTIONS(3), 1,
+      sym_method,
+    ACTIONS(5), 1,
+      sym_name,
+    ACTIONS(102), 1,
+      anon_sym_LT,
+    ACTIONS(104), 1,
+      sym_comment,
+    ACTIONS(181), 1,
+      aux_sym_json_file_token1,
+    ACTIONS(183), 1,
+      aux_sym__whitespace_token1,
+    STATE(51), 3,
+      sym_request,
+      sym_header,
+      sym_external_body,
+  [1381] = 7,
+    ACTIONS(3), 1,
+      sym_method,
+    ACTIONS(5), 1,
+      sym_name,
+    ACTIONS(102), 1,
+      anon_sym_LT,
+    ACTIONS(104), 1,
+      sym_comment,
+    ACTIONS(185), 1,
+      aux_sym__whitespace_token1,
+    STATE(30), 1,
+      aux_sym__whitespace,
+    STATE(52), 3,
+      sym_request,
+      sym_header,
+      sym_external_body,
+  [1405] = 6,
+    ACTIONS(3), 1,
+      sym_method,
+    ACTIONS(5), 1,
+      sym_name,
+    ACTIONS(7), 1,
+      anon_sym_LT,
+    ACTIONS(9), 1,
+      sym_comment,
+    ACTIONS(176), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACK,
+    STATE(53), 3,
+      sym_request,
+      sym_header,
+      sym_external_body,
+  [1427] = 6,
+    ACTIONS(3), 1,
+      sym_method,
+    ACTIONS(5), 1,
+      sym_name,
+    ACTIONS(7), 1,
+      anon_sym_LT,
+    ACTIONS(9), 1,
+      sym_comment,
+    ACTIONS(167), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACE,
+    STATE(54), 3,
+      sym_request,
+      sym_header,
+      sym_external_body,
+  [1449] = 6,
+    ACTIONS(3), 1,
+      sym_method,
+    ACTIONS(5), 1,
+      sym_name,
+    ACTIONS(7), 1,
+      anon_sym_LT,
+    ACTIONS(9), 1,
+      sym_comment,
+    ACTIONS(187), 2,
+      anon_sym_COMMA,
+      anon_sym_RBRACE,
+    STATE(55), 3,
+      sym_request,
+      sym_header,
+      sym_external_body,
+  [1471] = 7,
+    ACTIONS(3), 1,
+      sym_method,
+    ACTIONS(5), 1,
+      sym_name,
+    ACTIONS(102), 1,
+      anon_sym_LT,
+    ACTIONS(104), 1,
+      sym_comment,
+    ACTIONS(181), 1,
+      sym_url,
+    ACTIONS(183), 1,
+      aux_sym__whitespace_token1,
+    STATE(56), 3,
+      sym_request,
+      sym_header,
+      sym_external_body,
+  [1495] = 6,
+    ACTIONS(3), 1,
+      sym_method,
+    ACTIONS(5), 1,
+      sym_name,
+    ACTIONS(102), 1,
+      anon_sym_LT,
+    ACTIONS(104), 1,
+      sym_comment,
+    ACTIONS(181), 2,
+      sym_value,
+      aux_sym__whitespace_token1,
+    STATE(57), 3,
+      sym_request,
+      sym_header,
+      sym_external_body,
+  [1517] = 7,
+    ACTIONS(3), 1,
+      sym_method,
+    ACTIONS(5), 1,
+      sym_name,
+    ACTIONS(102), 1,
+      anon_sym_LT,
+    ACTIONS(104), 1,
+      sym_comment,
+    ACTIONS(116), 1,
+      aux_sym__whitespace_token1,
+    STATE(24), 1,
+      aux_sym__whitespace,
+    STATE(58), 3,
+      sym_request,
+      sym_header,
+      sym_external_body,
+  [1541] = 7,
+    ACTIONS(3), 1,
+      sym_method,
+    ACTIONS(5), 1,
+      sym_name,
+    ACTIONS(102), 1,
+      anon_sym_LT,
+    ACTIONS(104), 1,
+      sym_comment,
+    ACTIONS(171), 1,
+      aux_sym__whitespace_token1,
+    STATE(46), 1,
+      aux_sym__whitespace,
+    STATE(59), 3,
+      sym_request,
+      sym_header,
+      sym_external_body,
+  [1565] = 6,
+    ACTIONS(3), 1,
+      sym_method,
+    ACTIONS(5), 1,
+      sym_name,
+    ACTIONS(7), 1,
+      anon_sym_LT,
+    ACTIONS(9), 1,
+      sym_comment,
+    ACTIONS(189), 1,
+      anon_sym_COLON,
+    STATE(60), 3,
+      sym_request,
+      sym_header,
+      sym_external_body,
+  [1586] = 6,
+    ACTIONS(3), 1,
+      sym_method,
+    ACTIONS(5), 1,
+      sym_name,
+    ACTIONS(7), 1,
+      anon_sym_LT,
+    ACTIONS(9), 1,
+      sym_comment,
+    ACTIONS(191), 1,
+      anon_sym_DQUOTE,
+    STATE(61), 3,
+      sym_request,
+      sym_header,
+      sym_external_body,
+  [1607] = 6,
+    ACTIONS(3), 1,
+      sym_method,
+    ACTIONS(5), 1,
+      sym_name,
+    ACTIONS(7), 1,
+      anon_sym_LT,
+    ACTIONS(9), 1,
+      sym_comment,
+    ACTIONS(193), 1,
       ts_builtin_sym_end,
-  [1184] = 1,
-    ACTIONS(138), 1,
+    STATE(62), 3,
+      sym_request,
+      sym_header,
+      sym_external_body,
+  [1628] = 6,
+    ACTIONS(3), 1,
+      sym_method,
+    ACTIONS(5), 1,
+      sym_name,
+    ACTIONS(7), 1,
+      anon_sym_LT,
+    ACTIONS(9), 1,
+      sym_comment,
+    ACTIONS(195), 1,
+      anon_sym_COLON,
+    STATE(63), 3,
+      sym_request,
+      sym_header,
+      sym_external_body,
+  [1649] = 6,
+    ACTIONS(3), 1,
+      sym_method,
+    ACTIONS(5), 1,
+      sym_name,
+    ACTIONS(7), 1,
+      anon_sym_LT,
+    ACTIONS(9), 1,
+      sym_comment,
+    ACTIONS(197), 1,
+      anon_sym_DQUOTE,
+    STATE(64), 3,
+      sym_request,
+      sym_header,
+      sym_external_body,
+  [1670] = 6,
+    ACTIONS(3), 1,
+      sym_method,
+    ACTIONS(5), 1,
+      sym_name,
+    ACTIONS(7), 1,
+      anon_sym_LT,
+    ACTIONS(9), 1,
+      sym_comment,
+    ACTIONS(199), 1,
+      anon_sym_DOTjson,
+    STATE(65), 3,
+      sym_request,
+      sym_header,
+      sym_external_body,
+  [1691] = 1,
+    ACTIONS(201), 1,
       ts_builtin_sym_end,
-  [1188] = 1,
-    ACTIONS(140), 1,
+  [1695] = 1,
+    ACTIONS(203), 1,
       ts_builtin_sym_end,
-  [1192] = 1,
-    ACTIONS(142), 1,
+  [1699] = 1,
+    ACTIONS(205), 1,
+      ts_builtin_sym_end,
+  [1703] = 1,
+    ACTIONS(207), 1,
       ts_builtin_sym_end,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
-  [SMALL_STATE(2)] = 0,
-  [SMALL_STATE(3)] = 46,
-  [SMALL_STATE(4)] = 89,
-  [SMALL_STATE(5)] = 132,
-  [SMALL_STATE(6)] = 157,
-  [SMALL_STATE(7)] = 190,
-  [SMALL_STATE(8)] = 223,
-  [SMALL_STATE(9)] = 248,
-  [SMALL_STATE(10)] = 272,
-  [SMALL_STATE(11)] = 296,
-  [SMALL_STATE(12)] = 324,
-  [SMALL_STATE(13)] = 348,
-  [SMALL_STATE(14)] = 372,
-  [SMALL_STATE(15)] = 396,
-  [SMALL_STATE(16)] = 426,
-  [SMALL_STATE(17)] = 456,
-  [SMALL_STATE(18)] = 480,
-  [SMALL_STATE(19)] = 504,
-  [SMALL_STATE(20)] = 534,
-  [SMALL_STATE(21)] = 559,
-  [SMALL_STATE(22)] = 586,
-  [SMALL_STATE(23)] = 611,
-  [SMALL_STATE(24)] = 636,
-  [SMALL_STATE(25)] = 661,
-  [SMALL_STATE(26)] = 686,
-  [SMALL_STATE(27)] = 713,
-  [SMALL_STATE(28)] = 738,
-  [SMALL_STATE(29)] = 765,
-  [SMALL_STATE(30)] = 792,
-  [SMALL_STATE(31)] = 819,
-  [SMALL_STATE(32)] = 846,
-  [SMALL_STATE(33)] = 870,
-  [SMALL_STATE(34)] = 894,
-  [SMALL_STATE(35)] = 918,
-  [SMALL_STATE(36)] = 940,
-  [SMALL_STATE(37)] = 962,
-  [SMALL_STATE(38)] = 984,
-  [SMALL_STATE(39)] = 1008,
-  [SMALL_STATE(40)] = 1032,
-  [SMALL_STATE(41)] = 1054,
-  [SMALL_STATE(42)] = 1075,
-  [SMALL_STATE(43)] = 1096,
-  [SMALL_STATE(44)] = 1117,
-  [SMALL_STATE(45)] = 1138,
-  [SMALL_STATE(46)] = 1159,
-  [SMALL_STATE(47)] = 1180,
-  [SMALL_STATE(48)] = 1184,
-  [SMALL_STATE(49)] = 1188,
-  [SMALL_STATE(50)] = 1192,
+  [SMALL_STATE(4)] = 0,
+  [SMALL_STATE(5)] = 46,
+  [SMALL_STATE(6)] = 92,
+  [SMALL_STATE(7)] = 135,
+  [SMALL_STATE(8)] = 178,
+  [SMALL_STATE(9)] = 208,
+  [SMALL_STATE(10)] = 238,
+  [SMALL_STATE(11)] = 268,
+  [SMALL_STATE(12)] = 298,
+  [SMALL_STATE(13)] = 328,
+  [SMALL_STATE(14)] = 358,
+  [SMALL_STATE(15)] = 388,
+  [SMALL_STATE(16)] = 418,
+  [SMALL_STATE(17)] = 448,
+  [SMALL_STATE(18)] = 478,
+  [SMALL_STATE(19)] = 511,
+  [SMALL_STATE(20)] = 544,
+  [SMALL_STATE(21)] = 577,
+  [SMALL_STATE(22)] = 610,
+  [SMALL_STATE(23)] = 634,
+  [SMALL_STATE(24)] = 658,
+  [SMALL_STATE(25)] = 688,
+  [SMALL_STATE(26)] = 716,
+  [SMALL_STATE(27)] = 746,
+  [SMALL_STATE(28)] = 776,
+  [SMALL_STATE(29)] = 803,
+  [SMALL_STATE(30)] = 826,
+  [SMALL_STATE(31)] = 853,
+  [SMALL_STATE(32)] = 880,
+  [SMALL_STATE(33)] = 907,
+  [SMALL_STATE(34)] = 934,
+  [SMALL_STATE(35)] = 961,
+  [SMALL_STATE(36)] = 988,
+  [SMALL_STATE(37)] = 1013,
+  [SMALL_STATE(38)] = 1040,
+  [SMALL_STATE(39)] = 1065,
+  [SMALL_STATE(40)] = 1092,
+  [SMALL_STATE(41)] = 1115,
+  [SMALL_STATE(42)] = 1138,
+  [SMALL_STATE(43)] = 1161,
+  [SMALL_STATE(44)] = 1184,
+  [SMALL_STATE(45)] = 1209,
+  [SMALL_STATE(46)] = 1234,
+  [SMALL_STATE(47)] = 1261,
+  [SMALL_STATE(48)] = 1284,
+  [SMALL_STATE(49)] = 1309,
+  [SMALL_STATE(50)] = 1334,
+  [SMALL_STATE(51)] = 1357,
+  [SMALL_STATE(52)] = 1381,
+  [SMALL_STATE(53)] = 1405,
+  [SMALL_STATE(54)] = 1427,
+  [SMALL_STATE(55)] = 1449,
+  [SMALL_STATE(56)] = 1471,
+  [SMALL_STATE(57)] = 1495,
+  [SMALL_STATE(58)] = 1517,
+  [SMALL_STATE(59)] = 1541,
+  [SMALL_STATE(60)] = 1565,
+  [SMALL_STATE(61)] = 1586,
+  [SMALL_STATE(62)] = 1607,
+  [SMALL_STATE(63)] = 1628,
+  [SMALL_STATE(64)] = 1649,
+  [SMALL_STATE(65)] = 1670,
+  [SMALL_STATE(66)] = 1691,
+  [SMALL_STATE(67)] = 1695,
+  [SMALL_STATE(68)] = 1699,
+  [SMALL_STATE(69)] = 1703,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
-  [3] = {.entry = {.count = 1, .reusable = false}}, SHIFT(39),
-  [5] = {.entry = {.count = 1, .reusable = false}}, SHIFT(45),
-  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
+  [3] = {.entry = {.count = 1, .reusable = false}}, SHIFT(59),
+  [5] = {.entry = {.count = 1, .reusable = false}}, SHIFT(63),
+  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
   [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT_EXTRA(),
   [11] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 0),
-  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
-  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
-  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
-  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
-  [21] = {.entry = {.count = 1, .reusable = false}}, SHIFT(12),
-  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
-  [25] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 2),
-  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
-  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
-  [31] = {.entry = {.count = 1, .reusable = false}}, SHIFT(5),
-  [33] = {.entry = {.count = 1, .reusable = false}}, SHIFT(22),
-  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
-  [37] = {.entry = {.count = 1, .reusable = false}}, SHIFT(32),
-  [39] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
-  [41] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 3),
-  [43] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_array, 4),
-  [45] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_object, 4),
-  [47] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_string_content_repeat1, 2),
-  [49] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_string_content_repeat1, 2), SHIFT_REPEAT(22),
-  [52] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_string_content_repeat1, 2), SHIFT_REPEAT(22),
-  [55] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__value, 1),
-  [57] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_array, 3),
-  [59] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_object, 3),
-  [61] = {.entry = {.count = 1, .reusable = false}}, SHIFT(46),
-  [63] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
-  [65] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_object, 2),
-  [67] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_array, 2),
-  [69] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string_content, 1),
-  [71] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym__whitespace, 2),
-  [73] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__whitespace, 2), SHIFT_REPEAT(34),
-  [76] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
-  [78] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
-  [80] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_string_content_repeat1, 1),
-  [82] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_string_content_repeat1, 1),
-  [84] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__whitespace, 2), SHIFT_REPEAT(40),
-  [87] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__whitespace, 2), SHIFT_REPEAT(38),
-  [90] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_array_repeat1, 2), SHIFT_REPEAT(3),
-  [93] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_array_repeat1, 2),
-  [95] = {.entry = {.count = 1, .reusable = false}}, SHIFT(47),
-  [97] = {.entry = {.count = 1, .reusable = false}}, SHIFT(40),
-  [99] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_object_repeat1, 2), SHIFT_REPEAT(15),
-  [102] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_object_repeat1, 2),
-  [104] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
-  [106] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
-  [108] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
-  [110] = {.entry = {.count = 1, .reusable = false}}, SHIFT(50),
-  [112] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
-  [114] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
-  [116] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
-  [118] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym__whitespace, 1),
-  [120] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__whitespace, 1),
-  [122] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pair, 3, .production_id = 4),
-  [124] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
-  [126] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 1),
-  [128] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [130] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
-  [132] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
-  [134] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
-  [136] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_header, 4, .production_id = 3),
-  [138] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_json_file, 2),
-  [140] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_external_body, 3, .production_id = 2),
-  [142] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 3, .production_id = 1),
+  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
+  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
+  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
+  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
+  [21] = {.entry = {.count = 1, .reusable = false}}, SHIFT(9),
+  [23] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 1),
+  [25] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2),
+  [27] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(20),
+  [30] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(5),
+  [33] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(19),
+  [36] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(9),
+  [39] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(9),
+  [42] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
+  [44] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
+  [46] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
+  [48] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
+  [50] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
+  [52] = {.entry = {.count = 1, .reusable = false}}, SHIFT(29),
+  [54] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
+  [56] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 2),
+  [58] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string, 2),
+  [60] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__value, 1),
+  [62] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__value, 1),
+  [64] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 1),
+  [66] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 1),
+  [68] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_array, 4),
+  [70] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_array, 4),
+  [72] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_object, 4),
+  [74] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_object, 4),
+  [76] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_object, 2),
+  [78] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_object, 2),
+  [80] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_array, 2),
+  [82] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_array, 2),
+  [84] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 3),
+  [86] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string, 3),
+  [88] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_array, 3),
+  [90] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_array, 3),
+  [92] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_object, 3),
+  [94] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_object, 3),
+  [96] = {.entry = {.count = 1, .reusable = false}}, SHIFT(23),
+  [98] = {.entry = {.count = 1, .reusable = false}}, SHIFT(38),
+  [100] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
+  [102] = {.entry = {.count = 1, .reusable = false}}, SHIFT(58),
+  [104] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
+  [106] = {.entry = {.count = 1, .reusable = false}}, SHIFT(8),
+  [108] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
+  [110] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
+  [112] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
+  [114] = {.entry = {.count = 1, .reusable = false}}, SHIFT(65),
+  [116] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
+  [118] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_string_content_repeat1, 2),
+  [120] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_string_content_repeat1, 2), SHIFT_REPEAT(38),
+  [123] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_string_content_repeat1, 2), SHIFT_REPEAT(38),
+  [126] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string_content, 1),
+  [128] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
+  [130] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
+  [132] = {.entry = {.count = 1, .reusable = false}}, SHIFT(67),
+  [134] = {.entry = {.count = 1, .reusable = false}}, SHIFT(57),
+  [136] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
+  [138] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
+  [140] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
+  [142] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
+  [144] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
+  [146] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
+  [148] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym__whitespace, 2),
+  [150] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__whitespace, 2), SHIFT_REPEAT(57),
+  [153] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
+  [155] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_string_content_repeat1, 1),
+  [157] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_string_content_repeat1, 1),
+  [159] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
+  [161] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__whitespace, 2), SHIFT_REPEAT(51),
+  [164] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_object_repeat1, 2), SHIFT_REPEAT(26),
+  [167] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_object_repeat1, 2),
+  [169] = {.entry = {.count = 1, .reusable = false}}, SHIFT(68),
+  [171] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
+  [173] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_array_repeat1, 2), SHIFT_REPEAT(7),
+  [176] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_array_repeat1, 2),
+  [178] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__whitespace, 2), SHIFT_REPEAT(56),
+  [181] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym__whitespace, 1),
+  [183] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__whitespace, 1),
+  [185] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
+  [187] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pair, 3, .production_id = 4),
+  [189] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
+  [191] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
+  [193] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [195] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
+  [197] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
+  [199] = {.entry = {.count = 1, .reusable = true}}, SHIFT(66),
+  [201] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_json_file, 2),
+  [203] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_header, 4, .production_id = 3),
+  [205] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 3, .production_id = 1),
+  [207] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_external_body, 3, .production_id = 2),
 };
 
 #ifdef __cplusplus

--- a/src/parser.c
+++ b/src/parser.c
@@ -343,144 +343,218 @@ static const uint16_t ts_non_terminal_alias_map[] = {
   0,
 };
 
+static inline bool sym_url_character_set_1(int32_t c) {
+  return (c < ';'
+    ? (c < '+'
+      ? (c < '%'
+        ? c == '#'
+        : c <= '&')
+      : (c <= '+' || (c >= '-' && c <= '9')))
+    : (c <= ';' || (c < '^'
+      ? (c < '?'
+        ? c == '='
+        : c <= 'Z')
+      : (c <= '_' || c == '~'))));
+}
+
+static inline bool sym_url_character_set_2(int32_t c) {
+  return (c < ';'
+    ? (c < '+'
+      ? (c < '%'
+        ? c == '#'
+        : c <= '&')
+      : (c <= '+' || (c < '/'
+        ? c == '-'
+        : c <= '/')))
+    : (c <= ';' || (c < '^'
+      ? (c < '?'
+        ? c == '='
+        : c <= 'Z')
+      : (c <= '_' || (c < '~'
+        ? (c >= 'a' && c <= 'z')
+        : c <= '~')))));
+}
+
+static inline bool sym_url_character_set_3(int32_t c) {
+  return (c < ';'
+    ? (c < '+'
+      ? (c < '%'
+        ? c == '#'
+        : c <= '&')
+      : (c <= '+' || (c < '/'
+        ? c == '-'
+        : c <= '9')))
+    : (c <= ';' || (c < '^'
+      ? (c < '?'
+        ? c == '='
+        : c <= 'Z')
+      : (c <= '_' || c == '~'))));
+}
+
+static inline bool sym_url_character_set_4(int32_t c) {
+  return (c < ';'
+    ? (c < '+'
+      ? (c < '%'
+        ? c == '#'
+        : c <= '&')
+      : (c <= '+' || (c < '/'
+        ? c == '-'
+        : c <= '9')))
+    : (c <= ';' || (c < '^'
+      ? (c < '?'
+        ? c == '='
+        : c <= 'Z')
+      : (c <= '_' || (c < '~'
+        ? (c >= 'a' && c <= 'z')
+        : c <= '~')))));
+}
+
+static inline bool sym_url_character_set_5(int32_t c) {
+  return (c < '='
+    ? (c < '+'
+      ? (c < '%'
+        ? c == '#'
+        : c <= '&')
+      : (c <= '+' || (c >= '-' && c <= ';')))
+    : (c <= '=' || (c < 'a'
+      ? (c < '^'
+        ? (c >= '?' && c <= 'Z')
+        : c <= '_')
+      : (c <= 'z' || c == '~'))));
+}
+
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
   START_LEXER();
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(28);
-      if (lookahead == '"') ADVANCE(35);
-      if (lookahead == '#') ADVANCE(160);
+      if (eof) ADVANCE(32);
+      if (lookahead == '"') ADVANCE(39);
+      if (lookahead == '#') ADVANCE(164);
       if (lookahead == '+') ADVANCE(9);
-      if (lookahead == ',') ADVANCE(30);
-      if (lookahead == '-') ADVANCE(80);
-      if (lookahead == '.') ADVANCE(150);
-      if (lookahead == '0') ADVANCE(53);
-      if (lookahead == ':') ADVANCE(32);
-      if (lookahead == '<') ADVANCE(157);
-      if (lookahead == 'D') ADVANCE(90);
-      if (lookahead == 'G') ADVANCE(91);
-      if (lookahead == 'P') ADVANCE(84);
-      if (lookahead == '[') ADVANCE(33);
+      if (lookahead == ',') ADVANCE(34);
+      if (lookahead == '-') ADVANCE(84);
+      if (lookahead == '.') ADVANCE(154);
+      if (lookahead == '0') ADVANCE(57);
+      if (lookahead == ':') ADVANCE(36);
+      if (lookahead == '<') ADVANCE(161);
+      if (lookahead == 'D') ADVANCE(94);
+      if (lookahead == 'G') ADVANCE(95);
+      if (lookahead == 'P') ADVANCE(88);
+      if (lookahead == '[') ADVANCE(37);
       if (lookahead == '\\') ADVANCE(20);
-      if (lookahead == ']') ADVANCE(34);
-      if (lookahead == 'f') ADVANCE(120);
-      if (lookahead == 'n') ADVANCE(141);
-      if (lookahead == 't') ADVANCE(133);
-      if (lookahead == '{') ADVANCE(29);
-      if (lookahead == '}') ADVANCE(31);
+      if (lookahead == ']') ADVANCE(38);
+      if (lookahead == 'f') ADVANCE(124);
+      if (lookahead == 'n') ADVANCE(145);
+      if (lookahead == 't') ADVANCE(137);
+      if (lookahead == '{') ADVANCE(33);
+      if (lookahead == '}') ADVANCE(35);
       if (lookahead == '/' ||
-          lookahead == '_') ADVANCE(154);
+          lookahead == '_') ADVANCE(158);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') SKIP(25)
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(55);
+          lookahead == ' ') SKIP(29)
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(59);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(145);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
       END_STATE();
     case 1:
       if (lookahead == '\n') SKIP(5)
-      if (lookahead == '"') ADVANCE(35);
-      if (lookahead == '#') ADVANCE(49);
-      if (lookahead == '<') ADVANCE(158);
-      if (lookahead == 'D') ADVANCE(40);
-      if (lookahead == 'G') ADVANCE(41);
-      if (lookahead == 'P') ADVANCE(37);
+      if (lookahead == '"') ADVANCE(39);
+      if (lookahead == '#') ADVANCE(53);
+      if (lookahead == '<') ADVANCE(162);
+      if (lookahead == 'D') ADVANCE(44);
+      if (lookahead == 'G') ADVANCE(45);
+      if (lookahead == 'P') ADVANCE(41);
       if (lookahead == '\\') ADVANCE(20);
       if (lookahead == '\t' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(36);
+          lookahead == ' ') ADVANCE(40);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(50);
-      if (lookahead != 0) ADVANCE(51);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(54);
+      if (lookahead != 0) ADVANCE(55);
       END_STATE();
     case 2:
       if (lookahead == '\n') SKIP(2)
-      if (lookahead == 11) ADVANCE(149);
-      if (lookahead == '\r') ADVANCE(148);
-      if (lookahead == '#') ADVANCE(149);
-      if (lookahead == '<') ADVANCE(159);
-      if (lookahead == 'D') ADVANCE(96);
-      if (lookahead == 'G') ADVANCE(97);
-      if (lookahead == 'P') ADVANCE(86);
+      if (lookahead == 11) ADVANCE(153);
+      if (lookahead == '\r') ADVANCE(152);
+      if (lookahead == '#') ADVANCE(153);
+      if (lookahead == '<') ADVANCE(163);
+      if (lookahead == 'D') ADVANCE(100);
+      if (lookahead == 'G') ADVANCE(101);
+      if (lookahead == 'P') ADVANCE(90);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(148);
+          lookahead == ' ') ADVANCE(152);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(147);
-      if (lookahead != 0) ADVANCE(149);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
+      if (lookahead != 0) ADVANCE(153);
       END_STATE();
     case 3:
-      if (lookahead == 11) ADVANCE(161);
-      if (lookahead == '#') ADVANCE(160);
-      if (lookahead == '<') ADVANCE(157);
-      if (lookahead == 'D') ADVANCE(90);
-      if (lookahead == 'G') ADVANCE(91);
-      if (lookahead == 'P') ADVANCE(84);
+      if (lookahead == 11) ADVANCE(165);
+      if (lookahead == '#') ADVANCE(164);
+      if (lookahead == '<') ADVANCE(161);
+      if (lookahead == 'D') ADVANCE(94);
+      if (lookahead == 'G') ADVANCE(95);
+      if (lookahead == 'P') ADVANCE(88);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(162);
+          lookahead == ' ') ADVANCE(166);
       if (lookahead == '\n' ||
           lookahead == '\r') SKIP(3)
       if (lookahead == '.' ||
           lookahead == '/' ||
-          lookahead == '_') ADVANCE(154);
+          lookahead == '_') ADVANCE(158);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(145);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
       END_STATE();
     case 4:
-      if (lookahead == 11) ADVANCE(161);
-      if (lookahead == '#') ADVANCE(160);
-      if (lookahead == '<') ADVANCE(157);
-      if (lookahead == 'D') ADVANCE(93);
-      if (lookahead == 'G') ADVANCE(94);
-      if (lookahead == 'P') ADVANCE(85);
-      if (lookahead == 'h') ADVANCE(138);
-      if (lookahead == 'w') ADVANCE(144);
+      if (lookahead == 11) ADVANCE(165);
+      if (lookahead == '#') ADVANCE(164);
+      if (lookahead == '<') ADVANCE(161);
+      if (lookahead == 'D') ADVANCE(97);
+      if (lookahead == 'G') ADVANCE(98);
+      if (lookahead == 'P') ADVANCE(89);
+      if (lookahead == 'h') ADVANCE(142);
+      if (lookahead == 'w') ADVANCE(148);
+      if (lookahead == '{') ADVANCE(15);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(162);
+          lookahead == ' ') ADVANCE(166);
       if (lookahead == '\n' ||
           lookahead == '\r') SKIP(4)
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 5:
-      if (lookahead == '"') ADVANCE(35);
-      if (lookahead == '#') ADVANCE(160);
-      if (lookahead == '<') ADVANCE(157);
-      if (lookahead == 'D') ADVANCE(93);
-      if (lookahead == 'G') ADVANCE(94);
-      if (lookahead == 'P') ADVANCE(85);
+      if (lookahead == '"') ADVANCE(39);
+      if (lookahead == '#') ADVANCE(164);
+      if (lookahead == '<') ADVANCE(161);
+      if (lookahead == 'D') ADVANCE(97);
+      if (lookahead == 'G') ADVANCE(98);
+      if (lookahead == 'P') ADVANCE(89);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(5)
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 6:
-      if (lookahead == '.') ADVANCE(19);
-      if (lookahead == ',' ||
-          lookahead == ':') ADVANCE(75);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(74);
-      if (lookahead == '#' ||
-          lookahead == '%' ||
-          lookahead == '&' ||
-          ('+' <= lookahead && lookahead <= ';') ||
-          lookahead == '=' ||
-          ('?' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '^' ||
-          lookahead == '_' ||
-          lookahead == '~') ADVANCE(75);
+      if (lookahead == '.') ADVANCE(28);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(78);
+      if (sym_url_character_set_1(lookahead)) ADVANCE(79);
+      if (('$' <= lookahead && lookahead <= '{') ||
+          lookahead == '}' ||
+          (192 <= lookahead && lookahead <= 255)) ADVANCE(79);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '\r' &&
-          lookahead != ' ') ADVANCE(75);
+          lookahead != ' ') ADVANCE(79);
       END_STATE();
     case 7:
       if (lookahead == '/') ADVANCE(8);
@@ -489,15 +563,15 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '/') ADVANCE(14);
       END_STATE();
     case 9:
-      if (lookahead == '0') ADVANCE(54);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(55);
+      if (lookahead == '0') ADVANCE(58);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(59);
       END_STATE();
     case 10:
       if (lookahead == 'j') ADVANCE(13);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(56);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(60);
       END_STATE();
     case 11:
-      if (lookahead == 'n') ADVANCE(155);
+      if (lookahead == 'n') ADVANCE(159);
       END_STATE();
     case 12:
       if (lookahead == 'o') ADVANCE(11);
@@ -506,68 +580,35 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == 's') ADVANCE(12);
       END_STATE();
     case 14:
-      if (lookahead == 'w') ADVANCE(70);
+      if (lookahead == 'w') ADVANCE(74);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '\r' &&
           lookahead != ' ' &&
-          lookahead != '.') ADVANCE(75);
+          lookahead != '.') ADVANCE(79);
       END_STATE();
     case 15:
-      if (lookahead == '+' ||
-          lookahead == '-') ADVANCE(23);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(59);
+      if (lookahead == '{') ADVANCE(27);
       END_STATE();
     case 16:
-      if (lookahead == '0' ||
-          lookahead == '1') ADVANCE(57);
+      if (lookahead == '}') ADVANCE(17);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(16);
       END_STATE();
     case 17:
-      if (lookahead == ',' ||
-          lookahead == '.' ||
-          lookahead == ':') ADVANCE(19);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(77);
-      if (lookahead == '#' ||
-          lookahead == '%' ||
-          lookahead == '&' ||
-          ('+' <= lookahead && lookahead <= ';') ||
-          lookahead == '=' ||
-          ('?' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '^' ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == '~') ADVANCE(78);
+      if (lookahead == '}') ADVANCE(82);
       END_STATE();
     case 18:
-      if (lookahead == ',' ||
-          lookahead == '.' ||
-          lookahead == ':') ADVANCE(19);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(76);
-      if (lookahead == '#' ||
-          lookahead == '%' ||
-          lookahead == '&' ||
-          ('+' <= lookahead && lookahead <= ';') ||
-          lookahead == '=' ||
-          ('?' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '^' ||
-          lookahead == '_' ||
-          lookahead == '~') ADVANCE(78);
+      if (lookahead == '+' ||
+          lookahead == '-') ADVANCE(23);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(63);
       END_STATE();
     case 19:
-      if (lookahead == ',' ||
-          lookahead == '.' ||
-          lookahead == ':') ADVANCE(19);
-      if (lookahead == '#' ||
-          lookahead == '%' ||
-          lookahead == '&' ||
-          ('+' <= lookahead && lookahead <= ';') ||
-          lookahead == '=' ||
-          ('?' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '^' ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == '~') ADVANCE(78);
+      if (lookahead == '0' ||
+          lookahead == '1') ADVANCE(61);
       END_STATE();
     case 20:
       if (lookahead == '"' ||
@@ -577,1289 +618,1268 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == 'n' ||
           lookahead == 'r' ||
           lookahead == 't' ||
-          lookahead == 'u') ADVANCE(52);
+          lookahead == 'u') ADVANCE(56);
       END_STATE();
     case 21:
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(58);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(62);
       END_STATE();
     case 22:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(56);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(60);
       END_STATE();
     case 23:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(59);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(63);
       END_STATE();
     case 24:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(60);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(81);
+      if (sym_url_character_set_2(lookahead)) ADVANCE(82);
+      if (('$' <= lookahead && lookahead <= '{') ||
+          lookahead == '}' ||
+          (192 <= lookahead && lookahead <= 255)) ADVANCE(28);
       END_STATE();
     case 25:
-      if (eof) ADVANCE(28);
-      if (lookahead == '"') ADVANCE(35);
-      if (lookahead == '#') ADVANCE(160);
-      if (lookahead == '+') ADVANCE(9);
-      if (lookahead == ',') ADVANCE(30);
-      if (lookahead == '-') ADVANCE(80);
-      if (lookahead == '.') ADVANCE(150);
-      if (lookahead == '0') ADVANCE(53);
-      if (lookahead == ':') ADVANCE(32);
-      if (lookahead == '<') ADVANCE(157);
-      if (lookahead == 'D') ADVANCE(90);
-      if (lookahead == 'G') ADVANCE(91);
-      if (lookahead == 'P') ADVANCE(84);
-      if (lookahead == '[') ADVANCE(33);
-      if (lookahead == ']') ADVANCE(34);
-      if (lookahead == 'f') ADVANCE(120);
-      if (lookahead == 'n') ADVANCE(141);
-      if (lookahead == 't') ADVANCE(133);
-      if (lookahead == '{') ADVANCE(29);
-      if (lookahead == '}') ADVANCE(31);
-      if (lookahead == '/' ||
-          lookahead == '_') ADVANCE(154);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') SKIP(25)
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(55);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(145);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(64);
       END_STATE();
     case 26:
-      if (eof) ADVANCE(28);
-      if (lookahead == '"') ADVANCE(35);
-      if (lookahead == '#') ADVANCE(160);
-      if (lookahead == '+') ADVANCE(9);
-      if (lookahead == ',') ADVANCE(30);
-      if (lookahead == '-') ADVANCE(81);
-      if (lookahead == '.') ADVANCE(10);
-      if (lookahead == '0') ADVANCE(53);
-      if (lookahead == ':') ADVANCE(32);
-      if (lookahead == '<') ADVANCE(157);
-      if (lookahead == 'D') ADVANCE(93);
-      if (lookahead == 'G') ADVANCE(94);
-      if (lookahead == 'P') ADVANCE(85);
-      if (lookahead == ']') ADVANCE(34);
-      if (lookahead == '}') ADVANCE(31);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') SKIP(26)
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(55);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(80);
+      if (sym_url_character_set_3(lookahead)) ADVANCE(82);
+      if (('$' <= lookahead && lookahead <= '{') ||
+          lookahead == '}' ||
+          (192 <= lookahead && lookahead <= 255)) ADVANCE(28);
       END_STATE();
     case 27:
-      if (eof) ADVANCE(28);
-      if (lookahead == '"') ADVANCE(35);
-      if (lookahead == '#') ADVANCE(160);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(16);
+      END_STATE();
+    case 28:
+      if (sym_url_character_set_4(lookahead)) ADVANCE(82);
+      if (('$' <= lookahead && lookahead <= '{') ||
+          lookahead == '}' ||
+          (192 <= lookahead && lookahead <= 255)) ADVANCE(28);
+      END_STATE();
+    case 29:
+      if (eof) ADVANCE(32);
+      if (lookahead == '"') ADVANCE(39);
+      if (lookahead == '#') ADVANCE(164);
       if (lookahead == '+') ADVANCE(9);
-      if (lookahead == '-') ADVANCE(81);
-      if (lookahead == '.') ADVANCE(22);
-      if (lookahead == '0') ADVANCE(53);
-      if (lookahead == '<') ADVANCE(157);
-      if (lookahead == 'D') ADVANCE(93);
-      if (lookahead == 'G') ADVANCE(94);
-      if (lookahead == 'P') ADVANCE(85);
-      if (lookahead == '[') ADVANCE(33);
-      if (lookahead == ']') ADVANCE(34);
-      if (lookahead == 'f') ADVANCE(121);
-      if (lookahead == 'n') ADVANCE(142);
-      if (lookahead == 't') ADVANCE(134);
-      if (lookahead == '{') ADVANCE(29);
+      if (lookahead == ',') ADVANCE(34);
+      if (lookahead == '-') ADVANCE(84);
+      if (lookahead == '.') ADVANCE(154);
+      if (lookahead == '0') ADVANCE(57);
+      if (lookahead == ':') ADVANCE(36);
+      if (lookahead == '<') ADVANCE(161);
+      if (lookahead == 'D') ADVANCE(94);
+      if (lookahead == 'G') ADVANCE(95);
+      if (lookahead == 'P') ADVANCE(88);
+      if (lookahead == '[') ADVANCE(37);
+      if (lookahead == ']') ADVANCE(38);
+      if (lookahead == 'f') ADVANCE(124);
+      if (lookahead == 'n') ADVANCE(145);
+      if (lookahead == 't') ADVANCE(137);
+      if (lookahead == '{') ADVANCE(33);
+      if (lookahead == '}') ADVANCE(35);
+      if (lookahead == '/' ||
+          lookahead == '_') ADVANCE(158);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') SKIP(27)
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(55);
+          lookahead == ' ') SKIP(29)
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(59);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
-      END_STATE();
-    case 28:
-      ACCEPT_TOKEN(ts_builtin_sym_end);
-      END_STATE();
-    case 29:
-      ACCEPT_TOKEN(anon_sym_LBRACE);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
       END_STATE();
     case 30:
-      ACCEPT_TOKEN(anon_sym_COMMA);
+      if (eof) ADVANCE(32);
+      if (lookahead == '"') ADVANCE(39);
+      if (lookahead == '#') ADVANCE(164);
+      if (lookahead == '+') ADVANCE(9);
+      if (lookahead == ',') ADVANCE(34);
+      if (lookahead == '-') ADVANCE(85);
+      if (lookahead == '.') ADVANCE(10);
+      if (lookahead == '0') ADVANCE(57);
+      if (lookahead == ':') ADVANCE(36);
+      if (lookahead == '<') ADVANCE(161);
+      if (lookahead == 'D') ADVANCE(97);
+      if (lookahead == 'G') ADVANCE(98);
+      if (lookahead == 'P') ADVANCE(89);
+      if (lookahead == ']') ADVANCE(38);
+      if (lookahead == '}') ADVANCE(35);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(30)
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(59);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 31:
-      ACCEPT_TOKEN(anon_sym_RBRACE);
+      if (eof) ADVANCE(32);
+      if (lookahead == '"') ADVANCE(39);
+      if (lookahead == '#') ADVANCE(164);
+      if (lookahead == '+') ADVANCE(9);
+      if (lookahead == '-') ADVANCE(85);
+      if (lookahead == '.') ADVANCE(22);
+      if (lookahead == '0') ADVANCE(57);
+      if (lookahead == '<') ADVANCE(161);
+      if (lookahead == 'D') ADVANCE(97);
+      if (lookahead == 'G') ADVANCE(98);
+      if (lookahead == 'P') ADVANCE(89);
+      if (lookahead == '[') ADVANCE(37);
+      if (lookahead == ']') ADVANCE(38);
+      if (lookahead == 'f') ADVANCE(125);
+      if (lookahead == 'n') ADVANCE(146);
+      if (lookahead == 't') ADVANCE(138);
+      if (lookahead == '{') ADVANCE(33);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(31)
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(59);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 32:
-      ACCEPT_TOKEN(anon_sym_COLON);
+      ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
     case 33:
-      ACCEPT_TOKEN(anon_sym_LBRACK);
+      ACCEPT_TOKEN(anon_sym_LBRACE);
       END_STATE();
     case 34:
-      ACCEPT_TOKEN(anon_sym_RBRACK);
+      ACCEPT_TOKEN(anon_sym_COMMA);
       END_STATE();
     case 35:
-      ACCEPT_TOKEN(anon_sym_DQUOTE);
+      ACCEPT_TOKEN(anon_sym_RBRACE);
       END_STATE();
     case 36:
-      ACCEPT_TOKEN(aux_sym_string_content_token1);
-      if (lookahead == '#') ADVANCE(49);
-      if (lookahead == '<') ADVANCE(158);
-      if (lookahead == 'D') ADVANCE(40);
-      if (lookahead == 'G') ADVANCE(41);
-      if (lookahead == 'P') ADVANCE(37);
-      if (lookahead == '\t' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(36);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(50);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '"' &&
-          lookahead != '\\') ADVANCE(51);
+      ACCEPT_TOKEN(anon_sym_COLON);
       END_STATE();
     case 37:
-      ACCEPT_TOKEN(aux_sym_string_content_token1);
-      if (lookahead == 'A') ADVANCE(47);
-      if (lookahead == 'O') ADVANCE(45);
-      if (lookahead == 'U') ADVANCE(46);
-      if (lookahead == '-' ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(50);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '"' &&
-          lookahead != '\\') ADVANCE(51);
+      ACCEPT_TOKEN(anon_sym_LBRACK);
       END_STATE();
     case 38:
-      ACCEPT_TOKEN(aux_sym_string_content_token1);
-      if (lookahead == 'C') ADVANCE(43);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(50);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '"' &&
-          lookahead != '\\') ADVANCE(51);
+      ACCEPT_TOKEN(anon_sym_RBRACK);
       END_STATE();
     case 39:
-      ACCEPT_TOKEN(aux_sym_string_content_token1);
-      if (lookahead == 'E') ADVANCE(50);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(50);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '"' &&
-          lookahead != '\\') ADVANCE(51);
+      ACCEPT_TOKEN(anon_sym_DQUOTE);
       END_STATE();
     case 40:
       ACCEPT_TOKEN(aux_sym_string_content_token1);
-      if (lookahead == 'E') ADVANCE(44);
+      if (lookahead == '#') ADVANCE(53);
+      if (lookahead == '<') ADVANCE(162);
+      if (lookahead == 'D') ADVANCE(44);
+      if (lookahead == 'G') ADVANCE(45);
+      if (lookahead == 'P') ADVANCE(41);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(40);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(50);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(54);
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != '"' &&
-          lookahead != '\\') ADVANCE(51);
+          lookahead != '\\') ADVANCE(55);
       END_STATE();
     case 41:
       ACCEPT_TOKEN(aux_sym_string_content_token1);
-      if (lookahead == 'E') ADVANCE(46);
+      if (lookahead == 'A') ADVANCE(51);
+      if (lookahead == 'O') ADVANCE(49);
+      if (lookahead == 'U') ADVANCE(50);
       if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(50);
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(54);
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != '"' &&
-          lookahead != '\\') ADVANCE(51);
+          lookahead != '\\') ADVANCE(55);
       END_STATE();
     case 42:
+      ACCEPT_TOKEN(aux_sym_string_content_token1);
+      if (lookahead == 'C') ADVANCE(47);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(54);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '"' &&
+          lookahead != '\\') ADVANCE(55);
+      END_STATE();
+    case 43:
+      ACCEPT_TOKEN(aux_sym_string_content_token1);
+      if (lookahead == 'E') ADVANCE(54);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(54);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '"' &&
+          lookahead != '\\') ADVANCE(55);
+      END_STATE();
+    case 44:
       ACCEPT_TOKEN(aux_sym_string_content_token1);
       if (lookahead == 'E') ADVANCE(48);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(50);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(54);
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != '"' &&
-          lookahead != '\\') ADVANCE(51);
-      END_STATE();
-    case 43:
-      ACCEPT_TOKEN(aux_sym_string_content_token1);
-      if (lookahead == 'H') ADVANCE(50);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(50);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '"' &&
-          lookahead != '\\') ADVANCE(51);
-      END_STATE();
-    case 44:
-      ACCEPT_TOKEN(aux_sym_string_content_token1);
-      if (lookahead == 'L') ADVANCE(42);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(50);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '"' &&
-          lookahead != '\\') ADVANCE(51);
+          lookahead != '\\') ADVANCE(55);
       END_STATE();
     case 45:
       ACCEPT_TOKEN(aux_sym_string_content_token1);
-      if (lookahead == 'S') ADVANCE(46);
+      if (lookahead == 'E') ADVANCE(50);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(50);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(54);
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != '"' &&
-          lookahead != '\\') ADVANCE(51);
+          lookahead != '\\') ADVANCE(55);
       END_STATE();
     case 46:
       ACCEPT_TOKEN(aux_sym_string_content_token1);
-      if (lookahead == 'T') ADVANCE(50);
+      if (lookahead == 'E') ADVANCE(52);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(50);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(54);
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != '"' &&
-          lookahead != '\\') ADVANCE(51);
+          lookahead != '\\') ADVANCE(55);
       END_STATE();
     case 47:
       ACCEPT_TOKEN(aux_sym_string_content_token1);
-      if (lookahead == 'T') ADVANCE(38);
+      if (lookahead == 'H') ADVANCE(54);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(50);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(54);
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != '"' &&
-          lookahead != '\\') ADVANCE(51);
+          lookahead != '\\') ADVANCE(55);
       END_STATE();
     case 48:
       ACCEPT_TOKEN(aux_sym_string_content_token1);
-      if (lookahead == 'T') ADVANCE(39);
+      if (lookahead == 'L') ADVANCE(46);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(50);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(54);
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != '"' &&
-          lookahead != '\\') ADVANCE(51);
+          lookahead != '\\') ADVANCE(55);
       END_STATE();
     case 49:
       ACCEPT_TOKEN(aux_sym_string_content_token1);
-      if (lookahead == '"' ||
-          lookahead == '\\') ADVANCE(160);
+      if (lookahead == 'S') ADVANCE(50);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(54);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(49);
+          lookahead != '\n' &&
+          lookahead != '"' &&
+          lookahead != '\\') ADVANCE(55);
       END_STATE();
     case 50:
       ACCEPT_TOKEN(aux_sym_string_content_token1);
+      if (lookahead == 'T') ADVANCE(54);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(50);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(54);
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != '"' &&
-          lookahead != '\\') ADVANCE(51);
+          lookahead != '\\') ADVANCE(55);
       END_STATE();
     case 51:
+      ACCEPT_TOKEN(aux_sym_string_content_token1);
+      if (lookahead == 'T') ADVANCE(42);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(54);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '"' &&
+          lookahead != '\\') ADVANCE(55);
+      END_STATE();
+    case 52:
+      ACCEPT_TOKEN(aux_sym_string_content_token1);
+      if (lookahead == 'T') ADVANCE(43);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(54);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '"' &&
+          lookahead != '\\') ADVANCE(55);
+      END_STATE();
+    case 53:
+      ACCEPT_TOKEN(aux_sym_string_content_token1);
+      if (lookahead == '"' ||
+          lookahead == '\\') ADVANCE(164);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(53);
+      END_STATE();
+    case 54:
+      ACCEPT_TOKEN(aux_sym_string_content_token1);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(54);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '"' &&
+          lookahead != '\\') ADVANCE(55);
+      END_STATE();
+    case 55:
       ACCEPT_TOKEN(aux_sym_string_content_token1);
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != '"' &&
-          lookahead != '\\') ADVANCE(51);
-      END_STATE();
-    case 52:
-      ACCEPT_TOKEN(sym_escape_sequence);
-      END_STATE();
-    case 53:
-      ACCEPT_TOKEN(sym_number);
-      if (lookahead == '.') ADVANCE(56);
-      if (lookahead == 'B' ||
-          lookahead == 'b') ADVANCE(16);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(15);
-      if (lookahead == 'O' ||
-          lookahead == 'o') ADVANCE(21);
-      if (lookahead == 'X' ||
-          lookahead == 'x') ADVANCE(24);
-      END_STATE();
-    case 54:
-      ACCEPT_TOKEN(sym_number);
-      if (lookahead == '.') ADVANCE(56);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(15);
-      END_STATE();
-    case 55:
-      ACCEPT_TOKEN(sym_number);
-      if (lookahead == '.') ADVANCE(56);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(15);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(55);
+          lookahead != '\\') ADVANCE(55);
       END_STATE();
     case 56:
-      ACCEPT_TOKEN(sym_number);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(15);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(56);
+      ACCEPT_TOKEN(sym_escape_sequence);
       END_STATE();
     case 57:
       ACCEPT_TOKEN(sym_number);
-      if (lookahead == '0' ||
-          lookahead == '1') ADVANCE(57);
+      if (lookahead == '.') ADVANCE(60);
+      if (lookahead == 'B' ||
+          lookahead == 'b') ADVANCE(19);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(18);
+      if (lookahead == 'O' ||
+          lookahead == 'o') ADVANCE(21);
+      if (lookahead == 'X' ||
+          lookahead == 'x') ADVANCE(25);
       END_STATE();
     case 58:
       ACCEPT_TOKEN(sym_number);
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(58);
+      if (lookahead == '.') ADVANCE(60);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(18);
       END_STATE();
     case 59:
       ACCEPT_TOKEN(sym_number);
+      if (lookahead == '.') ADVANCE(60);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(18);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(59);
       END_STATE();
     case 60:
       ACCEPT_TOKEN(sym_number);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(60);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(18);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(60);
       END_STATE();
     case 61:
-      ACCEPT_TOKEN(sym_true);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(154);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(145);
+      ACCEPT_TOKEN(sym_number);
+      if (lookahead == '0' ||
+          lookahead == '1') ADVANCE(61);
       END_STATE();
     case 62:
+      ACCEPT_TOKEN(sym_number);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(62);
+      END_STATE();
+    case 63:
+      ACCEPT_TOKEN(sym_number);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(63);
+      END_STATE();
+    case 64:
+      ACCEPT_TOKEN(sym_number);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(64);
+      END_STATE();
+    case 65:
+      ACCEPT_TOKEN(sym_true);
+      if (lookahead == '.' ||
+          lookahead == '/' ||
+          lookahead == '_') ADVANCE(158);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
+      END_STATE();
+    case 66:
       ACCEPT_TOKEN(sym_true);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
-      END_STATE();
-    case 63:
-      ACCEPT_TOKEN(sym_false);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(154);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(145);
-      END_STATE();
-    case 64:
-      ACCEPT_TOKEN(sym_false);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
-      END_STATE();
-    case 65:
-      ACCEPT_TOKEN(sym_null);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(154);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(145);
-      END_STATE();
-    case 66:
-      ACCEPT_TOKEN(sym_null);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 67:
+      ACCEPT_TOKEN(sym_false);
+      if (lookahead == '.' ||
+          lookahead == '/' ||
+          lookahead == '_') ADVANCE(158);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
+      END_STATE();
+    case 68:
+      ACCEPT_TOKEN(sym_false);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      END_STATE();
+    case 69:
+      ACCEPT_TOKEN(sym_null);
+      if (lookahead == '.' ||
+          lookahead == '/' ||
+          lookahead == '_') ADVANCE(158);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
+      END_STATE();
+    case 70:
+      ACCEPT_TOKEN(sym_null);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
+      END_STATE();
+    case 71:
       ACCEPT_TOKEN(sym_method);
       if (lookahead == '.' ||
           lookahead == '/' ||
-          lookahead == '_') ADVANCE(154);
+          lookahead == '_') ADVANCE(158);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(145);
-      END_STATE();
-    case 68:
-      ACCEPT_TOKEN(sym_method);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
-      END_STATE();
-    case 69:
-      ACCEPT_TOKEN(sym_method);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(147);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(149);
-      END_STATE();
-    case 70:
-      ACCEPT_TOKEN(sym_url);
-      if (lookahead == ',') ADVANCE(75);
-      if (lookahead == '.') ADVANCE(6);
-      if (lookahead == ':') ADVANCE(73);
-      if (lookahead == 'w') ADVANCE(71);
-      if (lookahead == '#' ||
-          lookahead == '%' ||
-          lookahead == '&' ||
-          ('+' <= lookahead && lookahead <= ';') ||
-          lookahead == '=' ||
-          ('?' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '^' ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == '~') ADVANCE(75);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ') ADVANCE(75);
-      END_STATE();
-    case 71:
-      ACCEPT_TOKEN(sym_url);
-      if (lookahead == ',') ADVANCE(75);
-      if (lookahead == '.') ADVANCE(6);
-      if (lookahead == ':') ADVANCE(73);
-      if (lookahead == 'w') ADVANCE(72);
-      if (lookahead == '#' ||
-          lookahead == '%' ||
-          lookahead == '&' ||
-          ('+' <= lookahead && lookahead <= ';') ||
-          lookahead == '=' ||
-          ('?' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '^' ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == '~') ADVANCE(75);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ') ADVANCE(75);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
       END_STATE();
     case 72:
-      ACCEPT_TOKEN(sym_url);
-      if (lookahead == ',') ADVANCE(75);
-      if (lookahead == '.') ADVANCE(6);
-      if (lookahead == ':') ADVANCE(73);
-      if (lookahead == '#' ||
-          lookahead == '%' ||
-          lookahead == '&' ||
-          ('+' <= lookahead && lookahead <= ';') ||
-          lookahead == '=' ||
-          ('?' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '^' ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == '~') ADVANCE(75);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ') ADVANCE(75);
+      ACCEPT_TOKEN(sym_method);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 73:
-      ACCEPT_TOKEN(sym_url);
-      if (lookahead == ',') ADVANCE(75);
-      if (lookahead == '.') ADVANCE(18);
-      if (lookahead == ':') ADVANCE(73);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(73);
-      if (lookahead == '#' ||
-          lookahead == '%' ||
-          lookahead == '&' ||
-          ('+' <= lookahead && lookahead <= ';') ||
-          lookahead == '=' ||
-          ('?' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '^' ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == '~') ADVANCE(75);
+      ACCEPT_TOKEN(sym_method);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
       if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n' &&
-          lookahead != '\r' &&
-          lookahead != ' ') ADVANCE(75);
+          lookahead != '\n') ADVANCE(153);
       END_STATE();
     case 74:
       ACCEPT_TOKEN(sym_url);
-      if (lookahead == ',') ADVANCE(75);
-      if (lookahead == '.') ADVANCE(18);
-      if (lookahead == ':') ADVANCE(73);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(74);
-      if (lookahead == '#' ||
-          lookahead == '%' ||
-          lookahead == '&' ||
-          ('+' <= lookahead && lookahead <= ';') ||
-          lookahead == '=' ||
-          ('?' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '^' ||
-          lookahead == '_' ||
-          lookahead == '~') ADVANCE(75);
+      if (lookahead == '.') ADVANCE(6);
+      if (lookahead == ':') ADVANCE(77);
+      if (lookahead == 'w') ADVANCE(75);
+      if (sym_url_character_set_5(lookahead)) ADVANCE(79);
+      if (('$' <= lookahead && lookahead <= '{') ||
+          lookahead == '}' ||
+          (192 <= lookahead && lookahead <= 255)) ADVANCE(79);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '\r' &&
-          lookahead != ' ') ADVANCE(75);
+          lookahead != ' ') ADVANCE(79);
       END_STATE();
     case 75:
       ACCEPT_TOKEN(sym_url);
-      if (lookahead == ',') ADVANCE(75);
-      if (lookahead == '.') ADVANCE(18);
-      if (lookahead == ':') ADVANCE(73);
-      if (lookahead == '#' ||
-          lookahead == '%' ||
-          lookahead == '&' ||
-          ('+' <= lookahead && lookahead <= ';') ||
-          lookahead == '=' ||
-          ('?' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '^' ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == '~') ADVANCE(75);
+      if (lookahead == '.') ADVANCE(6);
+      if (lookahead == ':') ADVANCE(77);
+      if (lookahead == 'w') ADVANCE(76);
+      if (sym_url_character_set_5(lookahead)) ADVANCE(79);
+      if (('$' <= lookahead && lookahead <= '{') ||
+          lookahead == '}' ||
+          (192 <= lookahead && lookahead <= 255)) ADVANCE(79);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '\r' &&
-          lookahead != ' ') ADVANCE(75);
+          lookahead != ' ') ADVANCE(79);
       END_STATE();
     case 76:
       ACCEPT_TOKEN(sym_url);
-      if (lookahead == ',') ADVANCE(19);
-      if (lookahead == '.') ADVANCE(18);
-      if (lookahead == ':') ADVANCE(17);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(76);
-      if (lookahead == '#' ||
-          lookahead == '%' ||
-          lookahead == '&' ||
-          ('+' <= lookahead && lookahead <= ';') ||
-          lookahead == '=' ||
-          ('?' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '^' ||
-          lookahead == '_' ||
-          lookahead == '~') ADVANCE(78);
+      if (lookahead == '.') ADVANCE(6);
+      if (lookahead == ':') ADVANCE(77);
+      if (sym_url_character_set_5(lookahead)) ADVANCE(79);
+      if (('$' <= lookahead && lookahead <= '{') ||
+          lookahead == '}' ||
+          (192 <= lookahead && lookahead <= 255)) ADVANCE(79);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ' ') ADVANCE(79);
       END_STATE();
     case 77:
       ACCEPT_TOKEN(sym_url);
-      if (lookahead == ',' ||
-          lookahead == '.' ||
-          lookahead == ':') ADVANCE(19);
+      if (lookahead == '.') ADVANCE(26);
+      if (lookahead == ':') ADVANCE(77);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(77);
-      if (lookahead == '#' ||
-          lookahead == '%' ||
-          lookahead == '&' ||
-          ('+' <= lookahead && lookahead <= ';') ||
-          lookahead == '=' ||
-          ('?' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '^' ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == '~') ADVANCE(78);
+      if (sym_url_character_set_5(lookahead)) ADVANCE(79);
+      if (('$' <= lookahead && lookahead <= '{') ||
+          lookahead == '}' ||
+          (192 <= lookahead && lookahead <= 255)) ADVANCE(79);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ' ') ADVANCE(79);
       END_STATE();
     case 78:
       ACCEPT_TOKEN(sym_url);
-      if (lookahead == ',' ||
-          lookahead == '.' ||
-          lookahead == ':') ADVANCE(19);
+      if (lookahead == '.') ADVANCE(26);
+      if (lookahead == ':') ADVANCE(77);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(78);
       if (lookahead == '#' ||
           lookahead == '%' ||
           lookahead == '&' ||
-          ('+' <= lookahead && lookahead <= ';') ||
+          lookahead == '+' ||
+          ('-' <= lookahead && lookahead <= ';') ||
           lookahead == '=' ||
           ('?' <= lookahead && lookahead <= 'Z') ||
           lookahead == '^' ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == '~') ADVANCE(78);
+          lookahead == '~') ADVANCE(79);
+      if (('$' <= lookahead && lookahead <= '{') ||
+          lookahead == '}' ||
+          (192 <= lookahead && lookahead <= 255)) ADVANCE(79);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ' ') ADVANCE(79);
       END_STATE();
     case 79:
+      ACCEPT_TOKEN(sym_url);
+      if (lookahead == '.') ADVANCE(26);
+      if (lookahead == ':') ADVANCE(77);
+      if (sym_url_character_set_5(lookahead)) ADVANCE(79);
+      if (('$' <= lookahead && lookahead <= '{') ||
+          lookahead == '}' ||
+          (192 <= lookahead && lookahead <= 255)) ADVANCE(79);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ' ') ADVANCE(79);
+      END_STATE();
+    case 80:
+      ACCEPT_TOKEN(sym_url);
+      if (lookahead == '.') ADVANCE(26);
+      if (lookahead == ':') ADVANCE(24);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(80);
+      if (lookahead == '#' ||
+          lookahead == '%' ||
+          lookahead == '&' ||
+          lookahead == '+' ||
+          ('-' <= lookahead && lookahead <= ';') ||
+          lookahead == '=' ||
+          ('?' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '^' ||
+          lookahead == '_' ||
+          lookahead == '~') ADVANCE(82);
+      if (('$' <= lookahead && lookahead <= '{') ||
+          lookahead == '}' ||
+          (192 <= lookahead && lookahead <= 255)) ADVANCE(28);
+      END_STATE();
+    case 81:
+      ACCEPT_TOKEN(sym_url);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(81);
+      if (sym_url_character_set_2(lookahead)) ADVANCE(82);
+      if (('$' <= lookahead && lookahead <= '{') ||
+          lookahead == '}' ||
+          (192 <= lookahead && lookahead <= 255)) ADVANCE(28);
+      END_STATE();
+    case 82:
+      ACCEPT_TOKEN(sym_url);
+      if (sym_url_character_set_4(lookahead)) ADVANCE(82);
+      if (('$' <= lookahead && lookahead <= '{') ||
+          lookahead == '}' ||
+          (192 <= lookahead && lookahead <= 255)) ADVANCE(28);
+      END_STATE();
+    case 83:
       ACCEPT_TOKEN(sym_name);
       if (lookahead == '/') ADVANCE(8);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
-      END_STATE();
-    case 80:
-      ACCEPT_TOKEN(sym_name);
-      if (lookahead == '0') ADVANCE(54);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(154);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(55);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(145);
-      END_STATE();
-    case 81:
-      ACCEPT_TOKEN(sym_name);
-      if (lookahead == '0') ADVANCE(54);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(55);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
-      END_STATE();
-    case 82:
-      ACCEPT_TOKEN(sym_name);
-      if (lookahead == ':') ADVANCE(7);
-      if (lookahead == 's') ADVANCE(83);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
-      END_STATE();
-    case 83:
-      ACCEPT_TOKEN(sym_name);
-      if (lookahead == ':') ADVANCE(7);
-      if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 84:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'A') ADVANCE(112);
-      if (lookahead == 'O') ADVANCE(108);
-      if (lookahead == 'U') ADVANCE(111);
+      if (lookahead == '0') ADVANCE(58);
       if (lookahead == '.' ||
           lookahead == '/' ||
-          lookahead == '_') ADVANCE(154);
+          lookahead == '_') ADVANCE(158);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(59);
       if (lookahead == '-' ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(145);
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
       END_STATE();
     case 85:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'A') ADVANCE(114);
-      if (lookahead == 'O') ADVANCE(109);
-      if (lookahead == 'U') ADVANCE(113);
+      if (lookahead == '0') ADVANCE(58);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(59);
       if (lookahead == '-' ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 86:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'A') ADVANCE(116);
-      if (lookahead == 'O') ADVANCE(110);
-      if (lookahead == 'U') ADVANCE(115);
+      if (lookahead == ':') ADVANCE(7);
+      if (lookahead == 's') ADVANCE(87);
       if (lookahead == '-' ||
-          ('B' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(147);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(149);
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 87:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'C') ADVANCE(102);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(154);
+      if (lookahead == ':') ADVANCE(7);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(145);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 88:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'C') ADVANCE(103);
+      if (lookahead == 'A') ADVANCE(116);
+      if (lookahead == 'O') ADVANCE(112);
+      if (lookahead == 'U') ADVANCE(115);
+      if (lookahead == '.' ||
+          lookahead == '/' ||
+          lookahead == '_') ADVANCE(158);
       if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
       END_STATE();
     case 89:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'C') ADVANCE(104);
+      if (lookahead == 'A') ADVANCE(118);
+      if (lookahead == 'O') ADVANCE(113);
+      if (lookahead == 'U') ADVANCE(117);
       if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(147);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(149);
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 90:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'E') ADVANCE(105);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(154);
+      if (lookahead == 'A') ADVANCE(120);
+      if (lookahead == 'O') ADVANCE(114);
+      if (lookahead == 'U') ADVANCE(119);
       if (lookahead == '-' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(145);
+          ('B' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(153);
       END_STATE();
     case 91:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'E') ADVANCE(111);
+      if (lookahead == 'C') ADVANCE(106);
       if (lookahead == '.' ||
           lookahead == '/' ||
-          lookahead == '_') ADVANCE(154);
+          lookahead == '_') ADVANCE(158);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(145);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
       END_STATE();
     case 92:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'E') ADVANCE(67);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(154);
+      if (lookahead == 'C') ADVANCE(107);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(145);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 93:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'E') ADVANCE(106);
+      if (lookahead == 'C') ADVANCE(108);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(153);
       END_STATE();
     case 94:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'E') ADVANCE(113);
+      if (lookahead == 'E') ADVANCE(109);
+      if (lookahead == '.' ||
+          lookahead == '/' ||
+          lookahead == '_') ADVANCE(158);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
       END_STATE();
     case 95:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'E') ADVANCE(68);
+      if (lookahead == 'E') ADVANCE(115);
+      if (lookahead == '.' ||
+          lookahead == '/' ||
+          lookahead == '_') ADVANCE(158);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
       END_STATE();
     case 96:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'E') ADVANCE(107);
+      if (lookahead == 'E') ADVANCE(71);
+      if (lookahead == '.' ||
+          lookahead == '/' ||
+          lookahead == '_') ADVANCE(158);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(147);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(149);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
       END_STATE();
     case 97:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'E') ADVANCE(115);
+      if (lookahead == 'E') ADVANCE(110);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(147);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(149);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 98:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'E') ADVANCE(69);
+      if (lookahead == 'E') ADVANCE(117);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(147);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(149);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 99:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'E') ADVANCE(117);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(154);
+      if (lookahead == 'E') ADVANCE(72);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(145);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 100:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'E') ADVANCE(118);
+      if (lookahead == 'E') ADVANCE(111);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(153);
       END_STATE();
     case 101:
       ACCEPT_TOKEN(sym_name);
       if (lookahead == 'E') ADVANCE(119);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(147);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(149);
+          lookahead != '\n') ADVANCE(153);
       END_STATE();
     case 102:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'H') ADVANCE(67);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(154);
+      if (lookahead == 'E') ADVANCE(73);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(145);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(153);
       END_STATE();
     case 103:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'H') ADVANCE(68);
+      if (lookahead == 'E') ADVANCE(121);
+      if (lookahead == '.' ||
+          lookahead == '/' ||
+          lookahead == '_') ADVANCE(158);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
       END_STATE();
     case 104:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'H') ADVANCE(69);
+      if (lookahead == 'E') ADVANCE(122);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(147);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(149);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 105:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'L') ADVANCE(99);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(154);
+      if (lookahead == 'E') ADVANCE(123);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(145);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(153);
       END_STATE();
     case 106:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'L') ADVANCE(100);
+      if (lookahead == 'H') ADVANCE(71);
+      if (lookahead == '.' ||
+          lookahead == '/' ||
+          lookahead == '_') ADVANCE(158);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
       END_STATE();
     case 107:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'L') ADVANCE(101);
+      if (lookahead == 'H') ADVANCE(72);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(147);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(149);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 108:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'S') ADVANCE(111);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(154);
+      if (lookahead == 'H') ADVANCE(73);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(145);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(153);
       END_STATE();
     case 109:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'S') ADVANCE(113);
+      if (lookahead == 'L') ADVANCE(103);
+      if (lookahead == '.' ||
+          lookahead == '/' ||
+          lookahead == '_') ADVANCE(158);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
       END_STATE();
     case 110:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'S') ADVANCE(115);
+      if (lookahead == 'L') ADVANCE(104);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(147);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(149);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 111:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'T') ADVANCE(67);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(154);
+      if (lookahead == 'L') ADVANCE(105);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(145);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(153);
       END_STATE();
     case 112:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'T') ADVANCE(87);
+      if (lookahead == 'S') ADVANCE(115);
       if (lookahead == '.' ||
           lookahead == '/' ||
-          lookahead == '_') ADVANCE(154);
+          lookahead == '_') ADVANCE(158);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(145);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
       END_STATE();
     case 113:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'T') ADVANCE(68);
+      if (lookahead == 'S') ADVANCE(117);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 114:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'T') ADVANCE(88);
+      if (lookahead == 'S') ADVANCE(119);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(153);
       END_STATE();
     case 115:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'T') ADVANCE(69);
+      if (lookahead == 'T') ADVANCE(71);
+      if (lookahead == '.' ||
+          lookahead == '/' ||
+          lookahead == '_') ADVANCE(158);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(147);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(149);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
       END_STATE();
     case 116:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'T') ADVANCE(89);
+      if (lookahead == 'T') ADVANCE(91);
+      if (lookahead == '.' ||
+          lookahead == '/' ||
+          lookahead == '_') ADVANCE(158);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(147);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(149);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
       END_STATE();
     case 117:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'T') ADVANCE(92);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(154);
+      if (lookahead == 'T') ADVANCE(72);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(145);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 118:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'T') ADVANCE(95);
+      if (lookahead == 'T') ADVANCE(92);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 119:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'T') ADVANCE(98);
+      if (lookahead == 'T') ADVANCE(73);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(147);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(149);
+          lookahead != '\n') ADVANCE(153);
       END_STATE();
     case 120:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'a') ADVANCE(126);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(154);
+      if (lookahead == 'T') ADVANCE(93);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(145);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(153);
       END_STATE();
     case 121:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'a') ADVANCE(128);
+      if (lookahead == 'T') ADVANCE(96);
+      if (lookahead == '.' ||
+          lookahead == '/' ||
+          lookahead == '_') ADVANCE(158);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(146);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
       END_STATE();
     case 122:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'e') ADVANCE(61);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(154);
+      if (lookahead == 'T') ADVANCE(99);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(145);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 123:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'e') ADVANCE(63);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(154);
+      if (lookahead == 'T') ADVANCE(102);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(145);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(153);
       END_STATE();
     case 124:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'e') ADVANCE(62);
+      if (lookahead == 'a') ADVANCE(130);
+      if (lookahead == '.' ||
+          lookahead == '/' ||
+          lookahead == '_') ADVANCE(158);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(149);
       END_STATE();
     case 125:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'e') ADVANCE(64);
+      if (lookahead == 'a') ADVANCE(132);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 126:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'l') ADVANCE(135);
+      if (lookahead == 'e') ADVANCE(65);
       if (lookahead == '.' ||
           lookahead == '/' ||
-          lookahead == '_') ADVANCE(154);
+          lookahead == '_') ADVANCE(158);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(145);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
       END_STATE();
     case 127:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'l') ADVANCE(65);
+      if (lookahead == 'e') ADVANCE(67);
       if (lookahead == '.' ||
           lookahead == '/' ||
-          lookahead == '_') ADVANCE(154);
+          lookahead == '_') ADVANCE(158);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(145);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
       END_STATE();
     case 128:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'l') ADVANCE(136);
+      if (lookahead == 'e') ADVANCE(66);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 129:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'l') ADVANCE(66);
+      if (lookahead == 'e') ADVANCE(68);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 130:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'l') ADVANCE(127);
+      if (lookahead == 'l') ADVANCE(139);
       if (lookahead == '.' ||
           lookahead == '/' ||
-          lookahead == '_') ADVANCE(154);
+          lookahead == '_') ADVANCE(158);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(145);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
       END_STATE();
     case 131:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'l') ADVANCE(129);
+      if (lookahead == 'l') ADVANCE(69);
+      if (lookahead == '.' ||
+          lookahead == '/' ||
+          lookahead == '_') ADVANCE(158);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
       END_STATE();
     case 132:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'p') ADVANCE(82);
+      if (lookahead == 'l') ADVANCE(140);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 133:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'r') ADVANCE(139);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(154);
+      if (lookahead == 'l') ADVANCE(70);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(145);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 134:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'r') ADVANCE(140);
+      if (lookahead == 'l') ADVANCE(131);
+      if (lookahead == '.' ||
+          lookahead == '/' ||
+          lookahead == '_') ADVANCE(158);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
       END_STATE();
     case 135:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 's') ADVANCE(123);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(154);
+      if (lookahead == 'l') ADVANCE(133);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(145);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 136:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 's') ADVANCE(125);
+      if (lookahead == 'p') ADVANCE(86);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 137:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 't') ADVANCE(132);
+      if (lookahead == 'r') ADVANCE(143);
+      if (lookahead == '.' ||
+          lookahead == '/' ||
+          lookahead == '_') ADVANCE(158);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
       END_STATE();
     case 138:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 't') ADVANCE(137);
+      if (lookahead == 'r') ADVANCE(144);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 139:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'u') ADVANCE(122);
+      if (lookahead == 's') ADVANCE(127);
       if (lookahead == '.' ||
           lookahead == '/' ||
-          lookahead == '_') ADVANCE(154);
+          lookahead == '_') ADVANCE(158);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(145);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
       END_STATE();
     case 140:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'u') ADVANCE(124);
+      if (lookahead == 's') ADVANCE(129);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 141:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'u') ADVANCE(130);
-      if (lookahead == '.' ||
-          lookahead == '/' ||
-          lookahead == '_') ADVANCE(154);
+      if (lookahead == 't') ADVANCE(136);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(145);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 142:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'u') ADVANCE(131);
+      if (lookahead == 't') ADVANCE(141);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 143:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'w') ADVANCE(79);
+      if (lookahead == 'u') ADVANCE(126);
+      if (lookahead == '.' ||
+          lookahead == '/' ||
+          lookahead == '_') ADVANCE(158);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
       END_STATE();
     case 144:
       ACCEPT_TOKEN(sym_name);
-      if (lookahead == 'w') ADVANCE(143);
+      if (lookahead == 'u') ADVANCE(128);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 145:
       ACCEPT_TOKEN(sym_name);
+      if (lookahead == 'u') ADVANCE(134);
       if (lookahead == '.' ||
           lookahead == '/' ||
-          lookahead == '_') ADVANCE(154);
+          lookahead == '_') ADVANCE(158);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(145);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
       END_STATE();
     case 146:
       ACCEPT_TOKEN(sym_name);
+      if (lookahead == 'u') ADVANCE(135);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 147:
       ACCEPT_TOKEN(sym_name);
+      if (lookahead == 'w') ADVANCE(83);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(147);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(149);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 148:
-      ACCEPT_TOKEN(sym_value);
-      if (lookahead == 11) ADVANCE(149);
-      if (lookahead == '\r') ADVANCE(148);
-      if (lookahead == '#') ADVANCE(149);
-      if (lookahead == '<') ADVANCE(159);
-      if (lookahead == 'D') ADVANCE(96);
-      if (lookahead == 'G') ADVANCE(97);
-      if (lookahead == 'P') ADVANCE(86);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(148);
+      ACCEPT_TOKEN(sym_name);
+      if (lookahead == 'w') ADVANCE(147);
       if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(147);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(149);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 149:
-      ACCEPT_TOKEN(sym_value);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(149);
+      ACCEPT_TOKEN(sym_name);
+      if (lookahead == '.' ||
+          lookahead == '/' ||
+          lookahead == '_') ADVANCE(158);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(149);
       END_STATE();
     case 150:
-      ACCEPT_TOKEN(aux_sym_json_file_token1);
-      if (lookahead == 'j') ADVANCE(153);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(56);
-      if (('-' <= lookahead && lookahead <= '/') ||
+      ACCEPT_TOKEN(sym_name);
+      if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(154);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 151:
-      ACCEPT_TOKEN(aux_sym_json_file_token1);
-      if (lookahead == 'n') ADVANCE(156);
-      if (('-' <= lookahead && lookahead <= '/') ||
+      ACCEPT_TOKEN(sym_name);
+      if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(154);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(153);
       END_STATE();
     case 152:
-      ACCEPT_TOKEN(aux_sym_json_file_token1);
-      if (lookahead == 'o') ADVANCE(151);
-      if (('-' <= lookahead && lookahead <= '/') ||
+      ACCEPT_TOKEN(sym_value);
+      if (lookahead == 11) ADVANCE(153);
+      if (lookahead == '\r') ADVANCE(152);
+      if (lookahead == '#') ADVANCE(153);
+      if (lookahead == '<') ADVANCE(163);
+      if (lookahead == 'D') ADVANCE(100);
+      if (lookahead == 'G') ADVANCE(101);
+      if (lookahead == 'P') ADVANCE(90);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(152);
+      if (lookahead == '-' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(154);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(151);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(153);
       END_STATE();
     case 153:
-      ACCEPT_TOKEN(aux_sym_json_file_token1);
-      if (lookahead == 's') ADVANCE(152);
-      if (('-' <= lookahead && lookahead <= '/') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(154);
+      ACCEPT_TOKEN(sym_value);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(153);
       END_STATE();
     case 154:
       ACCEPT_TOKEN(aux_sym_json_file_token1);
+      if (lookahead == 'j') ADVANCE(157);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(60);
       if (('-' <= lookahead && lookahead <= '/') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(154);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(158);
       END_STATE();
     case 155:
-      ACCEPT_TOKEN(anon_sym_DOTjson);
+      ACCEPT_TOKEN(aux_sym_json_file_token1);
+      if (lookahead == 'n') ADVANCE(160);
+      if (('-' <= lookahead && lookahead <= '/') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(158);
       END_STATE();
     case 156:
+      ACCEPT_TOKEN(aux_sym_json_file_token1);
+      if (lookahead == 'o') ADVANCE(155);
+      if (('-' <= lookahead && lookahead <= '/') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(158);
+      END_STATE();
+    case 157:
+      ACCEPT_TOKEN(aux_sym_json_file_token1);
+      if (lookahead == 's') ADVANCE(156);
+      if (('-' <= lookahead && lookahead <= '/') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(158);
+      END_STATE();
+    case 158:
+      ACCEPT_TOKEN(aux_sym_json_file_token1);
+      if (('-' <= lookahead && lookahead <= '/') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(158);
+      END_STATE();
+    case 159:
+      ACCEPT_TOKEN(anon_sym_DOTjson);
+      END_STATE();
+    case 160:
       ACCEPT_TOKEN(anon_sym_DOTjson);
       if (('-' <= lookahead && lookahead <= '/') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(154);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(158);
       END_STATE();
-    case 157:
+    case 161:
       ACCEPT_TOKEN(anon_sym_LT);
       END_STATE();
-    case 158:
+    case 162:
       ACCEPT_TOKEN(anon_sym_LT);
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != '"' &&
-          lookahead != '\\') ADVANCE(51);
+          lookahead != '\\') ADVANCE(55);
       END_STATE();
-    case 159:
+    case 163:
       ACCEPT_TOKEN(anon_sym_LT);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(149);
+          lookahead != '\n') ADVANCE(153);
       END_STATE();
-    case 160:
+    case 164:
       ACCEPT_TOKEN(sym_comment);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(160);
+          lookahead != '\n') ADVANCE(164);
       END_STATE();
-    case 161:
+    case 165:
       ACCEPT_TOKEN(aux_sym__whitespace_token1);
       END_STATE();
-    case 162:
+    case 166:
       ACCEPT_TOKEN(aux_sym__whitespace_token1);
-      if (lookahead == 11) ADVANCE(161);
+      if (lookahead == 11) ADVANCE(165);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(162);
+          lookahead == ' ') ADVANCE(166);
       END_STATE();
     default:
       return false;
@@ -1868,52 +1888,52 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 27},
-  [2] = {.lex_state = 27},
-  [3] = {.lex_state = 27},
-  [4] = {.lex_state = 27},
-  [5] = {.lex_state = 26},
-  [6] = {.lex_state = 26},
+  [1] = {.lex_state = 31},
+  [2] = {.lex_state = 31},
+  [3] = {.lex_state = 31},
+  [4] = {.lex_state = 31},
+  [5] = {.lex_state = 30},
+  [6] = {.lex_state = 30},
   [7] = {.lex_state = 1},
-  [8] = {.lex_state = 26},
-  [9] = {.lex_state = 26},
-  [10] = {.lex_state = 26},
+  [8] = {.lex_state = 30},
+  [9] = {.lex_state = 30},
+  [10] = {.lex_state = 30},
   [11] = {.lex_state = 1},
-  [12] = {.lex_state = 26},
-  [13] = {.lex_state = 26},
-  [14] = {.lex_state = 26},
-  [15] = {.lex_state = 26},
+  [12] = {.lex_state = 30},
+  [13] = {.lex_state = 30},
+  [14] = {.lex_state = 30},
+  [15] = {.lex_state = 30},
   [16] = {.lex_state = 3},
-  [17] = {.lex_state = 26},
-  [18] = {.lex_state = 26},
+  [17] = {.lex_state = 30},
+  [18] = {.lex_state = 30},
   [19] = {.lex_state = 1},
   [20] = {.lex_state = 4},
-  [21] = {.lex_state = 26},
+  [21] = {.lex_state = 30},
   [22] = {.lex_state = 1},
   [23] = {.lex_state = 2},
   [24] = {.lex_state = 3},
-  [25] = {.lex_state = 26},
+  [25] = {.lex_state = 30},
   [26] = {.lex_state = 2},
-  [27] = {.lex_state = 26},
-  [28] = {.lex_state = 26},
-  [29] = {.lex_state = 26},
+  [27] = {.lex_state = 30},
+  [28] = {.lex_state = 30},
+  [29] = {.lex_state = 30},
   [30] = {.lex_state = 4},
-  [31] = {.lex_state = 26},
+  [31] = {.lex_state = 30},
   [32] = {.lex_state = 3},
   [33] = {.lex_state = 3},
   [34] = {.lex_state = 4},
-  [35] = {.lex_state = 26},
-  [36] = {.lex_state = 26},
-  [37] = {.lex_state = 26},
+  [35] = {.lex_state = 30},
+  [36] = {.lex_state = 30},
+  [37] = {.lex_state = 30},
   [38] = {.lex_state = 3},
   [39] = {.lex_state = 3},
   [40] = {.lex_state = 2},
-  [41] = {.lex_state = 26},
-  [42] = {.lex_state = 26},
-  [43] = {.lex_state = 26},
-  [44] = {.lex_state = 26},
-  [45] = {.lex_state = 26},
-  [46] = {.lex_state = 26},
+  [41] = {.lex_state = 30},
+  [42] = {.lex_state = 30},
+  [43] = {.lex_state = 30},
+  [44] = {.lex_state = 30},
+  [45] = {.lex_state = 30},
+  [46] = {.lex_state = 30},
   [47] = {(TSStateId)(-1)},
   [48] = {(TSStateId)(-1)},
   [49] = {(TSStateId)(-1)},

--- a/src/parser.c
+++ b/src/parser.c
@@ -344,83 +344,17 @@ static const uint16_t ts_non_terminal_alias_map[] = {
 };
 
 static inline bool sym_url_character_set_1(int32_t c) {
-  return (c < ';'
+  return (c < '?'
     ? (c < '+'
       ? (c < '%'
         ? c == '#'
         : c <= '&')
-      : (c <= '+' || (c >= '-' && c <= '9')))
-    : (c <= ';' || (c < '^'
-      ? (c < '?'
-        ? c == '='
-        : c <= 'Z')
-      : (c <= '_' || c == '~'))));
-}
-
-static inline bool sym_url_character_set_2(int32_t c) {
-  return (c < ';'
-    ? (c < '+'
-      ? (c < '%'
-        ? c == '#'
-        : c <= '&')
-      : (c <= '+' || (c < '/'
-        ? c == '-'
-        : c <= '/')))
-    : (c <= ';' || (c < '^'
-      ? (c < '?'
-        ? c == '='
-        : c <= 'Z')
-      : (c <= '_' || (c < '~'
-        ? (c >= 'a' && c <= 'z')
-        : c <= '~')))));
-}
-
-static inline bool sym_url_character_set_3(int32_t c) {
-  return (c < ';'
-    ? (c < '+'
-      ? (c < '%'
-        ? c == '#'
-        : c <= '&')
-      : (c <= '+' || (c < '/'
-        ? c == '-'
-        : c <= '9')))
-    : (c <= ';' || (c < '^'
-      ? (c < '?'
-        ? c == '='
-        : c <= 'Z')
-      : (c <= '_' || c == '~'))));
-}
-
-static inline bool sym_url_character_set_4(int32_t c) {
-  return (c < ';'
-    ? (c < '+'
-      ? (c < '%'
-        ? c == '#'
-        : c <= '&')
-      : (c <= '+' || (c < '/'
-        ? c == '-'
-        : c <= '9')))
-    : (c <= ';' || (c < '^'
-      ? (c < '?'
-        ? c == '='
-        : c <= 'Z')
-      : (c <= '_' || (c < '~'
-        ? (c >= 'a' && c <= 'z')
-        : c <= '~')))));
-}
-
-static inline bool sym_url_character_set_5(int32_t c) {
-  return (c < '='
-    ? (c < '+'
-      ? (c < '%'
-        ? c == '#'
-        : c <= '&')
-      : (c <= '+' || (c >= '-' && c <= ';')))
-    : (c <= '=' || (c < 'a'
-      ? (c < '^'
-        ? (c >= '?' && c <= 'Z')
-        : c <= '_')
-      : (c <= 'z' || c == '~'))));
+      : (c <= ';' || c == '='))
+    : (c <= 'Z' || (c < '~'
+      ? (c < 'a'
+        ? (c >= '^' && c <= '_')
+        : c <= 'z')
+      : (c <= '~' || (c >= 192 && c <= 255)))));
 }
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
@@ -442,7 +376,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == 'G') ADVANCE(95);
       if (lookahead == 'P') ADVANCE(88);
       if (lookahead == '[') ADVANCE(37);
-      if (lookahead == '\\') ADVANCE(20);
+      if (lookahead == '\\') ADVANCE(23);
       if (lookahead == ']') ADVANCE(38);
       if (lookahead == 'f') ADVANCE(124);
       if (lookahead == 'n') ADVANCE(145);
@@ -467,7 +401,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == 'D') ADVANCE(44);
       if (lookahead == 'G') ADVANCE(45);
       if (lookahead == 'P') ADVANCE(41);
-      if (lookahead == '\\') ADVANCE(20);
+      if (lookahead == '\\') ADVANCE(23);
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(40);
@@ -544,11 +478,21 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(150);
       END_STATE();
     case 6:
-      if (lookahead == '.') ADVANCE(28);
+      if (lookahead == '.') ADVANCE(22);
+      if (lookahead == ',' ||
+          lookahead == ':' ||
+          lookahead == '{' ||
+          lookahead == '}') ADVANCE(79);
       if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(78);
-      if (sym_url_character_set_1(lookahead)) ADVANCE(79);
-      if (('$' <= lookahead && lookahead <= '{') ||
-          lookahead == '}' ||
+      if (lookahead == '#' ||
+          lookahead == '%' ||
+          lookahead == '&' ||
+          ('+' <= lookahead && lookahead <= ';') ||
+          lookahead == '=' ||
+          ('?' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '^' ||
+          lookahead == '_' ||
+          lookahead == '~' ||
           (192 <= lookahead && lookahead <= 255)) ADVANCE(79);
       if (lookahead != 0 &&
           lookahead != '\t' &&
@@ -589,7 +533,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '.') ADVANCE(79);
       END_STATE();
     case 15:
-      if (lookahead == '{') ADVANCE(27);
+      if (lookahead == '{') ADVANCE(28);
       END_STATE();
     case 16:
       if (lookahead == '}') ADVANCE(17);
@@ -603,7 +547,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 18:
       if (lookahead == '+' ||
-          lookahead == '-') ADVANCE(23);
+          lookahead == '-') ADVANCE(26);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(63);
       END_STATE();
     case 19:
@@ -611,6 +555,41 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == '1') ADVANCE(61);
       END_STATE();
     case 20:
+      if (lookahead == ',' ||
+          lookahead == '.' ||
+          lookahead == ':' ||
+          lookahead == '{' ||
+          lookahead == '}') ADVANCE(22);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(81);
+      if (sym_url_character_set_1(lookahead)) ADVANCE(82);
+      END_STATE();
+    case 21:
+      if (lookahead == ',' ||
+          lookahead == '.' ||
+          lookahead == ':' ||
+          lookahead == '{' ||
+          lookahead == '}') ADVANCE(22);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(80);
+      if (lookahead == '#' ||
+          lookahead == '%' ||
+          lookahead == '&' ||
+          ('+' <= lookahead && lookahead <= ';') ||
+          lookahead == '=' ||
+          ('?' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '^' ||
+          lookahead == '_' ||
+          lookahead == '~' ||
+          (192 <= lookahead && lookahead <= 255)) ADVANCE(82);
+      END_STATE();
+    case 22:
+      if (lookahead == ',' ||
+          lookahead == '.' ||
+          lookahead == ':' ||
+          lookahead == '{' ||
+          lookahead == '}') ADVANCE(22);
+      if (sym_url_character_set_1(lookahead)) ADVANCE(82);
+      END_STATE();
+    case 23:
       if (lookahead == '"' ||
           lookahead == '/' ||
           lookahead == '\\' ||
@@ -620,45 +599,25 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == 't' ||
           lookahead == 'u') ADVANCE(56);
       END_STATE();
-    case 21:
+    case 24:
       if (('0' <= lookahead && lookahead <= '7')) ADVANCE(62);
       END_STATE();
-    case 22:
+    case 25:
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(60);
       END_STATE();
-    case 23:
+    case 26:
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(63);
       END_STATE();
-    case 24:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(81);
-      if (sym_url_character_set_2(lookahead)) ADVANCE(82);
-      if (('$' <= lookahead && lookahead <= '{') ||
-          lookahead == '}' ||
-          (192 <= lookahead && lookahead <= 255)) ADVANCE(28);
-      END_STATE();
-    case 25:
+    case 27:
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
           ('a' <= lookahead && lookahead <= 'f')) ADVANCE(64);
       END_STATE();
-    case 26:
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(80);
-      if (sym_url_character_set_3(lookahead)) ADVANCE(82);
-      if (('$' <= lookahead && lookahead <= '{') ||
-          lookahead == '}' ||
-          (192 <= lookahead && lookahead <= 255)) ADVANCE(28);
-      END_STATE();
-    case 27:
+    case 28:
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(16);
-      END_STATE();
-    case 28:
-      if (sym_url_character_set_4(lookahead)) ADVANCE(82);
-      if (('$' <= lookahead && lookahead <= '{') ||
-          lookahead == '}' ||
-          (192 <= lookahead && lookahead <= 255)) ADVANCE(28);
       END_STATE();
     case 29:
       if (eof) ADVANCE(32);
@@ -721,7 +680,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '#') ADVANCE(164);
       if (lookahead == '+') ADVANCE(9);
       if (lookahead == '-') ADVANCE(85);
-      if (lookahead == '.') ADVANCE(22);
+      if (lookahead == '.') ADVANCE(25);
       if (lookahead == '0') ADVANCE(57);
       if (lookahead == '<') ADVANCE(161);
       if (lookahead == 'D') ADVANCE(97);
@@ -952,9 +911,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == 'E' ||
           lookahead == 'e') ADVANCE(18);
       if (lookahead == 'O' ||
-          lookahead == 'o') ADVANCE(21);
+          lookahead == 'o') ADVANCE(24);
       if (lookahead == 'X' ||
-          lookahead == 'x') ADVANCE(25);
+          lookahead == 'x') ADVANCE(27);
       END_STATE();
     case 58:
       ACCEPT_TOKEN(sym_number);
@@ -1067,10 +1026,10 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '.') ADVANCE(6);
       if (lookahead == ':') ADVANCE(77);
       if (lookahead == 'w') ADVANCE(75);
-      if (sym_url_character_set_5(lookahead)) ADVANCE(79);
-      if (('$' <= lookahead && lookahead <= '{') ||
-          lookahead == '}' ||
-          (192 <= lookahead && lookahead <= 255)) ADVANCE(79);
+      if (lookahead == ',' ||
+          lookahead == '{' ||
+          lookahead == '}') ADVANCE(79);
+      if (sym_url_character_set_1(lookahead)) ADVANCE(79);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
@@ -1082,10 +1041,10 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '.') ADVANCE(6);
       if (lookahead == ':') ADVANCE(77);
       if (lookahead == 'w') ADVANCE(76);
-      if (sym_url_character_set_5(lookahead)) ADVANCE(79);
-      if (('$' <= lookahead && lookahead <= '{') ||
-          lookahead == '}' ||
-          (192 <= lookahead && lookahead <= 255)) ADVANCE(79);
+      if (lookahead == ',' ||
+          lookahead == '{' ||
+          lookahead == '}') ADVANCE(79);
+      if (sym_url_character_set_1(lookahead)) ADVANCE(79);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
@@ -1096,10 +1055,10 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       ACCEPT_TOKEN(sym_url);
       if (lookahead == '.') ADVANCE(6);
       if (lookahead == ':') ADVANCE(77);
-      if (sym_url_character_set_5(lookahead)) ADVANCE(79);
-      if (('$' <= lookahead && lookahead <= '{') ||
-          lookahead == '}' ||
-          (192 <= lookahead && lookahead <= 255)) ADVANCE(79);
+      if (lookahead == ',' ||
+          lookahead == '{' ||
+          lookahead == '}') ADVANCE(79);
+      if (sym_url_character_set_1(lookahead)) ADVANCE(79);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
@@ -1108,13 +1067,13 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 77:
       ACCEPT_TOKEN(sym_url);
-      if (lookahead == '.') ADVANCE(26);
+      if (lookahead == '.') ADVANCE(21);
       if (lookahead == ':') ADVANCE(77);
+      if (lookahead == ',' ||
+          lookahead == '{' ||
+          lookahead == '}') ADVANCE(79);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(77);
-      if (sym_url_character_set_5(lookahead)) ADVANCE(79);
-      if (('$' <= lookahead && lookahead <= '{') ||
-          lookahead == '}' ||
-          (192 <= lookahead && lookahead <= 255)) ADVANCE(79);
+      if (sym_url_character_set_1(lookahead)) ADVANCE(79);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
@@ -1123,21 +1082,21 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 78:
       ACCEPT_TOKEN(sym_url);
-      if (lookahead == '.') ADVANCE(26);
+      if (lookahead == '.') ADVANCE(21);
       if (lookahead == ':') ADVANCE(77);
+      if (lookahead == ',' ||
+          lookahead == '{' ||
+          lookahead == '}') ADVANCE(79);
       if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(78);
       if (lookahead == '#' ||
           lookahead == '%' ||
           lookahead == '&' ||
-          lookahead == '+' ||
-          ('-' <= lookahead && lookahead <= ';') ||
+          ('+' <= lookahead && lookahead <= ';') ||
           lookahead == '=' ||
           ('?' <= lookahead && lookahead <= 'Z') ||
           lookahead == '^' ||
           lookahead == '_' ||
-          lookahead == '~') ADVANCE(79);
-      if (('$' <= lookahead && lookahead <= '{') ||
-          lookahead == '}' ||
+          lookahead == '~' ||
           (192 <= lookahead && lookahead <= 255)) ADVANCE(79);
       if (lookahead != 0 &&
           lookahead != '\t' &&
@@ -1147,12 +1106,12 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 79:
       ACCEPT_TOKEN(sym_url);
-      if (lookahead == '.') ADVANCE(26);
+      if (lookahead == '.') ADVANCE(21);
       if (lookahead == ':') ADVANCE(77);
-      if (sym_url_character_set_5(lookahead)) ADVANCE(79);
-      if (('$' <= lookahead && lookahead <= '{') ||
-          lookahead == '}' ||
-          (192 <= lookahead && lookahead <= 255)) ADVANCE(79);
+      if (lookahead == ',' ||
+          lookahead == '{' ||
+          lookahead == '}') ADVANCE(79);
+      if (sym_url_character_set_1(lookahead)) ADVANCE(79);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
@@ -1161,37 +1120,41 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 80:
       ACCEPT_TOKEN(sym_url);
-      if (lookahead == '.') ADVANCE(26);
-      if (lookahead == ':') ADVANCE(24);
+      if (lookahead == '.') ADVANCE(21);
+      if (lookahead == ':') ADVANCE(20);
+      if (lookahead == ',' ||
+          lookahead == '{' ||
+          lookahead == '}') ADVANCE(22);
       if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(80);
       if (lookahead == '#' ||
           lookahead == '%' ||
           lookahead == '&' ||
-          lookahead == '+' ||
-          ('-' <= lookahead && lookahead <= ';') ||
+          ('+' <= lookahead && lookahead <= ';') ||
           lookahead == '=' ||
           ('?' <= lookahead && lookahead <= 'Z') ||
           lookahead == '^' ||
           lookahead == '_' ||
-          lookahead == '~') ADVANCE(82);
-      if (('$' <= lookahead && lookahead <= '{') ||
-          lookahead == '}' ||
-          (192 <= lookahead && lookahead <= 255)) ADVANCE(28);
+          lookahead == '~' ||
+          (192 <= lookahead && lookahead <= 255)) ADVANCE(82);
       END_STATE();
     case 81:
       ACCEPT_TOKEN(sym_url);
+      if (lookahead == ',' ||
+          lookahead == '.' ||
+          lookahead == ':' ||
+          lookahead == '{' ||
+          lookahead == '}') ADVANCE(22);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(81);
-      if (sym_url_character_set_2(lookahead)) ADVANCE(82);
-      if (('$' <= lookahead && lookahead <= '{') ||
-          lookahead == '}' ||
-          (192 <= lookahead && lookahead <= 255)) ADVANCE(28);
+      if (sym_url_character_set_1(lookahead)) ADVANCE(82);
       END_STATE();
     case 82:
       ACCEPT_TOKEN(sym_url);
-      if (sym_url_character_set_4(lookahead)) ADVANCE(82);
-      if (('$' <= lookahead && lookahead <= '{') ||
-          lookahead == '}' ||
-          (192 <= lookahead && lookahead <= 255)) ADVANCE(28);
+      if (lookahead == ',' ||
+          lookahead == '.' ||
+          lookahead == ':' ||
+          lookahead == '{' ||
+          lookahead == '}') ADVANCE(22);
+      if (sym_url_character_set_1(lookahead)) ADVANCE(82);
       END_STATE();
     case 83:
       ACCEPT_TOKEN(sym_name);

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -123,6 +123,7 @@ struct TSLanguage {
     unsigned (*serialize)(void *, char *);
     void (*deserialize)(void *, const char *, unsigned);
   } external_scanner;
+  const TSStateId *primary_state_ids;
 };
 
 /*


### PR DESCRIPTION
I updated grammar.js so that it accepts urls like this:
```
GET {{URL}}/resource/{{ID}}/ö-weird-letter
```
based on the features in https://github.com/NTBBloodbath/rest.nvim.