### PR TITLE
add flake.nix to ease contribution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+build:
+	$(CC) -fPIC -c src/parser.c -o parser/http.so $(CFLAGS)
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # HTTP tree-sitter parser
 
 HTTP grammar for [tree-sitter](https://github.com/tree-sitter/tree-sitter)
+
+
+# How to contribute
+
+You can get a development environment with
+`nix develop`
+then run:
+`npm install`

--- a/README.md
+++ b/README.md
@@ -8,4 +8,10 @@ HTTP grammar for [tree-sitter](https://github.com/tree-sitter/tree-sitter)
 You can get a development environment with
 `nix develop`
 then run:
-`npm install`
+```
+npm install
+make build
+```
+
+Neovim loads parser in runtimepath order so to test the generated grammar,
+prepend it to rtp with `set rtp^=/path/to/tree-sitter-http`.

--- a/binding.gyp
+++ b/binding.gyp
@@ -7,7 +7,8 @@
         "src"
       ],
       "sources": [
-        "bindings/node/binding.cc",
+		# breaks tree-sitter-cli generate
+        # "bindings/node/binding.cc",
         "src/parser.c",
         # If your language uses an external scanner, add it here.
       ],

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,42 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1672672955,
+        "narHash": "sha256-XRHGebzh3rboOOGo65KxC7iWGsNzQ1shB+HsRFohoI4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "bd3de3c63b30ea8177f650ae1606a203bb8901ea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,27 @@
+{
+  description = "Treesitter http grammar";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }: 
+    flake-utils.lib.eachSystem [ "x86_64-linux" ] (system:
+      let 
+        pkgs = nixpkgs.legacyPackages.${system};
+      in {
+
+
+    devShells = {
+      default = pkgs.mkShell {
+        buildInputs = [ 
+          pkgs.tree-sitter
+          (pkgs.vimPlugins.nvim-treesitter.withPlugins(p: [ p.json ]))
+          pkgs.nodejs
+          pkgs.python3  # needed by node-gyp
+        ];
+      };
+    };
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,46 @@
 {
   "name": "tree-sitter-http",
   "version": "0.1.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "tree-sitter-http",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "nan": "^2.14.2",
+        "tree-sitter-json": "^0.19.0"
+      },
+      "devDependencies": {
+        "tree-sitter-cli": "^0.20.0"
+      }
+    },
+    "node_modules/nan": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
+    },
+    "node_modules/tree-sitter-cli": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.20.0.tgz",
+      "integrity": "sha512-4D1qapWbJXZ5rrSUGM5rcw5Vuq/smzn9KbiFRhlON6KeuuXjra+KAtDYVrDgAoLIG4ku+jbEEGrJxCptUGi3dg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "tree-sitter": "cli.js"
+      }
+    },
+    "node_modules/tree-sitter-json": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-json/-/tree-sitter-json-0.19.0.tgz",
+      "integrity": "sha512-XospLJCiv/xTS6n4llBhXGCEDvnt30oEZr1Eo7qD9YgMJgEmjhQ/036Qx5kclB21CrP6CLWVudgjQZZ4LAMG8A==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "nan": "^2.14.1"
+      }
+    }
+  },
   "dependencies": {
     "nan": {
       "version": "2.15.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/NTBBloodbath/tree-sitter-http.git"
+    "url": "git+https://github.com/rest-nvim/tree-sitter-http.git"
   },
   "keywords": [
     "treesitter",
@@ -21,9 +21,9 @@
   "author": "NTBBloodbath",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/NTBBloodbath/tree-sitter-http/issues"
+    "url": "https://github.com/rest-nvim/tree-sitter-http/issues"
   },
-  "homepage": "https://github.com/NTBBloodbath/tree-sitter-http#readme",
+  "homepage": "https://github.com/rest-nvim/tree-sitter-http#readme",
   "dependencies": {
     "nan": "^2.14.2",
     "tree-sitter-json": "^0.19.0"

--- a/parser/README.md
+++ b/parser/README.md
@@ -1,0 +1,2 @@
+This README exists just to allow git to track the folder.
+`make build` in root directory should create the parser in this folder.


### PR DESCRIPTION
run nix develop to get everything you need

So I wanted to play a bit with the parser but I can't install it
```
 npm install

> tree-sitter-http@0.1.0 install
> node-gyp rebuild

gyp info it worked if it ends with ok
gyp info using node-gyp@9.1.0
gyp info using node@18.12.1 | linux | x64
gyp info find Python using Python version 3.10.9 found at "/nix/store/al6g1zbk8li6p8mcyp0h60d08jaahf8c-python3-3.10.9/bin/python3"
gyp info spawn /nix/store/al6g1zbk8li6p8mcyp0h60d08jaahf8c-python3-3.10.9/bin/python3
gyp info spawn args [
gyp info spawn args   '/nix/store/7ppnyqmp1c92gkfrixbz99sw7q6ifkg1-nodejs-18.12.1/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp_main.py',
gyp info spawn args   'binding.gyp',
gyp info spawn args   '-f',
gyp info spawn args   'make',
gyp info spawn args   '-I',
gyp info spawn args   '/home/teto/tree-sitter-http/build/config.gypi',
gyp info spawn args   '-I',
gyp info spawn args   '/nix/store/7ppnyqmp1c92gkfrixbz99sw7q6ifkg1-nodejs-18.12.1/lib/node_modules/npm/node_modules/node-gyp/addon.gypi',
gyp info spawn args   '-I',
gyp info spawn args   '/home/teto/.cache/node-gyp/18.12.1/include/node/common.gypi',
gyp info spawn args   '-Dlibrary=shared_library',
gyp info spawn args   '-Dvisibility=default',
gyp info spawn args   '-Dnode_root_dir=/home/teto/.cache/node-gyp/18.12.1',
gyp info spawn args   '-Dnode_gyp_dir=/nix/store/7ppnyqmp1c92gkfrixbz99sw7q6ifkg1-nodejs-18.12.1/lib/node_modules/npm/node_modules/node-gyp',
gyp info spawn args   '-Dnode_lib_file=/home/teto/.cache/node-gyp/18.12.1/<(target_arch)/node.lib',
gyp info spawn args   '-Dmodule_root_dir=/home/teto/tree-sitter-http',
gyp info spawn args   '-Dnode_engine=v8',
gyp info spawn args   '--depth=.',
gyp info spawn args   '--no-parallel',
gyp info spawn args   '--generator-output',
gyp info spawn args   'build',
gyp info spawn args   '-Goutput_dir=.'
gyp info spawn args ]
gyp info spawn make
gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
make: Entering directory '/home/teto/tree-sitter-http/build'
make: *** No rule to make target 'Release/obj.target/tree_sitter_http_binding/bindings/node/binding.o', needed by 'Release/obj.target/tree_sitter_http_binding.node'.  Stop.
make: Leaving directory '/home/teto/tree-sitter-http/build'
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/nix/store/7ppnyqmp1c92gkfrixbz99sw7q6ifkg1-nodejs-18.12.1/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:201:23)
gyp ERR! stack     at ChildProcess.emit (node:events:513:28)
gyp ERR! stack     at ChildProcess._handle.onexit (node:internal/child_process:291:12)
gyp ERR! System Linux 6.1.1
gyp ERR! command "/nix/store/7ppnyqmp1c92gkfrixbz99sw7q6ifkg1-nodejs-18.12.1/bin/node" "/nix/store/7ppnyqmp1c92gkfrixbz99sw7q6ifkg1-nodejs-18.12.1/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /home/teto/tree-sitter-http
gyp ERR! node -v v18.12.1
gyp ERR! node-gyp -v v9.1.0
gyp ERR! not ok 
npm ERR! code 1
npm ERR! path /home/teto/tree-sitter-http
npm ERR! command failed
npm ERR! command sh -c -- node-gyp rebuild

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/teto/.npm/_logs/2023-01-02T17_19_35_588Z-debug-0.log
```
I wonder if it rings a bell to anyone ? @NTBBloodbath 