### PR TITLE
feat: add support for variables as query string values

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -87,9 +87,7 @@ module.exports = grammar({
                     optional($.authority),
                     $.host,
                     optional($.path),
-                    optional(
-                        seq("?", repeat1($.query_param)),
-                    ),
+                    optional(repeat($.query_param)),
                     optional(
                         seq("#", $.fragment),
                     ),
@@ -98,9 +96,7 @@ module.exports = grammar({
                     $.variable,
                     optional($.authority),
                     optional($.path),
-                    optional(
-                        seq("?", repeat1($.query_param)),
-                    ),
+                    optional(repeat($.query_param)),
                     optional(
                         seq("#", $.fragment),
                     ),
@@ -142,10 +138,15 @@ module.exports = grammar({
         query_param: ($) =>
             prec.right(
                 seq(
-                    optional("&"),
+                    choice("&", "?"),
                     field("key", alias($.query_key, $.key)),
                     optional("="),
-                    optional(field("value", alias($.param, $.value))),
+                    optional(
+                        choice(
+                            field("value", $.variable),
+                            field("value", alias($.param, $.value)),
+                        ),
+                    ),
                 ),
             ),
 
@@ -281,7 +282,7 @@ module.exports = grammar({
 
         identifier: (_) => /[A-Za-z_.\$\d\u00A1-\uFFFF-]+/,
         query_key: (_) => /[^&#=\n]+/,
-        param: (_) => /[^&#\n]+/,
+        param: (_) => /[^{}&#\n]+/,
         number: (_) => /[0-9]+/,
         string: (_) => /"[^"]*"/,
         boolean: (_) => choice("true", "false"),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -429,20 +429,11 @@
               "type": "CHOICE",
               "members": [
                 {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "?"
-                    },
-                    {
-                      "type": "REPEAT1",
-                      "content": {
-                        "type": "SYMBOL",
-                        "name": "query_param"
-                      }
-                    }
-                  ]
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "query_param"
+                  }
                 },
                 {
                   "type": "BLANK"
@@ -507,20 +498,11 @@
               "type": "CHOICE",
               "members": [
                 {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "?"
-                    },
-                    {
-                      "type": "REPEAT1",
-                      "content": {
-                        "type": "SYMBOL",
-                        "name": "query_param"
-                      }
-                    }
-                  ]
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "query_param"
+                  }
                 },
                 {
                   "type": "BLANK"
@@ -732,7 +714,8 @@
                 "value": "&"
               },
               {
-                "type": "BLANK"
+                "type": "STRING",
+                "value": "?"
               }
             ]
           },
@@ -765,17 +748,30 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "FIELD",
-                "name": "value",
-                "content": {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "param"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "FIELD",
+                    "name": "value",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "variable"
+                    }
                   },
-                  "named": true,
-                  "value": "value"
-                }
+                  {
+                    "type": "FIELD",
+                    "name": "value",
+                    "content": {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "param"
+                      },
+                      "named": true,
+                      "value": "value"
+                    }
+                  }
+                ]
               },
               {
                 "type": "BLANK"
@@ -1501,7 +1497,7 @@
     },
     "param": {
       "type": "PATTERN",
-      "value": "[^&#\\n]+"
+      "value": "[^{}&#\\n]+"
     },
     "number": {
       "type": "PATTERN",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -263,6 +263,10 @@
           {
             "type": "value",
             "named": true
+          },
+          {
+            "type": "variable",
+            "named": true
           }
         ]
       }

--- a/src/parser.c
+++ b/src/parser.c
@@ -13,7 +13,7 @@
 #endif
 
 #define LANGUAGE_VERSION 14
-#define STATE_COUNT 240
+#define STATE_COUNT 213
 #define LARGE_STATE_COUNT 2
 #define SYMBOL_COUNT 114
 #define ALIAS_COUNT 1
@@ -21,7 +21,7 @@
 #define EXTERNAL_TOKEN_COUNT 0
 #define FIELD_COUNT 5
 #define MAX_ALIAS_SEQUENCE_LENGTH 10
-#define PRODUCTION_ID_COUNT 25
+#define PRODUCTION_ID_COUNT 22
 
 enum ts_symbol_identifiers {
   sym_identifier = 1,
@@ -72,11 +72,11 @@ enum ts_symbol_identifiers {
   aux_sym_http_version_token1 = 46,
   anon_sym_POUND = 47,
   anon_sym_COLON_SLASH_SLASH = 48,
-  anon_sym_QMARK = 49,
-  sym_status_code = 50,
-  sym_status_text = 51,
-  aux_sym_request_token1 = 52,
-  anon_sym_AMP = 53,
+  sym_status_code = 49,
+  sym_status_text = 50,
+  aux_sym_request_token1 = 51,
+  anon_sym_AMP = 52,
+  anon_sym_QMARK = 53,
   anon_sym_EQ = 54,
   aux_sym_header_token1 = 55,
   aux_sym_header_token2 = 56,
@@ -190,11 +190,11 @@ static const char * const ts_symbol_names[] = {
   [aux_sym_http_version_token1] = "http_version_token1",
   [anon_sym_POUND] = "#",
   [anon_sym_COLON_SLASH_SLASH] = "://",
-  [anon_sym_QMARK] = "\?",
   [sym_status_code] = "status_code",
   [sym_status_text] = "status_text",
   [aux_sym_request_token1] = "request_token1",
   [anon_sym_AMP] = "&",
+  [anon_sym_QMARK] = "\?",
   [anon_sym_EQ] = "=",
   [aux_sym_header_token1] = "value",
   [aux_sym_header_token2] = "value",
@@ -308,11 +308,11 @@ static const TSSymbol ts_symbol_map[] = {
   [aux_sym_http_version_token1] = aux_sym_http_version_token1,
   [anon_sym_POUND] = anon_sym_POUND,
   [anon_sym_COLON_SLASH_SLASH] = anon_sym_COLON_SLASH_SLASH,
-  [anon_sym_QMARK] = anon_sym_QMARK,
   [sym_status_code] = sym_status_code,
   [sym_status_text] = sym_status_text,
   [aux_sym_request_token1] = aux_sym_request_token1,
   [anon_sym_AMP] = anon_sym_AMP,
+  [anon_sym_QMARK] = anon_sym_QMARK,
   [anon_sym_EQ] = anon_sym_EQ,
   [aux_sym_header_token1] = aux_sym_header_token1,
   [aux_sym_header_token2] = aux_sym_header_token1,
@@ -573,10 +573,6 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
-  [anon_sym_QMARK] = {
-    .visible = true,
-    .named = false,
-  },
   [sym_status_code] = {
     .visible = true,
     .named = true,
@@ -590,6 +586,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = false,
   },
   [anon_sym_AMP] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_QMARK] = {
     .visible = true,
     .named = false,
   },
@@ -858,89 +858,78 @@ static const char * const ts_field_names[] = {
 
 static const TSFieldMapSlice ts_field_map_slices[PRODUCTION_ID_COUNT] = {
   [1] = {.index = 0, .length = 1},
-  [2] = {.index = 1, .length = 1},
-  [3] = {.index = 2, .length = 2},
-  [4] = {.index = 4, .length = 1},
-  [5] = {.index = 5, .length = 2},
+  [2] = {.index = 1, .length = 2},
+  [3] = {.index = 3, .length = 1},
+  [4] = {.index = 4, .length = 2},
+  [5] = {.index = 6, .length = 1},
   [6] = {.index = 7, .length = 1},
-  [7] = {.index = 8, .length = 1},
-  [8] = {.index = 9, .length = 2},
-  [9] = {.index = 11, .length = 2},
-  [10] = {.index = 13, .length = 2},
-  [11] = {.index = 15, .length = 2},
-  [12] = {.index = 17, .length = 2},
-  [13] = {.index = 19, .length = 2},
-  [14] = {.index = 21, .length = 1},
-  [15] = {.index = 5, .length = 2},
-  [16] = {.index = 5, .length = 2},
-  [17] = {.index = 22, .length = 2},
-  [18] = {.index = 22, .length = 2},
-  [19] = {.index = 24, .length = 4},
-  [20] = {.index = 28, .length = 1},
-  [21] = {.index = 29, .length = 4},
-  [22] = {.index = 33, .length = 4},
-  [23] = {.index = 37, .length = 4},
-  [24] = {.index = 2, .length = 2},
+  [7] = {.index = 8, .length = 2},
+  [8] = {.index = 10, .length = 2},
+  [9] = {.index = 12, .length = 2},
+  [10] = {.index = 14, .length = 2},
+  [11] = {.index = 16, .length = 1},
+  [12] = {.index = 4, .length = 2},
+  [13] = {.index = 4, .length = 2},
+  [14] = {.index = 17, .length = 2},
+  [15] = {.index = 17, .length = 2},
+  [16] = {.index = 19, .length = 4},
+  [17] = {.index = 23, .length = 1},
+  [18] = {.index = 24, .length = 4},
+  [19] = {.index = 28, .length = 4},
+  [20] = {.index = 32, .length = 4},
+  [21] = {.index = 1, .length = 2},
 };
 
 static const TSFieldMapEntry ts_field_map_entries[] = {
   [0] =
     {field_name, 1},
   [1] =
-    {field_key, 0},
-  [2] =
     {field_name, 1},
     {field_value, 3},
-  [4] =
+  [3] =
     {field_name, 2},
-  [5] =
+  [4] =
     {field_name, 0},
     {field_value, 2},
-  [7] =
+  [6] =
     {field_identifier, 0},
-  [8] =
+  [7] =
     {field_key, 1},
-  [9] =
-    {field_key, 0},
-    {field_value, 1},
-  [11] =
+  [8] =
     {field_name, 1},
     {field_value, 4},
-  [13] =
+  [10] =
     {field_key, 1},
     {field_value, 2},
-  [15] =
-    {field_key, 0},
-    {field_value, 2},
-  [17] =
+  [12] =
     {field_name, 1},
     {field_value, 5},
-  [19] =
+  [14] =
     {field_key, 1},
     {field_value, 3},
-  [21] =
+  [16] =
     {field_file_path, 2},
-  [22] =
+  [17] =
     {field_name, 0},
     {field_value, 3},
-  [24] =
+  [19] =
     {field_name, 0},
     {field_name, 3, .inherited = true},
     {field_value, 2},
     {field_value, 3, .inherited = true},
-  [28] =
+  [23] =
     {field_file_path, 4},
-  [29] =
+  [24] =
     {field_name, 0},
     {field_value, 2},
     {field_value, 3},
     {field_value, 4},
-  [33] =
+  [28] =
     {field_name, 0, .inherited = true},
     {field_name, 1, .inherited = true},
     {field_value, 0, .inherited = true},
     {field_value, 1, .inherited = true},
-  [37] =
+  [32] =
     {field_name, 0},
     {field_value, 3},
     {field_value, 4},
@@ -949,11 +938,21 @@ static const TSFieldMapEntry ts_field_map_entries[] = {
 
 static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGTH] = {
   [0] = {0},
-  [6] = {
+  [5] = {
     [0] = sym_identifier,
   },
-  [14] = {
+  [11] = {
     [2] = sym_path,
+  },
+  [12] = {
+    [0] = alias_sym_name,
+  },
+  [13] = {
+    [2] = aux_sym_header_token1,
+  },
+  [14] = {
+    [0] = alias_sym_name,
+    [3] = aux_sym_header_token1,
   },
   [15] = {
     [0] = alias_sym_name,
@@ -962,30 +961,20 @@ static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE
     [2] = aux_sym_header_token1,
   },
   [17] = {
-    [0] = alias_sym_name,
-    [3] = aux_sym_header_token1,
-  },
-  [18] = {
-    [0] = alias_sym_name,
-  },
-  [19] = {
-    [2] = aux_sym_header_token1,
-  },
-  [20] = {
     [4] = sym_path,
   },
-  [21] = {
+  [18] = {
     [0] = alias_sym_name,
     [3] = aux_sym_header_token1,
     [4] = aux_sym_header_token1,
   },
-  [23] = {
+  [20] = {
     [0] = alias_sym_name,
     [3] = aux_sym_header_token1,
     [4] = aux_sym_header_token1,
     [5] = aux_sym_header_token1,
   },
-  [24] = {
+  [21] = {
     [3] = aux_sym_header_token1,
   },
 };
@@ -1067,119 +1056,119 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [60] = 60,
   [61] = 61,
   [62] = 62,
-  [63] = 5,
+  [63] = 63,
   [64] = 64,
-  [65] = 7,
+  [65] = 65,
   [66] = 66,
   [67] = 67,
-  [68] = 62,
+  [68] = 5,
   [69] = 69,
   [70] = 70,
-  [71] = 71,
+  [71] = 7,
   [72] = 72,
-  [73] = 73,
-  [74] = 74,
-  [75] = 75,
-  [76] = 76,
-  [77] = 77,
+  [73] = 38,
+  [74] = 44,
+  [75] = 57,
+  [76] = 27,
+  [77] = 59,
   [78] = 78,
-  [79] = 79,
+  [79] = 30,
   [80] = 80,
-  [81] = 46,
+  [81] = 81,
   [82] = 82,
-  [83] = 56,
-  [84] = 43,
-  [85] = 29,
+  [83] = 83,
+  [84] = 84,
+  [85] = 85,
   [86] = 86,
   [87] = 87,
-  [88] = 28,
+  [88] = 88,
   [89] = 89,
   [90] = 90,
   [91] = 91,
   [92] = 92,
   [93] = 93,
   [94] = 94,
-  [95] = 57,
+  [95] = 95,
   [96] = 96,
   [97] = 97,
-  [98] = 46,
+  [98] = 98,
   [99] = 99,
-  [100] = 71,
+  [100] = 100,
   [101] = 101,
-  [102] = 73,
+  [102] = 102,
   [103] = 103,
   [104] = 104,
-  [105] = 105,
-  [106] = 106,
-  [107] = 56,
-  [108] = 43,
-  [109] = 57,
-  [110] = 110,
+  [105] = 53,
+  [106] = 45,
+  [107] = 107,
+  [108] = 108,
+  [109] = 109,
+  [110] = 5,
   [111] = 111,
-  [112] = 106,
-  [113] = 42,
+  [112] = 112,
+  [113] = 113,
   [114] = 114,
   [115] = 115,
   [116] = 116,
   [117] = 117,
   [118] = 118,
   [119] = 119,
-  [120] = 120,
-  [121] = 5,
+  [120] = 117,
+  [121] = 121,
   [122] = 122,
   [123] = 123,
-  [124] = 124,
-  [125] = 104,
+  [124] = 119,
+  [125] = 125,
   [126] = 126,
   [127] = 127,
-  [128] = 37,
-  [129] = 129,
-  [130] = 130,
-  [131] = 131,
-  [132] = 132,
-  [133] = 133,
-  [134] = 134,
-  [135] = 135,
-  [136] = 134,
+  [128] = 5,
+  [129] = 122,
+  [130] = 114,
+  [131] = 5,
+  [132] = 114,
+  [133] = 114,
+  [134] = 123,
+  [135] = 7,
+  [136] = 136,
   [137] = 137,
-  [138] = 135,
+  [138] = 138,
   [139] = 139,
   [140] = 140,
-  [141] = 141,
-  [142] = 142,
-  [143] = 139,
-  [144] = 140,
-  [145] = 141,
+  [141] = 127,
+  [142] = 126,
+  [143] = 143,
+  [144] = 144,
+  [145] = 145,
   [146] = 146,
-  [147] = 142,
+  [147] = 147,
   [148] = 148,
-  [149] = 5,
-  [150] = 135,
-  [151] = 114,
+  [149] = 149,
+  [150] = 150,
+  [151] = 151,
   [152] = 152,
   [153] = 153,
-  [154] = 5,
+  [154] = 154,
   [155] = 155,
-  [156] = 114,
+  [156] = 156,
   [157] = 157,
   [158] = 158,
-  [159] = 159,
-  [160] = 142,
-  [161] = 161,
-  [162] = 134,
+  [159] = 7,
+  [160] = 160,
+  [161] = 7,
+  [162] = 162,
   [163] = 163,
   [164] = 164,
-  [165] = 141,
-  [166] = 140,
+  [165] = 165,
+  [166] = 155,
   [167] = 167,
-  [168] = 114,
+  [168] = 168,
   [169] = 169,
-  [170] = 139,
-  [171] = 7,
+  [170] = 170,
+  [171] = 171,
   [172] = 172,
   [173] = 173,
   [174] = 174,
-  [175] = 7,
+  [175] = 175,
   [176] = 176,
   [177] = 177,
   [178] = 178,
@@ -1193,57 +1182,30 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [186] = 186,
   [187] = 187,
   [188] = 188,
-  [189] = 189,
+  [189] = 107,
   [190] = 190,
-  [191] = 191,
+  [191] = 179,
   [192] = 192,
   [193] = 193,
-  [194] = 7,
+  [194] = 194,
   [195] = 195,
   [196] = 196,
   [197] = 197,
-  [198] = 183,
+  [198] = 198,
   [199] = 199,
   [200] = 200,
   [201] = 201,
-  [202] = 202,
+  [202] = 195,
   [203] = 203,
   [204] = 204,
-  [205] = 205,
-  [206] = 206,
-  [207] = 127,
+  [205] = 201,
+  [206] = 104,
+  [207] = 207,
   [208] = 208,
   [209] = 209,
   [210] = 210,
-  [211] = 211,
+  [211] = 193,
   [212] = 212,
-  [213] = 213,
-  [214] = 214,
-  [215] = 215,
-  [216] = 216,
-  [217] = 217,
-  [218] = 118,
-  [219] = 219,
-  [220] = 220,
-  [221] = 221,
-  [222] = 222,
-  [223] = 223,
-  [224] = 224,
-  [225] = 225,
-  [226] = 226,
-  [227] = 227,
-  [228] = 223,
-  [229] = 229,
-  [230] = 226,
-  [231] = 229,
-  [232] = 232,
-  [233] = 233,
-  [234] = 234,
-  [235] = 235,
-  [236] = 236,
-  [237] = 214,
-  [238] = 238,
-  [239] = 239,
 };
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
@@ -1251,1492 +1213,1454 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(647);
-      ADVANCE_MAP(
-        '\n', 671,
-        '\r', 671,
-        '"', 76,
-        '#', 661,
-        '&', 672,
-        '(', 694,
-        '-', 700,
-        '/', 652,
-        ':', 649,
-        '<', 696,
-        '=', 673,
-        '?', 663,
-        '@', 658,
-        'H', 704,
-        '[', 15,
-        ']', 16,
-        'c', 710,
-        'f', 705,
-        't', 712,
-        '{', 17,
-        '}', 18,
-        '\t', 729,
-        0x0b, 729,
-        ' ', 729,
-      );
+      if (eof) ADVANCE(645);
+      if (lookahead == '\n') ADVANCE(666);
+      if (lookahead == '\r') ADVANCE(666);
+      if (lookahead == '"') ADVANCE(74);
+      if (lookahead == '#') ADVANCE(658);
+      if (lookahead == '&') ADVANCE(667);
+      if (lookahead == '(') ADVANCE(690);
+      if (lookahead == '-') ADVANCE(696);
+      if (lookahead == '/') ADVANCE(650);
+      if (lookahead == ':') ADVANCE(647);
+      if (lookahead == '<') ADVANCE(692);
+      if (lookahead == '=') ADVANCE(670);
+      if (lookahead == '?') ADVANCE(668);
+      if (lookahead == '@') ADVANCE(655);
+      if (lookahead == 'H') ADVANCE(700);
+      if (lookahead == '[') ADVANCE(13);
+      if (lookahead == ']') ADVANCE(14);
+      if (lookahead == 'c') ADVANCE(706);
+      if (lookahead == 'f') ADVANCE(701);
+      if (lookahead == 't') ADVANCE(708);
+      if (lookahead == '{') ADVANCE(15);
+      if (lookahead == '}') ADVANCE(16);
+      if (('\t' <= lookahead && lookahead <= 11) ||
+          lookahead == ' ') ADVANCE(722);
       if (lookahead == '0' ||
-          ('6' <= lookahead && lookahead <= '9')) ADVANCE(650);
-      if (('1' <= lookahead && lookahead <= '5')) ADVANCE(650);
+          ('6' <= lookahead && lookahead <= '9')) ADVANCE(648);
+      if (('1' <= lookahead && lookahead <= '5')) ADVANCE(648);
       if (lookahead == '$' ||
           lookahead == '.' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(717);
+          (161 <= lookahead && lookahead <= 55295) ||
+          (57344 <= lookahead && lookahead <= 65535)) ADVANCE(713);
       END_STATE();
     case 1:
-      ADVANCE_MAP(
-        '\n', 671,
-        '\r', 671,
-        '#', 661,
-        '(', 694,
-        '/', 652,
-        '?', 663,
-        '@', 658,
-        '{', 637,
-        '\t', 729,
-        0x0b, 729,
-        ' ', 729,
-      );
+      if (lookahead == '\n') ADVANCE(666);
+      if (lookahead == '\r') ADVANCE(666);
+      if (lookahead == '#') ADVANCE(658);
+      if (lookahead == '&') ADVANCE(667);
+      if (lookahead == '(') ADVANCE(690);
+      if (lookahead == '/') ADVANCE(650);
+      if (lookahead == '?') ADVANCE(668);
+      if (lookahead == '@') ADVANCE(655);
+      if (lookahead == '{') ADVANCE(635);
+      if (('\t' <= lookahead && lookahead <= 11) ||
+          lookahead == ' ') ADVANCE(722);
       if (lookahead == '$' ||
           ('-' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(717);
+          (161 <= lookahead && lookahead <= 55295) ||
+          (57344 <= lookahead && lookahead <= 65535)) ADVANCE(713);
       END_STATE();
     case 2:
-      ADVANCE_MAP(
-        '\n', 671,
-        '\r', 666,
-        '#', 661,
-        '&', 672,
-        '/', 653,
-        '{', 720,
-        '\t', 721,
-        0x0b, 721,
-        ' ', 721,
-      );
-      if (lookahead == '$' ||
-          ('-' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(718);
+      if (lookahead == '\n') ADVANCE(666);
+      if (lookahead == '\r') ADVANCE(662);
+      if (lookahead == '#') ADVANCE(658);
+      if (lookahead == '&') ADVANCE(667);
+      if (lookahead == '=') ADVANCE(671);
+      if (lookahead == '?') ADVANCE(669);
+      if (lookahead == '{') ADVANCE(635);
+      if (('\t' <= lookahead && lookahead <= 11) ||
+          lookahead == ' ') ADVANCE(715);
       if (lookahead != 0 &&
-          lookahead != '=') ADVANCE(721);
+          lookahead != '}') ADVANCE(715);
       END_STATE();
     case 3:
-      ADVANCE_MAP(
-        '\n', 671,
-        '\r', 666,
-        '#', 661,
-        '&', 672,
-        '/', 653,
-        '\t', 721,
-        0x0b, 721,
-        ' ', 721,
-      );
+      if (lookahead == '\n') ADVANCE(666);
+      if (lookahead == '\r') ADVANCE(662);
+      if (lookahead == '#') ADVANCE(658);
+      if (lookahead == '&') ADVANCE(667);
+      if (lookahead == '?') ADVANCE(669);
+      if (lookahead == '{') ADVANCE(635);
+      if (('\t' <= lookahead && lookahead <= 11) ||
+          lookahead == ' ') ADVANCE(715);
       if (lookahead != 0 &&
-          lookahead != '=') ADVANCE(721);
+          lookahead != '}') ADVANCE(715);
       END_STATE();
     case 4:
-      if (lookahead == '\n') ADVANCE(671);
-      if (lookahead == '\r') ADVANCE(666);
-      if (lookahead == '#') ADVANCE(661);
-      if (lookahead == '&') ADVANCE(672);
-      if (('\t' <= lookahead && lookahead <= 0x0b) ||
-          lookahead == ' ') ADVANCE(721);
-      if (lookahead != 0 &&
-          lookahead != '=') ADVANCE(721);
-      END_STATE();
-    case 5:
-      ADVANCE_MAP(
-        '\n', 671,
-        '\r', 667,
-        '#', 661,
-        '&', 672,
-        '=', 674,
-        '\t', 719,
-        0x0b, 719,
-        ' ', 719,
-      );
-      if (lookahead != 0) ADVANCE(719);
-      END_STATE();
-    case 6:
-      ADVANCE_MAP(
-        '\n', 671,
-        '\r', 667,
-        '#', 661,
-        '&', 672,
-        '=', 722,
-        '\t', 719,
-        0x0b, 719,
-        ' ', 719,
-      );
-      if (lookahead != 0) ADVANCE(719);
-      END_STATE();
-    case 7:
-      if (lookahead == '\n') ADVANCE(671);
-      if (lookahead == '\r') ADVANCE(668);
-      if (lookahead == '(') ADVANCE(695);
-      if (lookahead != 0) ADVANCE(741);
-      END_STATE();
-    case 8:
-      if (lookahead == '\n') ADVANCE(671);
-      if (lookahead == '\r') ADVANCE(668);
-      if (lookahead == '-') ADVANCE(737);
-      if (lookahead != 0) ADVANCE(741);
-      END_STATE();
-    case 9:
-      if (lookahead == '\n') ADVANCE(671);
-      if (lookahead == '\r') ADVANCE(668);
-      if (lookahead == '<') ADVANCE(738);
-      if (lookahead != 0) ADVANCE(741);
-      END_STATE();
-    case 10:
-      if (lookahead == '\n') ADVANCE(671);
-      if (lookahead == '\r') ADVANCE(668);
-      if (lookahead == ']') ADVANCE(732);
-      if (lookahead == '}') ADVANCE(733);
-      if (lookahead != 0) ADVANCE(741);
-      END_STATE();
-    case 11:
-      if (lookahead == '\n') ADVANCE(671);
-      if (lookahead == '\r') ADVANCE(668);
-      if (lookahead == '}') ADVANCE(733);
-      if (lookahead != 0) ADVANCE(741);
-      END_STATE();
-    case 12:
-      if (lookahead == '\n') ADVANCE(671);
-      if (lookahead == '\r') ADVANCE(668);
-      if (('\t' <= lookahead && lookahead <= 0x0b) ||
-          lookahead == ' ') ADVANCE(731);
-      if (lookahead != 0) ADVANCE(741);
-      END_STATE();
-    case 13:
-      if (lookahead == '\n') ADVANCE(671);
-      if (lookahead == '\r') ADVANCE(668);
-      if (lookahead != 0) ADVANCE(741);
-      END_STATE();
-    case 14:
-      if (lookahead == '\n') ADVANCE(671);
-      if (lookahead == '\r') ADVANCE(669);
+      if (lookahead == '\n') ADVANCE(666);
+      if (lookahead == '\r') ADVANCE(662);
       if (lookahead != 0 &&
           lookahead != '#' &&
-          lookahead != '&') ADVANCE(722);
+          lookahead != '&' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(715);
+      END_STATE();
+    case 5:
+      if (lookahead == '\n') ADVANCE(666);
+      if (lookahead == '\r') ADVANCE(663);
+      if (lookahead == '(') ADVANCE(691);
+      if (lookahead != 0) ADVANCE(734);
+      END_STATE();
+    case 6:
+      if (lookahead == '\n') ADVANCE(666);
+      if (lookahead == '\r') ADVANCE(663);
+      if (lookahead == '-') ADVANCE(730);
+      if (lookahead != 0) ADVANCE(734);
+      END_STATE();
+    case 7:
+      if (lookahead == '\n') ADVANCE(666);
+      if (lookahead == '\r') ADVANCE(663);
+      if (lookahead == '<') ADVANCE(731);
+      if (lookahead != 0) ADVANCE(734);
+      END_STATE();
+    case 8:
+      if (lookahead == '\n') ADVANCE(666);
+      if (lookahead == '\r') ADVANCE(663);
+      if (lookahead == ']') ADVANCE(725);
+      if (lookahead == '}') ADVANCE(726);
+      if (lookahead != 0) ADVANCE(734);
+      END_STATE();
+    case 9:
+      if (lookahead == '\n') ADVANCE(666);
+      if (lookahead == '\r') ADVANCE(663);
+      if (lookahead == '}') ADVANCE(726);
+      if (lookahead != 0) ADVANCE(734);
+      END_STATE();
+    case 10:
+      if (lookahead == '\n') ADVANCE(666);
+      if (lookahead == '\r') ADVANCE(663);
+      if (('\t' <= lookahead && lookahead <= 11) ||
+          lookahead == ' ') ADVANCE(724);
+      if (lookahead != 0) ADVANCE(734);
+      END_STATE();
+    case 11:
+      if (lookahead == '\n') ADVANCE(666);
+      if (lookahead == '\r') ADVANCE(663);
+      if (lookahead != 0) ADVANCE(734);
+      END_STATE();
+    case 12:
+      if (lookahead == '\n') ADVANCE(666);
+      if (lookahead == '\r') ADVANCE(664);
+      if (lookahead != 0 &&
+          lookahead != '#' &&
+          lookahead != '&' &&
+          lookahead != '=') ADVANCE(714);
+      END_STATE();
+    case 13:
+      if (lookahead == '\n') ADVANCE(687);
+      END_STATE();
+    case 14:
+      if (lookahead == '\n') ADVANCE(689);
       END_STATE();
     case 15:
-      if (lookahead == '\n') ADVANCE(691);
+      if (lookahead == '\n') ADVANCE(686);
+      if (lookahead == '{') ADVANCE(680);
       END_STATE();
     case 16:
-      if (lookahead == '\n') ADVANCE(693);
+      if (lookahead == '\n') ADVANCE(688);
+      if (lookahead == '}') ADVANCE(681);
       END_STATE();
     case 17:
-      if (lookahead == '\n') ADVANCE(690);
-      if (lookahead == '{') ADVANCE(683);
+      if (lookahead == '\n') ADVANCE(685);
+      if (lookahead == '>') ADVANCE(17);
+      if (lookahead != 0) ADVANCE(82);
       END_STATE();
     case 18:
-      if (lookahead == '\n') ADVANCE(692);
-      if (lookahead == '}') ADVANCE(685);
+      if (lookahead == '\n') ADVANCE(682);
       END_STATE();
     case 19:
-      if (lookahead == '\n') ADVANCE(689);
-      if (lookahead == '>') ADVANCE(19);
-      if (lookahead != 0) ADVANCE(84);
-      END_STATE();
-    case 20:
-      if (lookahead == '\n') ADVANCE(686);
-      END_STATE();
-    case 21:
-      if (lookahead == '\n') ADVANCE(675);
+      if (lookahead == '\n') ADVANCE(672);
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ' ||
           lookahead == '-' ||
           ('/' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(21);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(19);
       END_STATE();
-    case 22:
-      ADVANCE_MAP(
-        '\f', 21,
-        '/', 682,
-        '@', 658,
-        'c', 679,
-        '{', 637,
-        '\n', 670,
-        '\r', 670,
-        '\t', 730,
-        0x0b, 730,
-        ' ', 730,
-      );
+    case 20:
+      if (lookahead == '\f') ADVANCE(19);
+      if (lookahead == '/') ADVANCE(679);
+      if (lookahead == '@') ADVANCE(655);
+      if (lookahead == 'c') ADVANCE(676);
+      if (lookahead == '{') ADVANCE(635);
+      if (lookahead == '\n' ||
+          lookahead == '\r') ADVANCE(665);
+      if (('\t' <= lookahead && lookahead <= 11) ||
+          lookahead == ' ') ADVANCE(723);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(681);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(678);
       if (lookahead == '$' ||
           lookahead == '.' ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(717);
+          (161 <= lookahead && lookahead <= 55295) ||
+          (57344 <= lookahead && lookahead <= 65535)) ADVANCE(713);
       END_STATE();
-    case 23:
-      if (lookahead == ' ') ADVANCE(139);
-      END_STATE();
-    case 24:
-      if (lookahead == ' ') ADVANCE(92);
-      END_STATE();
-    case 25:
-      if (lookahead == ' ') ADVANCE(92);
-      if (lookahead == 'n') ADVANCE(80);
-      if (lookahead == 't') ADVANCE(27);
-      END_STATE();
-    case 26:
-      if (lookahead == ' ') ADVANCE(103);
-      END_STATE();
-    case 27:
-      if (lookahead == ' ') ADVANCE(88);
-      END_STATE();
-    case 28:
-      if (lookahead == ' ') ADVANCE(116);
-      END_STATE();
-    case 29:
-      if (lookahead == ' ') ADVANCE(98);
-      END_STATE();
-    case 30:
-      if (lookahead == ' ') ADVANCE(141);
-      if (lookahead == '/') ADVANCE(659);
-      END_STATE();
-    case 31:
-      if (lookahead == ' ') ADVANCE(94);
-      END_STATE();
-    case 32:
-      if (lookahead == ' ') ADVANCE(112);
-      END_STATE();
-    case 33:
-      if (lookahead == ' ') ADVANCE(123);
-      END_STATE();
-    case 34:
-      if (lookahead == ' ') ADVANCE(104);
-      END_STATE();
-    case 35:
-      if (lookahead == ' ') ADVANCE(110);
-      END_STATE();
-    case 36:
-      if (lookahead == ' ') ADVANCE(100);
-      END_STATE();
-    case 37:
-      if (lookahead == ' ') ADVANCE(111);
-      END_STATE();
-    case 38:
-      if (lookahead == ' ') ADVANCE(101);
-      END_STATE();
-    case 39:
-      if (lookahead == ' ') ADVANCE(97);
-      END_STATE();
-    case 40:
-      if (lookahead == ' ') ADVANCE(106);
-      END_STATE();
-    case 41:
-      if (lookahead == ' ') ADVANCE(119);
-      END_STATE();
-    case 42:
-      if (lookahead == ' ') ADVANCE(119);
-      if (lookahead == 'i') ADVANCE(407);
-      END_STATE();
-    case 43:
-      if (lookahead == ' ') ADVANCE(140);
-      END_STATE();
-    case 44:
-      if (lookahead == ' ') ADVANCE(93);
-      END_STATE();
-    case 45:
-      if (lookahead == ' ') ADVANCE(91);
-      END_STATE();
-    case 46:
-      if (lookahead == ' ') ADVANCE(129);
-      END_STATE();
-    case 47:
-      if (lookahead == ' ') ADVANCE(113);
-      END_STATE();
-    case 48:
-      if (lookahead == ' ') ADVANCE(125);
-      END_STATE();
-    case 49:
-      if (lookahead == ' ') ADVANCE(109);
-      END_STATE();
-    case 50:
-      if (lookahead == ' ') ADVANCE(102);
-      END_STATE();
-    case 51:
-      if (lookahead == ' ') ADVANCE(96);
-      END_STATE();
-    case 52:
-      if (lookahead == ' ') ADVANCE(136);
-      END_STATE();
-    case 53:
-      if (lookahead == ' ') ADVANCE(118);
-      END_STATE();
-    case 54:
-      if (lookahead == ' ') ADVANCE(131);
-      END_STATE();
-    case 55:
-      if (lookahead == ' ') ADVANCE(108);
-      END_STATE();
-    case 56:
-      if (lookahead == ' ') ADVANCE(99);
-      END_STATE();
-    case 57:
+    case 21:
       if (lookahead == ' ') ADVANCE(137);
       END_STATE();
-    case 58:
-      if (lookahead == ' ') ADVANCE(132);
-      END_STATE();
-    case 59:
-      if (lookahead == ' ') ADVANCE(159);
-      END_STATE();
-    case 60:
-      if (lookahead == ' ') ADVANCE(135);
-      END_STATE();
-    case 61:
-      if (lookahead == ' ') ADVANCE(582);
-      END_STATE();
-    case 62:
-      if (lookahead == ' ') ADVANCE(89);
-      END_STATE();
-    case 63:
-      if (lookahead == ' ') ADVANCE(95);
-      END_STATE();
-    case 64:
-      if (lookahead == ' ') ADVANCE(128);
-      END_STATE();
-    case 65:
-      if (lookahead == ' ') ADVANCE(126);
-      END_STATE();
-    case 66:
+    case 22:
       if (lookahead == ' ') ADVANCE(90);
       END_STATE();
-    case 67:
-      if (lookahead == ' ') ADVANCE(127);
+    case 23:
+      if (lookahead == ' ') ADVANCE(90);
+      if (lookahead == 'n') ADVANCE(78);
+      if (lookahead == 't') ADVANCE(25);
       END_STATE();
-    case 68:
-      if (lookahead == ' ') ADVANCE(124);
+    case 24:
+      if (lookahead == ' ') ADVANCE(101);
       END_STATE();
-    case 69:
-      if (lookahead == ' ') ADVANCE(120);
+    case 25:
+      if (lookahead == ' ') ADVANCE(86);
       END_STATE();
-    case 70:
-      if (lookahead == ' ') ADVANCE(122);
-      END_STATE();
-    case 71:
+    case 26:
       if (lookahead == ' ') ADVANCE(114);
       END_STATE();
-    case 72:
+    case 27:
+      if (lookahead == ' ') ADVANCE(96);
+      END_STATE();
+    case 28:
+      if (lookahead == ' ') ADVANCE(139);
+      if (lookahead == '/') ADVANCE(656);
+      END_STATE();
+    case 29:
+      if (lookahead == ' ') ADVANCE(92);
+      END_STATE();
+    case 30:
+      if (lookahead == ' ') ADVANCE(110);
+      END_STATE();
+    case 31:
+      if (lookahead == ' ') ADVANCE(121);
+      END_STATE();
+    case 32:
+      if (lookahead == ' ') ADVANCE(102);
+      END_STATE();
+    case 33:
+      if (lookahead == ' ') ADVANCE(108);
+      END_STATE();
+    case 34:
+      if (lookahead == ' ') ADVANCE(98);
+      END_STATE();
+    case 35:
+      if (lookahead == ' ') ADVANCE(109);
+      END_STATE();
+    case 36:
+      if (lookahead == ' ') ADVANCE(99);
+      END_STATE();
+    case 37:
+      if (lookahead == ' ') ADVANCE(95);
+      END_STATE();
+    case 38:
+      if (lookahead == ' ') ADVANCE(104);
+      END_STATE();
+    case 39:
+      if (lookahead == ' ') ADVANCE(117);
+      END_STATE();
+    case 40:
+      if (lookahead == ' ') ADVANCE(117);
+      if (lookahead == 'i') ADVANCE(405);
+      END_STATE();
+    case 41:
       if (lookahead == ' ') ADVANCE(138);
       END_STATE();
-    case 73:
-      if (lookahead == ' ') ADVANCE(115);
+    case 42:
+      if (lookahead == ' ') ADVANCE(91);
       END_STATE();
-    case 74:
-      ADVANCE_MAP(
-        '"', 76,
-        'A', 193,
-        'B', 142,
-        'C', 435,
-        'E', 627,
-        'F', 143,
-        'G', 144,
-        'H', 134,
-        'I', 79,
-        'L', 244,
-        'M', 238,
-        'N', 245,
-        'O', 107,
-        'P', 145,
-        'R', 153,
-        'S', 234,
-        'T', 241,
-        'U', 121,
-        'V', 151,
-        'f', 149,
-        't', 498,
-        '\n', 671,
-        '\r', 671,
-        '\t', 729,
-        0x0b, 729,
-        ' ', 729,
-      );
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(723);
+    case 43:
+      if (lookahead == ' ') ADVANCE(89);
       END_STATE();
-    case 75:
-      if (lookahead == '"') ADVANCE(76);
-      if (lookahead == 'f') ADVANCE(705);
-      if (lookahead == 't') ADVANCE(712);
+    case 44:
+      if (lookahead == ' ') ADVANCE(127);
+      END_STATE();
+    case 45:
+      if (lookahead == ' ') ADVANCE(111);
+      END_STATE();
+    case 46:
+      if (lookahead == ' ') ADVANCE(123);
+      END_STATE();
+    case 47:
+      if (lookahead == ' ') ADVANCE(107);
+      END_STATE();
+    case 48:
+      if (lookahead == ' ') ADVANCE(100);
+      END_STATE();
+    case 49:
+      if (lookahead == ' ') ADVANCE(94);
+      END_STATE();
+    case 50:
+      if (lookahead == ' ') ADVANCE(134);
+      END_STATE();
+    case 51:
+      if (lookahead == ' ') ADVANCE(116);
+      END_STATE();
+    case 52:
+      if (lookahead == ' ') ADVANCE(129);
+      END_STATE();
+    case 53:
+      if (lookahead == ' ') ADVANCE(106);
+      END_STATE();
+    case 54:
+      if (lookahead == ' ') ADVANCE(97);
+      END_STATE();
+    case 55:
+      if (lookahead == ' ') ADVANCE(135);
+      END_STATE();
+    case 56:
+      if (lookahead == ' ') ADVANCE(130);
+      END_STATE();
+    case 57:
+      if (lookahead == ' ') ADVANCE(157);
+      END_STATE();
+    case 58:
+      if (lookahead == ' ') ADVANCE(133);
+      END_STATE();
+    case 59:
+      if (lookahead == ' ') ADVANCE(580);
+      END_STATE();
+    case 60:
+      if (lookahead == ' ') ADVANCE(87);
+      END_STATE();
+    case 61:
+      if (lookahead == ' ') ADVANCE(93);
+      END_STATE();
+    case 62:
+      if (lookahead == ' ') ADVANCE(126);
+      END_STATE();
+    case 63:
+      if (lookahead == ' ') ADVANCE(124);
+      END_STATE();
+    case 64:
+      if (lookahead == ' ') ADVANCE(88);
+      END_STATE();
+    case 65:
+      if (lookahead == ' ') ADVANCE(125);
+      END_STATE();
+    case 66:
+      if (lookahead == ' ') ADVANCE(122);
+      END_STATE();
+    case 67:
+      if (lookahead == ' ') ADVANCE(118);
+      END_STATE();
+    case 68:
+      if (lookahead == ' ') ADVANCE(120);
+      END_STATE();
+    case 69:
+      if (lookahead == ' ') ADVANCE(112);
+      END_STATE();
+    case 70:
+      if (lookahead == ' ') ADVANCE(136);
+      END_STATE();
+    case 71:
+      if (lookahead == ' ') ADVANCE(113);
+      END_STATE();
+    case 72:
+      if (lookahead == '"') ADVANCE(74);
+      if (lookahead == 'A') ADVANCE(191);
+      if (lookahead == 'B') ADVANCE(140);
+      if (lookahead == 'C') ADVANCE(433);
+      if (lookahead == 'E') ADVANCE(625);
+      if (lookahead == 'F') ADVANCE(141);
+      if (lookahead == 'G') ADVANCE(142);
+      if (lookahead == 'H') ADVANCE(132);
+      if (lookahead == 'I') ADVANCE(77);
+      if (lookahead == 'L') ADVANCE(242);
+      if (lookahead == 'M') ADVANCE(236);
+      if (lookahead == 'N') ADVANCE(243);
+      if (lookahead == 'O') ADVANCE(105);
+      if (lookahead == 'P') ADVANCE(143);
+      if (lookahead == 'R') ADVANCE(151);
+      if (lookahead == 'S') ADVANCE(232);
+      if (lookahead == 'T') ADVANCE(239);
+      if (lookahead == 'U') ADVANCE(119);
+      if (lookahead == 'V') ADVANCE(149);
+      if (lookahead == 'f') ADVANCE(147);
+      if (lookahead == 't') ADVANCE(496);
       if (lookahead == '\n' ||
-          lookahead == '\r') ADVANCE(671);
+          lookahead == '\r') ADVANCE(666);
+      if (('\t' <= lookahead && lookahead <= 11) ||
+          lookahead == ' ') ADVANCE(722);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(716);
+      END_STATE();
+    case 73:
+      if (lookahead == '"') ADVANCE(74);
+      if (lookahead == 'f') ADVANCE(701);
+      if (lookahead == 't') ADVANCE(708);
+      if (lookahead == '\n' ||
+          lookahead == '\r') ADVANCE(666);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(712);
       if (lookahead == '$' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(717);
+          (161 <= lookahead && lookahead <= 55295) ||
+          (57344 <= lookahead && lookahead <= 65535)) ADVANCE(713);
       END_STATE();
-    case 76:
-      if (lookahead == '"') ADVANCE(724);
-      if (lookahead != 0) ADVANCE(76);
+    case 74:
+      if (lookahead == '"') ADVANCE(717);
+      if (lookahead != 0) ADVANCE(74);
       END_STATE();
-    case 77:
-      ADVANCE_MAP(
-        '#', 661,
-        '/', 652,
-        ':', 649,
-        '=', 673,
-        '?', 663,
-        '@', 658,
-        'c', 710,
-        '{', 637,
-        '}', 638,
-        '\n', 671,
-        '\r', 671,
-        '\t', 729,
-        0x0b, 729,
-        ' ', 729,
-      );
+    case 75:
+      if (lookahead == '#') ADVANCE(658);
+      if (lookahead == '&') ADVANCE(667);
+      if (lookahead == '/') ADVANCE(650);
+      if (lookahead == ':') ADVANCE(647);
+      if (lookahead == '=') ADVANCE(670);
+      if (lookahead == '?') ADVANCE(668);
+      if (lookahead == '@') ADVANCE(655);
+      if (lookahead == 'c') ADVANCE(706);
+      if (lookahead == '{') ADVANCE(635);
+      if (lookahead == '}') ADVANCE(636);
+      if (lookahead == '\n' ||
+          lookahead == '\r') ADVANCE(666);
+      if (('\t' <= lookahead && lookahead <= 11) ||
+          lookahead == ' ') ADVANCE(722);
       if (lookahead == '$' ||
           ('-' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(717);
+          (161 <= lookahead && lookahead <= 55295) ||
+          (57344 <= lookahead && lookahead <= 65535)) ADVANCE(713);
+      END_STATE();
+    case 76:
+      if (lookahead == '%') ADVANCE(18);
+      END_STATE();
+    case 77:
+      if (lookahead == '\'') ADVANCE(391);
+      if (lookahead == 'M') ADVANCE(21);
+      if (lookahead == 'n') ADVANCE(533);
       END_STATE();
     case 78:
-      if (lookahead == '%') ADVANCE(20);
+      if (lookahead == '-') ADVANCE(85);
       END_STATE();
     case 79:
-      if (lookahead == '\'') ADVANCE(393);
-      if (lookahead == 'M') ADVANCE(23);
-      if (lookahead == 'n') ADVANCE(535);
+      if (lookahead == '-') ADVANCE(128);
+      if (lookahead == 'p') ADVANCE(386);
       END_STATE();
     case 80:
-      if (lookahead == '-') ADVANCE(87);
+      if (lookahead == '/') ADVANCE(659);
       END_STATE();
     case 81:
-      if (lookahead == '-') ADVANCE(130);
-      if (lookahead == 'p') ADVANCE(388);
+      if (lookahead == '/') ADVANCE(80);
       END_STATE();
     case 82:
-      if (lookahead == '/') ADVANCE(662);
+      if (lookahead == '>') ADVANCE(17);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(82);
       END_STATE();
     case 83:
-      if (lookahead == '/') ADVANCE(82);
+      if (lookahead == '>') ADVANCE(684);
+      if (lookahead == '?') ADVANCE(83);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(84);
       END_STATE();
     case 84:
-      if (lookahead == '>') ADVANCE(19);
+      if (lookahead == '?') ADVANCE(83);
       if (lookahead != 0 &&
           lookahead != '\n') ADVANCE(84);
       END_STATE();
     case 85:
-      if (lookahead == '>') ADVANCE(688);
-      if (lookahead == '?') ADVANCE(85);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(86);
+      if (lookahead == 'A') ADVANCE(612);
       END_STATE();
     case 86:
-      if (lookahead == '?') ADVANCE(85);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(86);
+      if (lookahead == 'A') ADVANCE(208);
+      if (lookahead == 'E') ADVANCE(626);
+      if (lookahead == 'F') ADVANCE(436);
+      if (lookahead == 'I') ADVANCE(394);
+      if (lookahead == 'M') ADVANCE(459);
       END_STATE();
     case 87:
-      if (lookahead == 'A') ADVANCE(614);
+      if (lookahead == 'A') ADVANCE(608);
       END_STATE();
     case 88:
-      if (lookahead == 'A') ADVANCE(210);
-      if (lookahead == 'E') ADVANCE(628);
-      if (lookahead == 'F') ADVANCE(438);
-      if (lookahead == 'I') ADVANCE(396);
-      if (lookahead == 'M') ADVANCE(461);
+      if (lookahead == 'A') ADVANCE(376);
       END_STATE();
     case 89:
-      if (lookahead == 'A') ADVANCE(610);
+      if (lookahead == 'A') ADVANCE(375);
       END_STATE();
     case 90:
-      if (lookahead == 'A') ADVANCE(378);
+      if (lookahead == 'C') ADVANCE(439);
       END_STATE();
     case 91:
-      if (lookahead == 'A') ADVANCE(377);
+      if (lookahead == 'C') ADVANCE(321);
       END_STATE();
     case 92:
-      if (lookahead == 'C') ADVANCE(441);
+      if (lookahead == 'D') ADVANCE(293);
       END_STATE();
     case 93:
-      if (lookahead == 'C') ADVANCE(323);
+      if (lookahead == 'D') ADVANCE(284);
       END_STATE();
     case 94:
-      if (lookahead == 'D') ADVANCE(295);
+      if (lookahead == 'E') ADVANCE(514);
       END_STATE();
     case 95:
-      if (lookahead == 'D') ADVANCE(286);
+      if (lookahead == 'E') ADVANCE(414);
       END_STATE();
     case 96:
-      if (lookahead == 'E') ADVANCE(516);
+      if (lookahead == 'E') ADVANCE(156);
+      if (lookahead == 'M') ADVANCE(158);
       END_STATE();
     case 97:
-      if (lookahead == 'E') ADVANCE(416);
+      if (lookahead == 'F') ADVANCE(342);
       END_STATE();
     case 98:
-      if (lookahead == 'E') ADVANCE(158);
-      if (lookahead == 'M') ADVANCE(160);
+      if (lookahead == 'F') ADVANCE(178);
       END_STATE();
     case 99:
-      if (lookahead == 'F') ADVANCE(344);
+      if (lookahead == 'F') ADVANCE(178);
+      if (lookahead == 'R') ADVANCE(238);
       END_STATE();
     case 100:
-      if (lookahead == 'F') ADVANCE(180);
+      if (lookahead == 'F') ADVANCE(466);
       END_STATE();
     case 101:
-      if (lookahead == 'F') ADVANCE(180);
-      if (lookahead == 'R') ADVANCE(240);
+      if (lookahead == 'G') ADVANCE(179);
+      if (lookahead == 'R') ADVANCE(235);
       END_STATE();
     case 102:
-      if (lookahead == 'F') ADVANCE(468);
+      if (lookahead == 'H') ADVANCE(291);
+      if (lookahead == 'T') ADVANCE(347);
       END_STATE();
     case 103:
-      if (lookahead == 'G') ADVANCE(181);
-      if (lookahead == 'R') ADVANCE(237);
+      if (lookahead == 'I') ADVANCE(50);
       END_STATE();
     case 104:
-      if (lookahead == 'H') ADVANCE(293);
-      if (lookahead == 'T') ADVANCE(349);
+      if (lookahead == 'I') ADVANCE(404);
       END_STATE();
     case 105:
-      if (lookahead == 'I') ADVANCE(52);
+      if (lookahead == 'K') ADVANCE(661);
       END_STATE();
     case 106:
-      if (lookahead == 'I') ADVANCE(406);
+      if (lookahead == 'L') ADVANCE(256);
       END_STATE();
     case 107:
-      if (lookahead == 'K') ADVANCE(665);
+      if (lookahead == 'L') ADVANCE(162);
       END_STATE();
     case 108:
-      if (lookahead == 'L') ADVANCE(258);
+      if (lookahead == 'L') ADVANCE(449);
       END_STATE();
     case 109:
-      if (lookahead == 'L') ADVANCE(164);
+      if (lookahead == 'M') ADVANCE(292);
       END_STATE();
     case 110:
-      if (lookahead == 'L') ADVANCE(451);
+      if (lookahead == 'N') ADVANCE(468);
       END_STATE();
     case 111:
-      if (lookahead == 'M') ADVANCE(294);
+      if (lookahead == 'N') ADVANCE(252);
       END_STATE();
     case 112:
-      if (lookahead == 'N') ADVANCE(470);
+      if (lookahead == 'N') ADVANCE(469);
       END_STATE();
     case 113:
-      if (lookahead == 'N') ADVANCE(254);
+      if (lookahead == 'N') ADVANCE(470);
       END_STATE();
     case 114:
-      if (lookahead == 'N') ADVANCE(471);
+      if (lookahead == 'O') ADVANCE(554);
       END_STATE();
     case 115:
-      if (lookahead == 'N') ADVANCE(472);
+      if (lookahead == 'P') ADVANCE(28);
       END_STATE();
     case 116:
-      if (lookahead == 'O') ADVANCE(556);
+      if (lookahead == 'P') ADVANCE(304);
       END_STATE();
     case 117:
-      if (lookahead == 'P') ADVANCE(30);
+      if (lookahead == 'P') ADVANCE(508);
       END_STATE();
     case 118:
-      if (lookahead == 'P') ADVANCE(306);
+      if (lookahead == 'P') ADVANCE(511);
       END_STATE();
     case 119:
-      if (lookahead == 'P') ADVANCE(510);
+      if (lookahead == 'R') ADVANCE(103);
+      if (lookahead == 'n') ADVANCE(144);
+      if (lookahead == 'p') ADVANCE(312);
+      if (lookahead == 's') ADVANCE(255);
       END_STATE();
     case 120:
-      if (lookahead == 'P') ADVANCE(513);
+      if (lookahead == 'R') ADVANCE(235);
       END_STATE();
     case 121:
-      if (lookahead == 'R') ADVANCE(105);
-      if (lookahead == 'n') ADVANCE(146);
-      if (lookahead == 'p') ADVANCE(314);
-      if (lookahead == 's') ADVANCE(257);
+      if (lookahead == 'R') ADVANCE(238);
       END_STATE();
     case 122:
-      if (lookahead == 'R') ADVANCE(237);
+      if (lookahead == 'R') ADVANCE(303);
       END_STATE();
     case 123:
-      if (lookahead == 'R') ADVANCE(240);
+      if (lookahead == 'R') ADVANCE(271);
       END_STATE();
     case 124:
-      if (lookahead == 'R') ADVANCE(305);
+      if (lookahead == 'R') ADVANCE(300);
       END_STATE();
     case 125:
-      if (lookahead == 'R') ADVANCE(273);
+      if (lookahead == 'R') ADVANCE(296);
       END_STATE();
     case 126:
-      if (lookahead == 'R') ADVANCE(302);
+      if (lookahead == 'S') ADVANCE(590);
       END_STATE();
     case 127:
-      if (lookahead == 'R') ADVANCE(298);
+      if (lookahead == 'S') ADVANCE(270);
       END_STATE();
     case 128:
-      if (lookahead == 'S') ADVANCE(592);
+      if (lookahead == 'S') ADVANCE(564);
       END_STATE();
     case 129:
-      if (lookahead == 'S') ADVANCE(272);
+      if (lookahead == 'S') ADVANCE(174);
       END_STATE();
     case 130:
-      if (lookahead == 'S') ADVANCE(566);
+      if (lookahead == 'S') ADVANCE(613);
       END_STATE();
     case 131:
-      if (lookahead == 'S') ADVANCE(176);
+      if (lookahead == 'T') ADVANCE(115);
       END_STATE();
     case 132:
-      if (lookahead == 'S') ADVANCE(615);
+      if (lookahead == 'T') ADVANCE(131);
       END_STATE();
     case 133:
-      if (lookahead == 'T') ADVANCE(117);
+      if (lookahead == 'T') ADVANCE(631);
       END_STATE();
     case 134:
-      if (lookahead == 'T') ADVANCE(133);
+      if (lookahead == 'T') ADVANCE(458);
       END_STATE();
     case 135:
-      if (lookahead == 'T') ADVANCE(633);
+      if (lookahead == 'T') ADVANCE(347);
       END_STATE();
     case 136:
-      if (lookahead == 'T') ADVANCE(460);
+      if (lookahead == 'T') ADVANCE(463);
       END_STATE();
     case 137:
-      if (lookahead == 'T') ADVANCE(349);
+      if (lookahead == 'U') ADVANCE(536);
       END_STATE();
     case 138:
-      if (lookahead == 'T') ADVANCE(465);
+      if (lookahead == 'U') ADVANCE(412);
       END_STATE();
     case 139:
-      if (lookahead == 'U') ADVANCE(538);
+      if (lookahead == 'V') ADVANCE(260);
       END_STATE();
     case 140:
-      if (lookahead == 'U') ADVANCE(414);
+      if (lookahead == 'a') ADVANCE(211);
       END_STATE();
     case 141:
-      if (lookahead == 'V') ADVANCE(262);
+      if (lookahead == 'a') ADVANCE(329);
+      if (lookahead == 'o') ADVANCE(497);
       END_STATE();
     case 142:
-      if (lookahead == 'a') ADVANCE(213);
+      if (lookahead == 'a') ADVANCE(556);
+      if (lookahead == 'o') ADVANCE(407);
       END_STATE();
     case 143:
-      if (lookahead == 'a') ADVANCE(331);
-      if (lookahead == 'o') ADVANCE(499);
+      if (lookahead == 'a') ADVANCE(502);
+      if (lookahead == 'e') ADVANCE(500);
+      if (lookahead == 'r') ADVANCE(240);
       END_STATE();
     case 144:
-      if (lookahead == 'a') ADVANCE(558);
-      if (lookahead == 'o') ADVANCE(409);
+      if (lookahead == 'a') ADVANCE(607);
+      if (lookahead == 'p') ADVANCE(503);
+      if (lookahead == 's') ADVANCE(601);
       END_STATE();
     case 145:
-      if (lookahead == 'a') ADVANCE(504);
-      if (lookahead == 'e') ADVANCE(502);
-      if (lookahead == 'r') ADVANCE(242);
+      if (lookahead == 'a') ADVANCE(187);
       END_STATE();
     case 146:
-      if (lookahead == 'a') ADVANCE(609);
-      if (lookahead == 'p') ADVANCE(505);
-      if (lookahead == 's') ADVANCE(603);
+      if (lookahead == 'a') ADVANCE(627);
       END_STATE();
     case 147:
-      if (lookahead == 'a') ADVANCE(189);
+      if (lookahead == 'a') ADVANCE(369);
       END_STATE();
     case 148:
-      if (lookahead == 'a') ADVANCE(629);
+      if (lookahead == 'a') ADVANCE(618);
       END_STATE();
     case 149:
-      if (lookahead == 'a') ADVANCE(371);
+      if (lookahead == 'a') ADVANCE(499);
       END_STATE();
     case 150:
-      if (lookahead == 'a') ADVANCE(620);
-      END_STATE();
-    case 151:
-      if (lookahead == 'a') ADVANCE(501);
-      END_STATE();
-    case 152:
-      if (lookahead == 'a') ADVANCE(224);
-      END_STATE();
-    case 153:
-      if (lookahead == 'a') ADVANCE(405);
-      if (lookahead == 'e') ADVANCE(494);
-      END_STATE();
-    case 154:
-      if (lookahead == 'a') ADVANCE(227);
-      END_STATE();
-    case 155:
-      if (lookahead == 'a') ADVANCE(315);
-      END_STATE();
-    case 156:
-      if (lookahead == 'a') ADVANCE(382);
-      END_STATE();
-    case 157:
-      if (lookahead == 'a') ADVANCE(483);
-      END_STATE();
-    case 158:
-      if (lookahead == 'a') ADVANCE(509);
-      END_STATE();
-    case 159:
-      if (lookahead == 'a') ADVANCE(61);
-      END_STATE();
-    case 160:
-      if (lookahead == 'a') ADVANCE(433);
-      END_STATE();
-    case 161:
-      if (lookahead == 'a') ADVANCE(528);
-      END_STATE();
-    case 162:
-      if (lookahead == 'a') ADVANCE(560);
-      END_STATE();
-    case 163:
-      if (lookahead == 'a') ADVANCE(546);
-      END_STATE();
-    case 164:
-      if (lookahead == 'a') ADVANCE(506);
-      END_STATE();
-    case 165:
-      if (lookahead == 'a') ADVANCE(60);
-      END_STATE();
-    case 166:
-      if (lookahead == 'a') ADVANCE(336);
-      END_STATE();
-    case 167:
-      if (lookahead == 'a') ADVANCE(564);
-      END_STATE();
-    case 168:
-      if (lookahead == 'a') ADVANCE(432);
-      END_STATE();
-    case 169:
-      if (lookahead == 'a') ADVANCE(188);
-      END_STATE();
-    case 170:
-      if (lookahead == 'a') ADVANCE(565);
-      END_STATE();
-    case 171:
-      if (lookahead == 'a') ADVANCE(384);
-      END_STATE();
-    case 172:
-      if (lookahead == 'a') ADVANCE(631);
-      END_STATE();
-    case 173:
-      if (lookahead == 'a') ADVANCE(419);
-      END_STATE();
-    case 174:
-      if (lookahead == 'a') ADVANCE(386);
-      END_STATE();
-    case 175:
       if (lookahead == 'a') ADVANCE(222);
       END_STATE();
+    case 151:
+      if (lookahead == 'a') ADVANCE(403);
+      if (lookahead == 'e') ADVANCE(492);
+      END_STATE();
+    case 152:
+      if (lookahead == 'a') ADVANCE(225);
+      END_STATE();
+    case 153:
+      if (lookahead == 'a') ADVANCE(313);
+      END_STATE();
+    case 154:
+      if (lookahead == 'a') ADVANCE(380);
+      END_STATE();
+    case 155:
+      if (lookahead == 'a') ADVANCE(481);
+      END_STATE();
+    case 156:
+      if (lookahead == 'a') ADVANCE(507);
+      END_STATE();
+    case 157:
+      if (lookahead == 'a') ADVANCE(59);
+      END_STATE();
+    case 158:
+      if (lookahead == 'a') ADVANCE(431);
+      END_STATE();
+    case 159:
+      if (lookahead == 'a') ADVANCE(526);
+      END_STATE();
+    case 160:
+      if (lookahead == 'a') ADVANCE(558);
+      END_STATE();
+    case 161:
+      if (lookahead == 'a') ADVANCE(544);
+      END_STATE();
+    case 162:
+      if (lookahead == 'a') ADVANCE(504);
+      END_STATE();
+    case 163:
+      if (lookahead == 'a') ADVANCE(58);
+      END_STATE();
+    case 164:
+      if (lookahead == 'a') ADVANCE(334);
+      END_STATE();
+    case 165:
+      if (lookahead == 'a') ADVANCE(562);
+      END_STATE();
+    case 166:
+      if (lookahead == 'a') ADVANCE(430);
+      END_STATE();
+    case 167:
+      if (lookahead == 'a') ADVANCE(186);
+      END_STATE();
+    case 168:
+      if (lookahead == 'a') ADVANCE(563);
+      END_STATE();
+    case 169:
+      if (lookahead == 'a') ADVANCE(382);
+      END_STATE();
+    case 170:
+      if (lookahead == 'a') ADVANCE(629);
+      END_STATE();
+    case 171:
+      if (lookahead == 'a') ADVANCE(417);
+      END_STATE();
+    case 172:
+      if (lookahead == 'a') ADVANCE(384);
+      END_STATE();
+    case 173:
+      if (lookahead == 'a') ADVANCE(220);
+      END_STATE();
+    case 174:
+      if (lookahead == 'a') ADVANCE(570);
+      END_STATE();
+    case 175:
+      if (lookahead == 'a') ADVANCE(229);
+      END_STATE();
     case 176:
-      if (lookahead == 'a') ADVANCE(572);
+      if (lookahead == 'a') ADVANCE(571);
       END_STATE();
     case 177:
-      if (lookahead == 'a') ADVANCE(231);
+      if (lookahead == 'a') ADVANCE(578);
       END_STATE();
     case 178:
-      if (lookahead == 'a') ADVANCE(573);
+      if (lookahead == 'a') ADVANCE(355);
       END_STATE();
     case 179:
-      if (lookahead == 'a') ADVANCE(580);
+      if (lookahead == 'a') ADVANCE(584);
       END_STATE();
     case 180:
-      if (lookahead == 'a') ADVANCE(357);
+      if (lookahead == 'a') ADVANCE(427);
       END_STATE();
     case 181:
-      if (lookahead == 'a') ADVANCE(586);
+      if (lookahead == 'a') ADVANCE(361);
       END_STATE();
     case 182:
-      if (lookahead == 'a') ADVANCE(429);
+      if (lookahead == 'a') ADVANCE(188);
       END_STATE();
     case 183:
-      if (lookahead == 'a') ADVANCE(363);
+      if (lookahead == 'a') ADVANCE(597);
       END_STATE();
     case 184:
-      if (lookahead == 'a') ADVANCE(190);
+      if (lookahead == 'a') ADVANCE(598);
       END_STATE();
     case 185:
-      if (lookahead == 'a') ADVANCE(599);
+      if (lookahead == 'b') ADVANCE(330);
       END_STATE();
     case 186:
-      if (lookahead == 'a') ADVANCE(600);
+      if (lookahead == 'b') ADVANCE(372);
       END_STATE();
     case 187:
-      if (lookahead == 'b') ADVANCE(332);
+      if (lookahead == 'b') ADVANCE(387);
       END_STATE();
     case 188:
-      if (lookahead == 'b') ADVANCE(374);
+      if (lookahead == 'b') ADVANCE(388);
       END_STATE();
     case 189:
-      if (lookahead == 'b') ADVANCE(389);
+      if (lookahead == 'c') ADVANCE(476);
       END_STATE();
     case 190:
-      if (lookahead == 'b') ADVANCE(390);
+      if (lookahead == 'c') ADVANCE(365);
+      if (lookahead == 'o') ADVANCE(480);
       END_STATE();
     case 191:
-      if (lookahead == 'c') ADVANCE(478);
+      if (lookahead == 'c') ADVANCE(194);
+      if (lookahead == 'l') ADVANCE(501);
       END_STATE();
     case 192:
-      if (lookahead == 'c') ADVANCE(367);
-      if (lookahead == 'o') ADVANCE(482);
+      if (lookahead == 'c') ADVANCE(477);
       END_STATE();
     case 193:
-      if (lookahead == 'c') ADVANCE(196);
-      if (lookahead == 'l') ADVANCE(503);
+      if (lookahead == 'c') ADVANCE(627);
       END_STATE();
     case 194:
-      if (lookahead == 'c') ADVANCE(479);
+      if (lookahead == 'c') ADVANCE(250);
       END_STATE();
     case 195:
-      if (lookahead == 'c') ADVANCE(629);
+      if (lookahead == 'c') ADVANCE(319);
       END_STATE();
     case 196:
-      if (lookahead == 'c') ADVANCE(252);
+      if (lookahead == 'c') ADVANCE(561);
       END_STATE();
     case 197:
-      if (lookahead == 'c') ADVANCE(321);
+      if (lookahead == 'c') ADVANCE(549);
       END_STATE();
     case 198:
-      if (lookahead == 'c') ADVANCE(563);
+      if (lookahead == 'c') ADVANCE(364);
       END_STATE();
     case 199:
-      if (lookahead == 'c') ADVANCE(551);
+      if (lookahead == 'c') ADVANCE(247);
+      if (lookahead == 'x') ADVANCE(628);
       END_STATE();
     case 200:
-      if (lookahead == 'c') ADVANCE(366);
+      if (lookahead == 'c') ADVANCE(465);
       END_STATE();
     case 201:
-      if (lookahead == 'c') ADVANCE(249);
-      if (lookahead == 'x') ADVANCE(630);
+      if (lookahead == 'c') ADVANCE(282);
       END_STATE();
     case 202:
-      if (lookahead == 'c') ADVANCE(467);
-      END_STATE();
-    case 203:
-      if (lookahead == 'c') ADVANCE(284);
-      END_STATE();
-    case 204:
-      if (lookahead == 'c') ADVANCE(261);
-      END_STATE();
-    case 205:
-      if (lookahead == 'c') ADVANCE(564);
-      END_STATE();
-    case 206:
       if (lookahead == 'c') ADVANCE(259);
       END_STATE();
+    case 203:
+      if (lookahead == 'c') ADVANCE(562);
+      END_STATE();
+    case 204:
+      if (lookahead == 'c') ADVANCE(257);
+      END_STATE();
+    case 205:
+      if (lookahead == 'c') ADVANCE(441);
+      END_STATE();
+    case 206:
+      if (lookahead == 'c') ADVANCE(286);
+      END_STATE();
     case 207:
-      if (lookahead == 'c') ADVANCE(443);
+      if (lookahead == 'c') ADVANCE(593);
       END_STATE();
     case 208:
-      if (lookahead == 'c') ADVANCE(288);
+      if (lookahead == 'c') ADVANCE(204);
       END_STATE();
     case 209:
-      if (lookahead == 'c') ADVANCE(595);
+      if (lookahead == 'c') ADVANCE(183);
       END_STATE();
     case 210:
-      if (lookahead == 'c') ADVANCE(206);
+      if (lookahead == 'd') ADVANCE(661);
       END_STATE();
     case 211:
-      if (lookahead == 'c') ADVANCE(185);
+      if (lookahead == 'd') ADVANCE(24);
       END_STATE();
     case 212:
-      if (lookahead == 'd') ADVANCE(665);
+      if (lookahead == 'd') ADVANCE(344);
       END_STATE();
     case 213:
-      if (lookahead == 'd') ADVANCE(26);
+      if (lookahead == 'd') ADVANCE(218);
       END_STATE();
     case 214:
-      if (lookahead == 'd') ADVANCE(346);
+      if (lookahead == 'd') ADVANCE(345);
       END_STATE();
     case 215:
-      if (lookahead == 'd') ADVANCE(220);
+      if (lookahead == 'd') ADVANCE(51);
       END_STATE();
     case 216:
-      if (lookahead == 'd') ADVANCE(347);
+      if (lookahead == 'd') ADVANCE(241);
       END_STATE();
     case 217:
-      if (lookahead == 'd') ADVANCE(53);
+      if (lookahead == 'd') ADVANCE(546);
       END_STATE();
     case 218:
-      if (lookahead == 'd') ADVANCE(243);
+      if (lookahead == 'd') ADVANCE(263);
       END_STATE();
     case 219:
-      if (lookahead == 'd') ADVANCE(548);
+      if (lookahead == 'd') ADVANCE(35);
       END_STATE();
     case 220:
-      if (lookahead == 'd') ADVANCE(265);
+      if (lookahead == 'd') ADVANCE(272);
       END_STATE();
     case 221:
-      if (lookahead == 'd') ADVANCE(37);
+      if (lookahead == 'd') ADVANCE(275);
       END_STATE();
     case 222:
-      if (lookahead == 'd') ADVANCE(274);
+      if (lookahead == 'd') ADVANCE(630);
       END_STATE();
     case 223:
-      if (lookahead == 'd') ADVANCE(277);
+      if (lookahead == 'd') ADVANCE(362);
       END_STATE();
     case 224:
-      if (lookahead == 'd') ADVANCE(632);
+      if (lookahead == 'd') ADVANCE(61);
       END_STATE();
     case 225:
-      if (lookahead == 'd') ADVANCE(364);
+      if (lookahead == 'd') ADVANCE(269);
       END_STATE();
     case 226:
-      if (lookahead == 'd') ADVANCE(63);
+      if (lookahead == 'd') ADVANCE(348);
       END_STATE();
     case 227:
-      if (lookahead == 'd') ADVANCE(271);
+      if (lookahead == 'd') ADVANCE(68);
       END_STATE();
     case 228:
-      if (lookahead == 'd') ADVANCE(350);
+      if (lookahead == 'd') ADVANCE(354);
       END_STATE();
     case 229:
       if (lookahead == 'd') ADVANCE(70);
       END_STATE();
     case 230:
-      if (lookahead == 'd') ADVANCE(356);
+      if (lookahead == 'd') ADVANCE(69);
       END_STATE();
     case 231:
-      if (lookahead == 'd') ADVANCE(72);
+      if (lookahead == 'e') ADVANCE(661);
       END_STATE();
     case 232:
-      if (lookahead == 'd') ADVANCE(71);
+      if (lookahead == 'e') ADVANCE(248);
+      if (lookahead == 'w') ADVANCE(332);
       END_STATE();
     case 233:
-      if (lookahead == 'e') ADVANCE(665);
+      if (lookahead == 'e') ADVANCE(718);
       END_STATE();
     case 234:
-      if (lookahead == 'e') ADVANCE(250);
-      if (lookahead == 'w') ADVANCE(334);
+      if (lookahead == 'e') ADVANCE(720);
       END_STATE();
     case 235:
-      if (lookahead == 'e') ADVANCE(725);
-      END_STATE();
-    case 236:
-      if (lookahead == 'e') ADVANCE(727);
-      END_STATE();
-    case 237:
-      if (lookahead == 'e') ADVANCE(495);
-      END_STATE();
-    case 238:
-      if (lookahead == 'e') ADVANCE(552);
-      if (lookahead == 'i') ADVANCE(534);
-      if (lookahead == 'o') ADVANCE(617);
-      if (lookahead == 'u') ADVANCE(372);
-      END_STATE();
-    case 239:
-      if (lookahead == 'e') ADVANCE(622);
-      END_STATE();
-    case 240:
       if (lookahead == 'e') ADVANCE(493);
       END_STATE();
+    case 236:
+      if (lookahead == 'e') ADVANCE(550);
+      if (lookahead == 'i') ADVANCE(532);
+      if (lookahead == 'o') ADVANCE(615);
+      if (lookahead == 'u') ADVANCE(370);
+      END_STATE();
+    case 237:
+      if (lookahead == 'e') ADVANCE(620);
+      END_STATE();
+    case 238:
+      if (lookahead == 'e') ADVANCE(491);
+      END_STATE();
+    case 239:
+      if (lookahead == 'e') ADVANCE(392);
+      if (lookahead == 'o') ADVANCE(437);
+      END_STATE();
+    case 240:
+      if (lookahead == 'e') ADVANCE(205);
+      if (lookahead == 'o') ADVANCE(199);
+      END_STATE();
     case 241:
-      if (lookahead == 'e') ADVANCE(394);
-      if (lookahead == 'o') ADVANCE(439);
+      if (lookahead == 'e') ADVANCE(210);
       END_STATE();
     case 242:
-      if (lookahead == 'e') ADVANCE(207);
-      if (lookahead == 'o') ADVANCE(201);
+      if (lookahead == 'e') ADVANCE(401);
+      if (lookahead == 'o') ADVANCE(190);
       END_STATE();
     case 243:
-      if (lookahead == 'e') ADVANCE(212);
+      if (lookahead == 'e') ADVANCE(551);
+      if (lookahead == 'o') ADVANCE(23);
       END_STATE();
     case 244:
-      if (lookahead == 'e') ADVANCE(403);
-      if (lookahead == 'o') ADVANCE(192);
+      if (lookahead == 'e') ADVANCE(196);
       END_STATE();
     case 245:
-      if (lookahead == 'e') ADVANCE(553);
-      if (lookahead == 'o') ADVANCE(25);
+      if (lookahead == 'e') ADVANCE(165);
       END_STATE();
     case 246:
-      if (lookahead == 'e') ADVANCE(198);
+      if (lookahead == 'e') ADVANCE(395);
       END_STATE();
     case 247:
-      if (lookahead == 'e') ADVANCE(167);
+      if (lookahead == 'e') ADVANCE(534);
       END_STATE();
     case 248:
-      if (lookahead == 'e') ADVANCE(397);
+      if (lookahead == 'e') ADVANCE(26);
+      if (lookahead == 'r') ADVANCE(614);
       END_STATE();
     case 249:
-      if (lookahead == 'e') ADVANCE(536);
+      if (lookahead == 'e') ADVANCE(542);
       END_STATE();
     case 250:
-      if (lookahead == 'e') ADVANCE(28);
-      if (lookahead == 'r') ADVANCE(616);
+      if (lookahead == 'e') ADVANCE(482);
       END_STATE();
     case 251:
-      if (lookahead == 'e') ADVANCE(544);
+      if (lookahead == 'e') ADVANCE(505);
       END_STATE();
     case 252:
-      if (lookahead == 'e') ADVANCE(484);
+      if (lookahead == 'e') ADVANCE(315);
       END_STATE();
     case 253:
-      if (lookahead == 'e') ADVANCE(507);
+      if (lookahead == 'e') ADVANCE(207);
       END_STATE();
     case 254:
-      if (lookahead == 'e') ADVANCE(317);
+      if (lookahead == 'e') ADVANCE(565);
       END_STATE();
     case 255:
-      if (lookahead == 'e') ADVANCE(209);
-      END_STATE();
-    case 256:
-      if (lookahead == 'e') ADVANCE(567);
-      END_STATE();
-    case 257:
-      if (lookahead == 'e') ADVANCE(41);
-      END_STATE();
-    case 258:
-      if (lookahead == 'e') ADVANCE(319);
-      END_STATE();
-    case 259:
-      if (lookahead == 'e') ADVANCE(487);
-      END_STATE();
-    case 260:
-      if (lookahead == 'e') ADVANCE(422);
-      END_STATE();
-    case 261:
-      if (lookahead == 'e') ADVANCE(533);
-      END_STATE();
-    case 262:
-      if (lookahead == 'e') ADVANCE(508);
-      END_STATE();
-    case 263:
-      if (lookahead == 'e') ADVANCE(375);
-      END_STATE();
-    case 264:
-      if (lookahead == 'e') ADVANCE(157);
-      END_STATE();
-    case 265:
-      if (lookahead == 'e') ADVANCE(401);
-      END_STATE();
-    case 266:
-      if (lookahead == 'e') ADVANCE(32);
-      END_STATE();
-    case 267:
-      if (lookahead == 'e') ADVANCE(412);
-      END_STATE();
-    case 268:
-      if (lookahead == 'e') ADVANCE(463);
-      END_STATE();
-    case 269:
-      if (lookahead == 'e') ADVANCE(497);
-      END_STATE();
-    case 270:
-      if (lookahead == 'e') ADVANCE(421);
-      END_STATE();
-    case 271:
-      if (lookahead == 'e') ADVANCE(33);
-      END_STATE();
-    case 272:
-      if (lookahead == 'e') ADVANCE(521);
-      END_STATE();
-    case 273:
-      if (lookahead == 'e') ADVANCE(163);
-      END_STATE();
-    case 274:
-      if (lookahead == 'e') ADVANCE(517);
-      END_STATE();
-    case 275:
-      if (lookahead == 'e') ADVANCE(427);
-      END_STATE();
-    case 276:
-      if (lookahead == 'e') ADVANCE(415);
-      END_STATE();
-    case 277:
-      if (lookahead == 'e') ADVANCE(410);
-      END_STATE();
-    case 278:
-      if (lookahead == 'e') ADVANCE(44);
-      END_STATE();
-    case 279:
-      if (lookahead == 'e') ADVANCE(50);
-      END_STATE();
-    case 280:
       if (lookahead == 'e') ADVANCE(39);
       END_STATE();
+    case 256:
+      if (lookahead == 'e') ADVANCE(317);
+      END_STATE();
+    case 257:
+      if (lookahead == 'e') ADVANCE(485);
+      END_STATE();
+    case 258:
+      if (lookahead == 'e') ADVANCE(420);
+      END_STATE();
+    case 259:
+      if (lookahead == 'e') ADVANCE(531);
+      END_STATE();
+    case 260:
+      if (lookahead == 'e') ADVANCE(506);
+      END_STATE();
+    case 261:
+      if (lookahead == 'e') ADVANCE(373);
+      END_STATE();
+    case 262:
+      if (lookahead == 'e') ADVANCE(155);
+      END_STATE();
+    case 263:
+      if (lookahead == 'e') ADVANCE(399);
+      END_STATE();
+    case 264:
+      if (lookahead == 'e') ADVANCE(30);
+      END_STATE();
+    case 265:
+      if (lookahead == 'e') ADVANCE(410);
+      END_STATE();
+    case 266:
+      if (lookahead == 'e') ADVANCE(461);
+      END_STATE();
+    case 267:
+      if (lookahead == 'e') ADVANCE(495);
+      END_STATE();
+    case 268:
+      if (lookahead == 'e') ADVANCE(419);
+      END_STATE();
+    case 269:
+      if (lookahead == 'e') ADVANCE(31);
+      END_STATE();
+    case 270:
+      if (lookahead == 'e') ADVANCE(519);
+      END_STATE();
+    case 271:
+      if (lookahead == 'e') ADVANCE(161);
+      END_STATE();
+    case 272:
+      if (lookahead == 'e') ADVANCE(515);
+      END_STATE();
+    case 273:
+      if (lookahead == 'e') ADVANCE(425);
+      END_STATE();
+    case 274:
+      if (lookahead == 'e') ADVANCE(413);
+      END_STATE();
+    case 275:
+      if (lookahead == 'e') ADVANCE(408);
+      END_STATE();
+    case 276:
+      if (lookahead == 'e') ADVANCE(42);
+      END_STATE();
+    case 277:
+      if (lookahead == 'e') ADVANCE(48);
+      END_STATE();
+    case 278:
+      if (lookahead == 'e') ADVANCE(37);
+      END_STATE();
+    case 279:
+      if (lookahead == 'e') ADVANCE(38);
+      END_STATE();
+    case 280:
+      if (lookahead == 'e') ADVANCE(150);
+      END_STATE();
     case 281:
-      if (lookahead == 'e') ADVANCE(40);
+      if (lookahead == 'e') ADVANCE(215);
       END_STATE();
     case 282:
-      if (lookahead == 'e') ADVANCE(152);
+      if (lookahead == 'e') ADVANCE(41);
       END_STATE();
     case 283:
-      if (lookahead == 'e') ADVANCE(217);
+      if (lookahead == 'e') ADVANCE(622);
       END_STATE();
     case 284:
-      if (lookahead == 'e') ADVANCE(43);
+      if (lookahead == 'e') ADVANCE(488);
       END_STATE();
     case 285:
-      if (lookahead == 'e') ADVANCE(624);
+      if (lookahead == 'e') ADVANCE(197);
       END_STATE();
     case 286:
-      if (lookahead == 'e') ADVANCE(490);
+      if (lookahead == 'e') ADVANCE(535);
       END_STATE();
     case 287:
-      if (lookahead == 'e') ADVANCE(199);
-      END_STATE();
-    case 288:
       if (lookahead == 'e') ADVANCE(537);
       END_STATE();
+    case 288:
+      if (lookahead == 'e') ADVANCE(516);
+      END_STATE();
     case 289:
-      if (lookahead == 'e') ADVANCE(539);
+      if (lookahead == 'e') ADVANCE(224);
       END_STATE();
     case 290:
-      if (lookahead == 'e') ADVANCE(518);
+      if (lookahead == 'e') ADVANCE(539);
       END_STATE();
     case 291:
-      if (lookahead == 'e') ADVANCE(226);
+      if (lookahead == 'e') ADVANCE(173);
       END_STATE();
     case 292:
-      if (lookahead == 'e') ADVANCE(541);
+      if (lookahead == 'e') ADVANCE(226);
       END_STATE();
     case 293:
-      if (lookahead == 'e') ADVANCE(175);
+      if (lookahead == 'e') ADVANCE(591);
       END_STATE();
     case 294:
-      if (lookahead == 'e') ADVANCE(228);
+      if (lookahead == 'e') ADVANCE(227);
       END_STATE();
     case 295:
-      if (lookahead == 'e') ADVANCE(593);
+      if (lookahead == 'e') ADVANCE(219);
       END_STATE();
     case 296:
-      if (lookahead == 'e') ADVANCE(229);
+      if (lookahead == 'e') ADVANCE(494);
       END_STATE();
     case 297:
-      if (lookahead == 'e') ADVANCE(221);
+      if (lookahead == 'e') ADVANCE(203);
       END_STATE();
     case 298:
-      if (lookahead == 'e') ADVANCE(496);
+      if (lookahead == 'e') ADVANCE(418);
       END_STATE();
     case 299:
-      if (lookahead == 'e') ADVANCE(205);
+      if (lookahead == 'e') ADVANCE(426);
       END_STATE();
     case 300:
-      if (lookahead == 'e') ADVANCE(420);
+      if (lookahead == 'e') ADVANCE(489);
       END_STATE();
     case 301:
       if (lookahead == 'e') ADVANCE(428);
       END_STATE();
     case 302:
-      if (lookahead == 'e') ADVANCE(491);
+      if (lookahead == 'e') ADVANCE(429);
       END_STATE();
     case 303:
-      if (lookahead == 'e') ADVANCE(430);
+      if (lookahead == 'e') ADVANCE(228);
       END_STATE();
     case 304:
-      if (lookahead == 'e') ADVANCE(431);
+      if (lookahead == 'e') ADVANCE(527);
       END_STATE();
     case 305:
-      if (lookahead == 'e') ADVANCE(230);
+      if (lookahead == 'f') ADVANCE(307);
       END_STATE();
     case 306:
-      if (lookahead == 'e') ADVANCE(529);
+      if (lookahead == 'f') ADVANCE(374);
+      if (lookahead == 't') ADVANCE(331);
       END_STATE();
     case 307:
-      if (lookahead == 'f') ADVANCE(309);
+      if (lookahead == 'f') ADVANCE(333);
       END_STATE();
     case 308:
-      if (lookahead == 'f') ADVANCE(376);
-      if (lookahead == 't') ADVANCE(333);
+      if (lookahead == 'f') ADVANCE(339);
       END_STATE();
     case 309:
-      if (lookahead == 'f') ADVANCE(335);
+      if (lookahead == 'f') ADVANCE(472);
       END_STATE();
     case 310:
-      if (lookahead == 'f') ADVANCE(341);
+      if (lookahead == 'f') ADVANCE(349);
       END_STATE();
     case 311:
-      if (lookahead == 'f') ADVANCE(474);
+      if (lookahead == 'g') ADVANCE(661);
       END_STATE();
     case 312:
-      if (lookahead == 'f') ADVANCE(351);
+      if (lookahead == 'g') ADVANCE(522);
       END_STATE();
     case 313:
-      if (lookahead == 'g') ADVANCE(665);
+      if (lookahead == 'g') ADVANCE(231);
       END_STATE();
     case 314:
-      if (lookahead == 'g') ADVANCE(524);
+      if (lookahead == 'g') ADVANCE(552);
       END_STATE();
     case 315:
-      if (lookahead == 'g') ADVANCE(233);
+      if (lookahead == 'g') ADVANCE(473);
       END_STATE();
     case 316:
-      if (lookahead == 'g') ADVANCE(554);
+      if (lookahead == 'g') ADVANCE(264);
       END_STATE();
     case 317:
-      if (lookahead == 'g') ADVANCE(475);
+      if (lookahead == 'g') ADVANCE(172);
       END_STATE();
     case 318:
-      if (lookahead == 'g') ADVANCE(266);
+      if (lookahead == 'g') ADVANCE(67);
       END_STATE();
     case 319:
-      if (lookahead == 'g') ADVANCE(174);
+      if (lookahead == 'h') ADVANCE(40);
       END_STATE();
     case 320:
-      if (lookahead == 'g') ADVANCE(69);
+      if (lookahead == 'h') ADVANCE(467);
       END_STATE();
     case 321:
-      if (lookahead == 'h') ADVANCE(42);
+      if (lookahead == 'h') ADVANCE(474);
       END_STATE();
     case 322:
-      if (lookahead == 'h') ADVANCE(469);
+      if (lookahead == 'h') ADVANCE(31);
       END_STATE();
     case 323:
-      if (lookahead == 'h') ADVANCE(476);
+      if (lookahead == 'h') ADVANCE(267);
       END_STATE();
     case 324:
-      if (lookahead == 'h') ADVANCE(33);
+      if (lookahead == 'h') ADVANCE(273);
       END_STATE();
     case 325:
-      if (lookahead == 'h') ADVANCE(269);
+      if (lookahead == 'h') ADVANCE(443);
       END_STATE();
     case 326:
-      if (lookahead == 'h') ADVANCE(275);
+      if (lookahead == 'h') ADVANCE(448);
       END_STATE();
     case 327:
-      if (lookahead == 'h') ADVANCE(445);
+      if (lookahead == 'i') ADVANCE(79);
       END_STATE();
     case 328:
-      if (lookahead == 'h') ADVANCE(450);
+      if (lookahead == 'i') ADVANCE(634);
       END_STATE();
     case 329:
-      if (lookahead == 'i') ADVANCE(81);
+      if (lookahead == 'i') ADVANCE(389);
       END_STATE();
     case 330:
-      if (lookahead == 'i') ADVANCE(636);
+      if (lookahead == 'i') ADVANCE(213);
       END_STATE();
     case 331:
-      if (lookahead == 'i') ADVANCE(391);
+      if (lookahead == 'i') ADVANCE(423);
       END_STATE();
     case 332:
-      if (lookahead == 'i') ADVANCE(215);
-      END_STATE();
-    case 333:
-      if (lookahead == 'i') ADVANCE(425);
-      END_STATE();
-    case 334:
-      if (lookahead == 'i') ADVANCE(557);
-      END_STATE();
-    case 335:
-      if (lookahead == 'i') ADVANCE(200);
-      END_STATE();
-    case 336:
-      if (lookahead == 'i') ADVANCE(380);
-      END_STATE();
-    case 337:
-      if (lookahead == 'i') ADVANCE(182);
-      END_STATE();
-    case 338:
-      if (lookahead == 'i') ADVANCE(211);
-      END_STATE();
-    case 339:
-      if (lookahead == 'i') ADVANCE(156);
-      END_STATE();
-    case 340:
-      if (lookahead == 'i') ADVANCE(543);
-      END_STATE();
-    case 341:
-      if (lookahead == 'i') ADVANCE(243);
-      END_STATE();
-    case 342:
-      if (lookahead == 'i') ADVANCE(408);
-      END_STATE();
-    case 343:
       if (lookahead == 'i') ADVANCE(555);
       END_STATE();
+    case 333:
+      if (lookahead == 'i') ADVANCE(198);
+      END_STATE();
+    case 334:
+      if (lookahead == 'i') ADVANCE(378);
+      END_STATE();
+    case 335:
+      if (lookahead == 'i') ADVANCE(180);
+      END_STATE();
+    case 336:
+      if (lookahead == 'i') ADVANCE(209);
+      END_STATE();
+    case 337:
+      if (lookahead == 'i') ADVANCE(154);
+      END_STATE();
+    case 338:
+      if (lookahead == 'i') ADVANCE(541);
+      END_STATE();
+    case 339:
+      if (lookahead == 'i') ADVANCE(241);
+      END_STATE();
+    case 340:
+      if (lookahead == 'i') ADVANCE(406);
+      END_STATE();
+    case 341:
+      if (lookahead == 'i') ADVANCE(553);
+      END_STATE();
+    case 342:
+      if (lookahead == 'i') ADVANCE(261);
+      END_STATE();
+    case 343:
+      if (lookahead == 'i') ADVANCE(201);
+      END_STATE();
     case 344:
-      if (lookahead == 'i') ADVANCE(263);
+      if (lookahead == 'i') ADVANCE(513);
       END_STATE();
     case 345:
-      if (lookahead == 'i') ADVANCE(203);
+      if (lookahead == 'i') ADVANCE(308);
       END_STATE();
     case 346:
-      if (lookahead == 'i') ADVANCE(515);
+      if (lookahead == 'i') ADVANCE(197);
       END_STATE();
     case 347:
-      if (lookahead == 'i') ADVANCE(310);
+      if (lookahead == 'i') ADVANCE(396);
       END_STATE();
     case 348:
-      if (lookahead == 'i') ADVANCE(199);
+      if (lookahead == 'i') ADVANCE(163);
       END_STATE();
     case 349:
-      if (lookahead == 'i') ADVANCE(398);
+      if (lookahead == 'i') ADVANCE(167);
       END_STATE();
     case 350:
-      if (lookahead == 'i') ADVANCE(165);
+      if (lookahead == 'i') ADVANCE(617);
       END_STATE();
     case 351:
-      if (lookahead == 'i') ADVANCE(169);
+      if (lookahead == 'i') ADVANCE(509);
       END_STATE();
     case 352:
-      if (lookahead == 'i') ADVANCE(619);
+      if (lookahead == 'i') ADVANCE(450);
       END_STATE();
     case 353:
-      if (lookahead == 'i') ADVANCE(511);
+      if (lookahead == 'i') ADVANCE(202);
       END_STATE();
     case 354:
-      if (lookahead == 'i') ADVANCE(452);
+      if (lookahead == 'i') ADVANCE(521);
       END_STATE();
     case 355:
-      if (lookahead == 'i') ADVANCE(204);
+      if (lookahead == 'i') ADVANCE(379);
       END_STATE();
     case 356:
-      if (lookahead == 'i') ADVANCE(523);
+      if (lookahead == 'i') ADVANCE(451);
       END_STATE();
     case 357:
-      if (lookahead == 'i') ADVANCE(381);
+      if (lookahead == 'i') ADVANCE(462);
       END_STATE();
     case 358:
-      if (lookahead == 'i') ADVANCE(453);
+      if (lookahead == 'i') ADVANCE(454);
       END_STATE();
     case 359:
-      if (lookahead == 'i') ADVANCE(464);
+      if (lookahead == 'i') ADVANCE(444);
       END_STATE();
     case 360:
-      if (lookahead == 'i') ADVANCE(456);
+      if (lookahead == 'i') ADVANCE(177);
       END_STATE();
     case 361:
-      if (lookahead == 'i') ADVANCE(446);
+      if (lookahead == 'i') ADVANCE(385);
       END_STATE();
     case 362:
-      if (lookahead == 'i') ADVANCE(179);
+      if (lookahead == 'i') ADVANCE(595);
       END_STATE();
     case 363:
-      if (lookahead == 'i') ADVANCE(387);
+      if (lookahead == 'i') ADVANCE(594);
       END_STATE();
     case 364:
-      if (lookahead == 'i') ADVANCE(597);
+      if (lookahead == 'i') ADVANCE(302);
       END_STATE();
     case 365:
-      if (lookahead == 'i') ADVANCE(596);
+      if (lookahead == 'k') ADVANCE(241);
       END_STATE();
     case 366:
-      if (lookahead == 'i') ADVANCE(304);
+      if (lookahead == 'k') ADVANCE(60);
       END_STATE();
     case 367:
-      if (lookahead == 'k') ADVANCE(243);
+      if (lookahead == 'l') ADVANCE(84);
       END_STATE();
     case 368:
-      if (lookahead == 'k') ADVANCE(62);
+      if (lookahead == 'l') ADVANCE(627);
       END_STATE();
     case 369:
-      if (lookahead == 'l') ADVANCE(86);
+      if (lookahead == 'l') ADVANCE(538);
       END_STATE();
     case 370:
-      if (lookahead == 'l') ADVANCE(629);
+      if (lookahead == 'l') ADVANCE(557);
       END_STATE();
     case 371:
-      if (lookahead == 'l') ADVANCE(540);
+      if (lookahead == 'l') ADVANCE(471);
+      if (lookahead == 'm') ADVANCE(258);
       END_STATE();
     case 372:
-      if (lookahead == 'l') ADVANCE(559);
+      if (lookahead == 'l') ADVANCE(231);
       END_STATE();
     case 373:
-      if (lookahead == 'l') ADVANCE(473);
-      if (lookahead == 'm') ADVANCE(260);
+      if (lookahead == 'l') ADVANCE(217);
       END_STATE();
     case 374:
-      if (lookahead == 'l') ADVANCE(233);
+      if (lookahead == 'l') ADVANCE(346);
       END_STATE();
     case 375:
-      if (lookahead == 'l') ADVANCE(219);
+      if (lookahead == 'l') ADVANCE(543);
       END_STATE();
     case 376:
-      if (lookahead == 'l') ADVANCE(348);
+      if (lookahead == 'l') ADVANCE(381);
       END_STATE();
     case 377:
-      if (lookahead == 'l') ADVANCE(545);
+      if (lookahead == 'l') ADVANCE(531);
       END_STATE();
     case 378:
-      if (lookahead == 'l') ADVANCE(383);
+      if (lookahead == 'l') ADVANCE(145);
       END_STATE();
     case 379:
-      if (lookahead == 'l') ADVANCE(533);
+      if (lookahead == 'l') ADVANCE(241);
       END_STATE();
     case 380:
-      if (lookahead == 'l') ADVANCE(147);
+      if (lookahead == 'l') ADVANCE(22);
       END_STATE();
     case 381:
-      if (lookahead == 'l') ADVANCE(243);
+      if (lookahead == 'l') ADVANCE(434);
       END_STATE();
     case 382:
-      if (lookahead == 'l') ADVANCE(24);
+      if (lookahead == 'l') ADVANCE(44);
       END_STATE();
     case 383:
-      if (lookahead == 'l') ADVANCE(436);
+      if (lookahead == 'l') ADVANCE(246);
       END_STATE();
     case 384:
       if (lookahead == 'l') ADVANCE(46);
       END_STATE();
     case 385:
-      if (lookahead == 'l') ADVANCE(248);
+      if (lookahead == 'l') ADVANCE(167);
       END_STATE();
     case 386:
-      if (lookahead == 'l') ADVANCE(48);
+      if (lookahead == 'l') ADVANCE(276);
       END_STATE();
     case 387:
-      if (lookahead == 'l') ADVANCE(169);
+      if (lookahead == 'l') ADVANCE(277);
       END_STATE();
     case 388:
       if (lookahead == 'l') ADVANCE(278);
       END_STATE();
     case 389:
-      if (lookahead == 'l') ADVANCE(279);
+      if (lookahead == 'l') ADVANCE(289);
       END_STATE();
     case 390:
-      if (lookahead == 'l') ADVANCE(280);
+      if (lookahead == 'm') ADVANCE(367);
       END_STATE();
     case 391:
-      if (lookahead == 'l') ADVANCE(291);
+      if (lookahead == 'm') ADVANCE(57);
       END_STATE();
     case 392:
-      if (lookahead == 'm') ADVANCE(369);
+      if (lookahead == 'm') ADVANCE(483);
       END_STATE();
     case 393:
-      if (lookahead == 'm') ADVANCE(59);
+      if (lookahead == 'm') ADVANCE(166);
       END_STATE();
     case 394:
-      if (lookahead == 'm') ADVANCE(485);
+      if (lookahead == 'm') ADVANCE(484);
       END_STATE();
     case 395:
-      if (lookahead == 'm') ADVANCE(168);
+      if (lookahead == 'm') ADVANCE(298);
       END_STATE();
     case 396:
-      if (lookahead == 'm') ADVANCE(486);
+      if (lookahead == 'm') ADVANCE(266);
       END_STATE();
     case 397:
-      if (lookahead == 'm') ADVANCE(300);
+      if (lookahead == 'm') ADVANCE(171);
       END_STATE();
     case 398:
-      if (lookahead == 'm') ADVANCE(268);
+      if (lookahead == 'm') ADVANCE(184);
       END_STATE();
     case 399:
-      if (lookahead == 'm') ADVANCE(173);
+      if (lookahead == 'n') ADVANCE(661);
       END_STATE();
     case 400:
-      if (lookahead == 'm') ADVANCE(186);
+      if (lookahead == 'n') ADVANCE(306);
       END_STATE();
     case 401:
-      if (lookahead == 'n') ADVANCE(665);
+      if (lookahead == 'n') ADVANCE(314);
       END_STATE();
     case 402:
-      if (lookahead == 'n') ADVANCE(308);
+      if (lookahead == 'n') ADVANCE(210);
       END_STATE();
     case 403:
       if (lookahead == 'n') ADVANCE(316);
       END_STATE();
     case 404:
-      if (lookahead == 'n') ADVANCE(212);
+      if (lookahead == 'n') ADVANCE(309);
       END_STATE();
     case 405:
       if (lookahead == 'n') ADVANCE(318);
@@ -2745,1171 +2669,1214 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == 'n') ADVANCE(311);
       END_STATE();
     case 407:
-      if (lookahead == 'n') ADVANCE(320);
+      if (lookahead == 'n') ADVANCE(231);
       END_STATE();
     case 408:
-      if (lookahead == 'n') ADVANCE(313);
+      if (lookahead == 'n') ADVANCE(193);
       END_STATE();
     case 409:
-      if (lookahead == 'n') ADVANCE(233);
+      if (lookahead == 'n') ADVANCE(531);
       END_STATE();
     case 410:
-      if (lookahead == 'n') ADVANCE(195);
+      if (lookahead == 'n') ADVANCE(549);
       END_STATE();
     case 411:
-      if (lookahead == 'n') ADVANCE(533);
+      if (lookahead == 'n') ADVANCE(31);
       END_STATE();
     case 412:
-      if (lookahead == 'n') ADVANCE(551);
+      if (lookahead == 'n') ADVANCE(148);
       END_STATE();
     case 413:
-      if (lookahead == 'n') ADVANCE(33);
+      if (lookahead == 'n') ADVANCE(559);
       END_STATE();
     case 414:
-      if (lookahead == 'n') ADVANCE(150);
+      if (lookahead == 'n') ADVANCE(587);
       END_STATE();
     case 415:
-      if (lookahead == 'n') ADVANCE(561);
+      if (lookahead == 'n') ADVANCE(34);
       END_STATE();
     case 416:
-      if (lookahead == 'n') ADVANCE(589);
-      END_STATE();
-    case 417:
       if (lookahead == 'n') ADVANCE(36);
       END_STATE();
+    case 417:
+      if (lookahead == 'n') ADVANCE(274);
+      END_STATE();
     case 418:
-      if (lookahead == 'n') ADVANCE(38);
+      if (lookahead == 'n') ADVANCE(562);
       END_STATE();
     case 419:
-      if (lookahead == 'n') ADVANCE(276);
+      if (lookahead == 'n') ADVANCE(216);
       END_STATE();
     case 420:
-      if (lookahead == 'n') ADVANCE(564);
+      if (lookahead == 'n') ADVANCE(566);
       END_STATE();
     case 421:
-      if (lookahead == 'n') ADVANCE(218);
+      if (lookahead == 'n') ADVANCE(169);
       END_STATE();
     case 422:
-      if (lookahead == 'n') ADVANCE(568);
-      END_STATE();
-    case 423:
-      if (lookahead == 'n') ADVANCE(171);
-      END_STATE();
-    case 424:
-      if (lookahead == 'n') ADVANCE(576);
-      END_STATE();
-    case 425:
-      if (lookahead == 'n') ADVANCE(604);
-      END_STATE();
-    case 426:
-      if (lookahead == 'n') ADVANCE(225);
-      END_STATE();
-    case 427:
-      if (lookahead == 'n') ADVANCE(569);
-      END_STATE();
-    case 428:
-      if (lookahead == 'n') ADVANCE(223);
-      END_STATE();
-    case 429:
       if (lookahead == 'n') ADVANCE(574);
       END_STATE();
+    case 423:
+      if (lookahead == 'n') ADVANCE(602);
+      END_STATE();
+    case 424:
+      if (lookahead == 'n') ADVANCE(223);
+      END_STATE();
+    case 425:
+      if (lookahead == 'n') ADVANCE(567);
+      END_STATE();
+    case 426:
+      if (lookahead == 'n') ADVANCE(221);
+      END_STATE();
+    case 427:
+      if (lookahead == 'n') ADVANCE(572);
+      END_STATE();
+    case 428:
+      if (lookahead == 'n') ADVANCE(588);
+      END_STATE();
+    case 429:
+      if (lookahead == 'n') ADVANCE(576);
+      END_STATE();
     case 430:
-      if (lookahead == 'n') ADVANCE(590);
+      if (lookahead == 'n') ADVANCE(301);
       END_STATE();
     case 431:
-      if (lookahead == 'n') ADVANCE(578);
+      if (lookahead == 'n') ADVANCE(632);
       END_STATE();
     case 432:
-      if (lookahead == 'n') ADVANCE(303);
+      if (lookahead == 'n') ADVANCE(71);
       END_STATE();
     case 433:
-      if (lookahead == 'n') ADVANCE(634);
+      if (lookahead == 'o') ADVANCE(400);
+      if (lookahead == 'r') ADVANCE(245);
       END_STATE();
     case 434:
-      if (lookahead == 'n') ADVANCE(73);
+      if (lookahead == 'o') ADVANCE(621);
       END_STATE();
     case 435:
-      if (lookahead == 'o') ADVANCE(402);
-      if (lookahead == 'r') ADVANCE(247);
+      if (lookahead == 'o') ADVANCE(624);
       END_STATE();
     case 436:
-      if (lookahead == 'o') ADVANCE(623);
+      if (lookahead == 'o') ADVANCE(600);
       END_STATE();
     case 437:
-      if (lookahead == 'o') ADVANCE(626);
+      if (lookahead == 'o') ADVANCE(27);
       END_STATE();
     case 438:
-      if (lookahead == 'o') ADVANCE(602);
+      if (lookahead == 'o') ADVANCE(498);
       END_STATE();
     case 439:
-      if (lookahead == 'o') ADVANCE(29);
+      if (lookahead == 'o') ADVANCE(422);
       END_STATE();
     case 440:
-      if (lookahead == 'o') ADVANCE(500);
+      if (lookahead == 'o') ADVANCE(523);
       END_STATE();
     case 441:
       if (lookahead == 'o') ADVANCE(424);
       END_STATE();
     case 442:
-      if (lookahead == 'o') ADVANCE(525);
+      if (lookahead == 'o') ADVANCE(549);
       END_STATE();
     case 443:
-      if (lookahead == 'o') ADVANCE(426);
+      if (lookahead == 'o') ADVANCE(510);
       END_STATE();
     case 444:
-      if (lookahead == 'o') ADVANCE(551);
+      if (lookahead == 'o') ADVANCE(399);
       END_STATE();
     case 445:
-      if (lookahead == 'o') ADVANCE(512);
+      if (lookahead == 'o') ADVANCE(528);
       END_STATE();
     case 446:
-      if (lookahead == 'o') ADVANCE(401);
+      if (lookahead == 'o') ADVANCE(569);
       END_STATE();
     case 447:
-      if (lookahead == 'o') ADVANCE(530);
+      if (lookahead == 'o') ADVANCE(495);
       END_STATE();
     case 448:
-      if (lookahead == 'o') ADVANCE(571);
+      if (lookahead == 'o') ADVANCE(524);
       END_STATE();
     case 449:
-      if (lookahead == 'o') ADVANCE(497);
+      if (lookahead == 'o') ADVANCE(406);
       END_STATE();
     case 450:
-      if (lookahead == 'o') ADVANCE(526);
+      if (lookahead == 'o') ADVANCE(415);
       END_STATE();
     case 451:
-      if (lookahead == 'o') ADVANCE(408);
+      if (lookahead == 'o') ADVANCE(432);
       END_STATE();
     case 452:
-      if (lookahead == 'o') ADVANCE(417);
+      if (lookahead == 'o') ADVANCE(33);
       END_STATE();
     case 453:
-      if (lookahead == 'o') ADVANCE(434);
+      if (lookahead == 'o') ADVANCE(512);
       END_STATE();
     case 454:
-      if (lookahead == 'o') ADVANCE(35);
-      END_STATE();
-    case 455:
-      if (lookahead == 'o') ADVANCE(514);
-      END_STATE();
-    case 456:
-      if (lookahead == 'o') ADVANCE(413);
-      END_STATE();
-    case 457:
-      if (lookahead == 'o') ADVANCE(49);
-      END_STATE();
-    case 458:
       if (lookahead == 'o') ADVANCE(411);
       END_STATE();
-    case 459:
+    case 455:
       if (lookahead == 'o') ADVANCE(47);
       END_STATE();
+    case 456:
+      if (lookahead == 'o') ADVANCE(409);
+      END_STATE();
+    case 457:
+      if (lookahead == 'o') ADVANCE(45);
+      END_STATE();
+    case 458:
+      if (lookahead == 'o') ADVANCE(452);
+      END_STATE();
+    case 459:
+      if (lookahead == 'o') ADVANCE(214);
+      END_STATE();
     case 460:
-      if (lookahead == 'o') ADVANCE(454);
+      if (lookahead == 'o') ADVANCE(200);
       END_STATE();
     case 461:
-      if (lookahead == 'o') ADVANCE(216);
+      if (lookahead == 'o') ADVANCE(605);
       END_STATE();
     case 462:
-      if (lookahead == 'o') ADVANCE(202);
+      if (lookahead == 'o') ADVANCE(416);
       END_STATE();
     case 463:
-      if (lookahead == 'o') ADVANCE(607);
+      if (lookahead == 'o') ADVANCE(455);
       END_STATE();
     case 464:
-      if (lookahead == 'o') ADVANCE(418);
+      if (lookahead == 'o') ADVANCE(206);
       END_STATE();
     case 465:
-      if (lookahead == 'o') ADVANCE(457);
+      if (lookahead == 'o') ADVANCE(377);
       END_STATE();
     case 466:
-      if (lookahead == 'o') ADVANCE(208);
+      if (lookahead == 'o') ADVANCE(517);
       END_STATE();
     case 467:
-      if (lookahead == 'o') ADVANCE(379);
+      if (lookahead == 'o') ADVANCE(230);
       END_STATE();
     case 468:
-      if (lookahead == 'o') ADVANCE(519);
+      if (lookahead == 'o') ADVANCE(573);
       END_STATE();
     case 469:
-      if (lookahead == 'o') ADVANCE(232);
+      if (lookahead == 'o') ADVANCE(586);
       END_STATE();
     case 470:
-      if (lookahead == 'o') ADVANCE(575);
+      if (lookahead == 'o') ADVANCE(577);
       END_STATE();
     case 471:
-      if (lookahead == 'o') ADVANCE(588);
+      if (lookahead == 'o') ADVANCE(175);
       END_STATE();
     case 472:
-      if (lookahead == 'o') ADVANCE(579);
-      END_STATE();
-    case 473:
-      if (lookahead == 'o') ADVANCE(177);
-      END_STATE();
-    case 474:
-      if (lookahead == 'o') ADVANCE(522);
-      END_STATE();
-    case 475:
-      if (lookahead == 'o') ADVANCE(591);
-      END_STATE();
-    case 476:
-      if (lookahead == 'o') ADVANCE(355);
-      END_STATE();
-    case 477:
       if (lookahead == 'o') ADVANCE(520);
       END_STATE();
+    case 473:
+      if (lookahead == 'o') ADVANCE(589);
+      END_STATE();
+    case 474:
+      if (lookahead == 'o') ADVANCE(353);
+      END_STATE();
+    case 475:
+      if (lookahead == 'o') ADVANCE(518);
+      END_STATE();
+    case 476:
+      if (lookahead == 'p') ADVANCE(651);
+      END_STATE();
+    case 477:
+      if (lookahead == 'p') ADVANCE(653);
+      END_STATE();
     case 478:
-      if (lookahead == 'p') ADVANCE(654);
+      if (lookahead == 'p') ADVANCE(244);
       END_STATE();
     case 479:
-      if (lookahead == 'p') ADVANCE(656);
+      if (lookahead == 'p') ADVANCE(231);
       END_STATE();
     case 480:
-      if (lookahead == 'p') ADVANCE(246);
+      if (lookahead == 'p') ADVANCE(29);
       END_STATE();
     case 481:
-      if (lookahead == 'p') ADVANCE(233);
-      END_STATE();
-    case 482:
-      if (lookahead == 'p') ADVANCE(31);
-      END_STATE();
-    case 483:
-      if (lookahead == 'p') ADVANCE(444);
-      END_STATE();
-    case 484:
-      if (lookahead == 'p') ADVANCE(564);
-      END_STATE();
-    case 485:
       if (lookahead == 'p') ADVANCE(442);
       END_STATE();
+    case 482:
+      if (lookahead == 'p') ADVANCE(562);
+      END_STATE();
+    case 483:
+      if (lookahead == 'p') ADVANCE(440);
+      END_STATE();
+    case 484:
+      if (lookahead == 'p') ADVANCE(383);
+      END_STATE();
+    case 485:
+      if (lookahead == 'p') ADVANCE(585);
+      END_STATE();
     case 486:
-      if (lookahead == 'p') ADVANCE(385);
+      if (lookahead == 'p') ADVANCE(445);
       END_STATE();
     case 487:
-      if (lookahead == 'p') ADVANCE(587);
+      if (lookahead == 'p') ADVANCE(486);
       END_STATE();
     case 488:
-      if (lookahead == 'p') ADVANCE(447);
+      if (lookahead == 'p') ADVANCE(299);
       END_STATE();
     case 489:
-      if (lookahead == 'p') ADVANCE(488);
+      if (lookahead == 'p') ADVANCE(475);
       END_STATE();
     case 490:
-      if (lookahead == 'p') ADVANCE(301);
+      if (lookahead == 'p') ADVANCE(489);
       END_STATE();
     case 491:
-      if (lookahead == 'p') ADVANCE(477);
-      END_STATE();
-    case 492:
-      if (lookahead == 'p') ADVANCE(491);
-      END_STATE();
-    case 493:
-      if (lookahead == 'q') ADVANCE(613);
-      END_STATE();
-    case 494:
-      if (lookahead == 'q') ADVANCE(608);
-      if (lookahead == 's') ADVANCE(256);
-      END_STATE();
-    case 495:
       if (lookahead == 'q') ADVANCE(611);
       END_STATE();
+    case 492:
+      if (lookahead == 'q') ADVANCE(606);
+      if (lookahead == 's') ADVANCE(254);
+      END_STATE();
+    case 493:
+      if (lookahead == 'q') ADVANCE(609);
+      END_STATE();
+    case 494:
+      if (lookahead == 'q') ADVANCE(610);
+      END_STATE();
+    case 495:
+      if (lookahead == 'r') ADVANCE(661);
+      END_STATE();
     case 496:
-      if (lookahead == 'q') ADVANCE(612);
+      if (lookahead == 'r') ADVANCE(604);
       END_STATE();
     case 497:
-      if (lookahead == 'r') ADVANCE(665);
+      if (lookahead == 'r') ADVANCE(185);
+      if (lookahead == 'u') ADVANCE(402);
       END_STATE();
     case 498:
-      if (lookahead == 'r') ADVANCE(606);
+      if (lookahead == 'r') ADVANCE(366);
       END_STATE();
     case 499:
-      if (lookahead == 'r') ADVANCE(187);
-      if (lookahead == 'u') ADVANCE(404);
+      if (lookahead == 'r') ADVANCE(335);
       END_STATE();
     case 500:
-      if (lookahead == 'r') ADVANCE(368);
+      if (lookahead == 'r') ADVANCE(393);
       END_STATE();
     case 501:
-      if (lookahead == 'r') ADVANCE(337);
+      if (lookahead == 'r') ADVANCE(280);
       END_STATE();
     case 502:
-      if (lookahead == 'r') ADVANCE(395);
+      if (lookahead == 'r') ADVANCE(582);
+      if (lookahead == 'y') ADVANCE(371);
       END_STATE();
     case 503:
-      if (lookahead == 'r') ADVANCE(282);
+      if (lookahead == 'r') ADVANCE(464);
       END_STATE();
     case 504:
-      if (lookahead == 'r') ADVANCE(584);
-      if (lookahead == 'y') ADVANCE(373);
+      if (lookahead == 'r') ADVANCE(313);
       END_STATE();
     case 505:
-      if (lookahead == 'r') ADVANCE(466);
+      if (lookahead == 'r') ADVANCE(421);
       END_STATE();
     case 506:
-      if (lookahead == 'r') ADVANCE(315);
+      if (lookahead == 'r') ADVANCE(545);
       END_STATE();
     case 507:
-      if (lookahead == 'r') ADVANCE(423);
+      if (lookahead == 'r') ADVANCE(368);
       END_STATE();
     case 508:
-      if (lookahead == 'r') ADVANCE(547);
+      if (lookahead == 'r') ADVANCE(435);
       END_STATE();
     case 509:
-      if (lookahead == 'r') ADVANCE(370);
+      if (lookahead == 'r') ADVANCE(241);
       END_STATE();
     case 510:
-      if (lookahead == 'r') ADVANCE(437);
+      if (lookahead == 'r') ADVANCE(328);
       END_STATE();
     case 511:
-      if (lookahead == 'r') ADVANCE(243);
+      if (lookahead == 'r') ADVANCE(446);
       END_STATE();
     case 512:
-      if (lookahead == 'r') ADVANCE(330);
+      if (lookahead == 'r') ADVANCE(153);
       END_STATE();
     case 513:
-      if (lookahead == 'r') ADVANCE(448);
+      if (lookahead == 'r') ADVANCE(253);
       END_STATE();
     case 514:
-      if (lookahead == 'r') ADVANCE(155);
+      if (lookahead == 'r') ADVANCE(525);
       END_STATE();
     case 515:
-      if (lookahead == 'r') ADVANCE(255);
+      if (lookahead == 'r') ADVANCE(54);
       END_STATE();
     case 516:
-      if (lookahead == 'r') ADVANCE(527);
+      if (lookahead == 'r') ADVANCE(49);
       END_STATE();
     case 517:
-      if (lookahead == 'r') ADVANCE(56);
+      if (lookahead == 'r') ADVANCE(53);
       END_STATE();
     case 518:
-      if (lookahead == 'r') ADVANCE(51);
+      if (lookahead == 'r') ADVANCE(562);
       END_STATE();
     case 519:
-      if (lookahead == 'r') ADVANCE(55);
+      if (lookahead == 'r') ADVANCE(616);
       END_STATE();
     case 520:
-      if (lookahead == 'r') ADVANCE(564);
+      if (lookahead == 'r') ADVANCE(398);
       END_STATE();
     case 521:
-      if (lookahead == 'r') ADVANCE(618);
+      if (lookahead == 'r') ADVANCE(285);
       END_STATE();
     case 522:
-      if (lookahead == 'r') ADVANCE(400);
+      if (lookahead == 'r') ADVANCE(152);
       END_STATE();
     case 523:
-      if (lookahead == 'r') ADVANCE(287);
+      if (lookahead == 'r') ADVANCE(159);
       END_STATE();
     case 524:
-      if (lookahead == 'r') ADVANCE(154);
+      if (lookahead == 'r') ADVANCE(363);
       END_STATE();
     case 525:
-      if (lookahead == 'r') ADVANCE(161);
+      if (lookahead == 'r') ADVANCE(447);
       END_STATE();
     case 526:
-      if (lookahead == 'r') ADVANCE(365);
+      if (lookahead == 'r') ADVANCE(633);
       END_STATE();
     case 527:
-      if (lookahead == 'r') ADVANCE(449);
+      if (lookahead == 'r') ADVANCE(397);
       END_STATE();
     case 528:
-      if (lookahead == 'r') ADVANCE(635);
+      if (lookahead == 'r') ADVANCE(596);
       END_STATE();
     case 529:
-      if (lookahead == 'r') ADVANCE(399);
+      if (lookahead == 's') ADVANCE(652);
       END_STATE();
     case 530:
-      if (lookahead == 'r') ADVANCE(598);
+      if (lookahead == 's') ADVANCE(654);
       END_STATE();
     case 531:
-      if (lookahead == 's') ADVANCE(655);
+      if (lookahead == 's') ADVANCE(661);
       END_STATE();
     case 532:
-      if (lookahead == 's') ADVANCE(657);
+      if (lookahead == 's') ADVANCE(212);
       END_STATE();
     case 533:
-      if (lookahead == 's') ADVANCE(665);
+      if (lookahead == 's') ADVANCE(599);
+      if (lookahead == 't') ADVANCE(251);
       END_STATE();
     case 534:
-      if (lookahead == 's') ADVANCE(214);
+      if (lookahead == 's') ADVANCE(540);
       END_STATE();
     case 535:
-      if (lookahead == 's') ADVANCE(601);
-      if (lookahead == 't') ADVANCE(253);
+      if (lookahead == 's') ADVANCE(547);
       END_STATE();
     case 536:
-      if (lookahead == 's') ADVANCE(542);
+      if (lookahead == 's') ADVANCE(241);
       END_STATE();
     case 537:
       if (lookahead == 's') ADVANCE(549);
       END_STATE();
     case 538:
-      if (lookahead == 's') ADVANCE(243);
+      if (lookahead == 's') ADVANCE(234);
       END_STATE();
     case 539:
-      if (lookahead == 's') ADVANCE(551);
+      if (lookahead == 's') ADVANCE(560);
       END_STATE();
     case 540:
-      if (lookahead == 's') ADVANCE(236);
+      if (lookahead == 's') ADVANCE(340);
       END_STATE();
     case 541:
-      if (lookahead == 's') ADVANCE(562);
+      if (lookahead == 's') ADVANCE(310);
       END_STATE();
     case 542:
-      if (lookahead == 's') ADVANCE(342);
+      if (lookahead == 's') ADVANCE(568);
       END_STATE();
     case 543:
-      if (lookahead == 's') ADVANCE(312);
+      if (lookahead == 's') ADVANCE(457);
       END_STATE();
     case 544:
-      if (lookahead == 's') ADVANCE(570);
+      if (lookahead == 's') ADVANCE(456);
       END_STATE();
     case 545:
-      if (lookahead == 's') ADVANCE(459);
+      if (lookahead == 's') ADVANCE(356);
       END_STATE();
     case 546:
-      if (lookahead == 's') ADVANCE(458);
+      if (lookahead == 's') ADVANCE(70);
       END_STATE();
     case 547:
-      if (lookahead == 's') ADVANCE(358);
+      if (lookahead == 's') ADVANCE(182);
       END_STATE();
     case 548:
-      if (lookahead == 's') ADVANCE(72);
+      if (lookahead == 't') ADVANCE(189);
+      if (lookahead == 'w') ADVANCE(529);
       END_STATE();
     case 549:
-      if (lookahead == 's') ADVANCE(184);
+      if (lookahead == 't') ADVANCE(661);
       END_STATE();
     case 550:
-      if (lookahead == 't') ADVANCE(191);
-      if (lookahead == 'w') ADVANCE(531);
+      if (lookahead == 't') ADVANCE(320);
       END_STATE();
     case 551:
-      if (lookahead == 't') ADVANCE(665);
+      if (lookahead == 't') ADVANCE(619);
       END_STATE();
     case 552:
       if (lookahead == 't') ADVANCE(322);
       END_STATE();
     case 553:
-      if (lookahead == 't') ADVANCE(621);
+      if (lookahead == 't') ADVANCE(627);
       END_STATE();
     case 554:
-      if (lookahead == 't') ADVANCE(324);
+      if (lookahead == 't') ADVANCE(323);
       END_STATE();
     case 555:
-      if (lookahead == 't') ADVANCE(629);
+      if (lookahead == 't') ADVANCE(195);
       END_STATE();
     case 556:
-      if (lookahead == 't') ADVANCE(325);
+      if (lookahead == 't') ADVANCE(237);
       END_STATE();
     case 557:
-      if (lookahead == 't') ADVANCE(197);
-      END_STATE();
-    case 558:
-      if (lookahead == 't') ADVANCE(239);
-      END_STATE();
-    case 559:
-      if (lookahead == 't') ADVANCE(329);
-      END_STATE();
-    case 560:
-      if (lookahead == 't') ADVANCE(605);
-      END_STATE();
-    case 561:
-      if (lookahead == 't') ADVANCE(370);
-      END_STATE();
-    case 562:
-      if (lookahead == 't') ADVANCE(533);
-      END_STATE();
-    case 563:
-      if (lookahead == 't') ADVANCE(170);
-      END_STATE();
-    case 564:
-      if (lookahead == 't') ADVANCE(243);
-      END_STATE();
-    case 565:
-      if (lookahead == 't') ADVANCE(354);
-      END_STATE();
-    case 566:
-      if (lookahead == 't') ADVANCE(162);
-      END_STATE();
-    case 567:
-      if (lookahead == 't') ADVANCE(24);
-      END_STATE();
-    case 568:
-      if (lookahead == 't') ADVANCE(33);
-      END_STATE();
-    case 569:
-      if (lookahead == 't') ADVANCE(338);
-      END_STATE();
-    case 570:
-      if (lookahead == 't') ADVANCE(34);
-      END_STATE();
-    case 571:
-      if (lookahead == 't') ADVANCE(462);
-      END_STATE();
-    case 572:
-      if (lookahead == 't') ADVANCE(340);
-      END_STATE();
-    case 573:
-      if (lookahead == 't') ADVANCE(352);
-      END_STATE();
-    case 574:
-      if (lookahead == 't') ADVANCE(45);
-      END_STATE();
-    case 575:
-      if (lookahead == 't') ADVANCE(54);
-      END_STATE();
-    case 576:
-      if (lookahead == 't') ADVANCE(267);
-      END_STATE();
-    case 577:
-      if (lookahead == 't') ADVANCE(270);
-      END_STATE();
-    case 578:
-      if (lookahead == 't') ADVANCE(64);
-      END_STATE();
-    case 579:
-      if (lookahead == 't') ADVANCE(58);
-      END_STATE();
-    case 580:
-      if (lookahead == 't') ADVANCE(261);
-      END_STATE();
-    case 581:
-      if (lookahead == 't') ADVANCE(194);
-      if (lookahead == 'w') ADVANCE(532);
-      END_STATE();
-    case 582:
-      if (lookahead == 't') ADVANCE(264);
-      END_STATE();
-    case 583:
       if (lookahead == 't') ADVANCE(327);
       END_STATE();
+    case 558:
+      if (lookahead == 't') ADVANCE(603);
+      END_STATE();
+    case 559:
+      if (lookahead == 't') ADVANCE(368);
+      END_STATE();
+    case 560:
+      if (lookahead == 't') ADVANCE(531);
+      END_STATE();
+    case 561:
+      if (lookahead == 't') ADVANCE(168);
+      END_STATE();
+    case 562:
+      if (lookahead == 't') ADVANCE(241);
+      END_STATE();
+    case 563:
+      if (lookahead == 't') ADVANCE(352);
+      END_STATE();
+    case 564:
+      if (lookahead == 't') ADVANCE(160);
+      END_STATE();
+    case 565:
+      if (lookahead == 't') ADVANCE(22);
+      END_STATE();
+    case 566:
+      if (lookahead == 't') ADVANCE(31);
+      END_STATE();
+    case 567:
+      if (lookahead == 't') ADVANCE(336);
+      END_STATE();
+    case 568:
+      if (lookahead == 't') ADVANCE(32);
+      END_STATE();
+    case 569:
+      if (lookahead == 't') ADVANCE(460);
+      END_STATE();
+    case 570:
+      if (lookahead == 't') ADVANCE(338);
+      END_STATE();
+    case 571:
+      if (lookahead == 't') ADVANCE(350);
+      END_STATE();
+    case 572:
+      if (lookahead == 't') ADVANCE(43);
+      END_STATE();
+    case 573:
+      if (lookahead == 't') ADVANCE(52);
+      END_STATE();
+    case 574:
+      if (lookahead == 't') ADVANCE(265);
+      END_STATE();
+    case 575:
+      if (lookahead == 't') ADVANCE(268);
+      END_STATE();
+    case 576:
+      if (lookahead == 't') ADVANCE(62);
+      END_STATE();
+    case 577:
+      if (lookahead == 't') ADVANCE(56);
+      END_STATE();
+    case 578:
+      if (lookahead == 't') ADVANCE(259);
+      END_STATE();
+    case 579:
+      if (lookahead == 't') ADVANCE(192);
+      if (lookahead == 'w') ADVANCE(530);
+      END_STATE();
+    case 580:
+      if (lookahead == 't') ADVANCE(262);
+      END_STATE();
+    case 581:
+      if (lookahead == 't') ADVANCE(325);
+      END_STATE();
+    case 582:
+      if (lookahead == 't') ADVANCE(337);
+      END_STATE();
+    case 583:
+      if (lookahead == 't') ADVANCE(324);
+      END_STATE();
     case 584:
-      if (lookahead == 't') ADVANCE(339);
+      if (lookahead == 't') ADVANCE(283);
       END_STATE();
     case 585:
-      if (lookahead == 't') ADVANCE(326);
+      if (lookahead == 't') ADVANCE(167);
       END_STATE();
     case 586:
-      if (lookahead == 't') ADVANCE(285);
+      if (lookahead == 't') ADVANCE(64);
       END_STATE();
     case 587:
-      if (lookahead == 't') ADVANCE(169);
+      if (lookahead == 't') ADVANCE(341);
       END_STATE();
     case 588:
       if (lookahead == 't') ADVANCE(66);
       END_STATE();
     case 589:
-      if (lookahead == 't') ADVANCE(343);
-      END_STATE();
-    case 590:
-      if (lookahead == 't') ADVANCE(68);
-      END_STATE();
-    case 591:
-      if (lookahead == 't') ADVANCE(362);
-      END_STATE();
-    case 592:
-      if (lookahead == 't') ADVANCE(455);
-      END_STATE();
-    case 593:
-      if (lookahead == 't') ADVANCE(299);
-      END_STATE();
-    case 594:
-      if (lookahead == 't') ADVANCE(328);
-      END_STATE();
-    case 595:
-      if (lookahead == 't') ADVANCE(296);
-      END_STATE();
-    case 596:
-      if (lookahead == 't') ADVANCE(178);
-      END_STATE();
-    case 597:
-      if (lookahead == 't') ADVANCE(359);
-      END_STATE();
-    case 598:
-      if (lookahead == 't') ADVANCE(297);
-      END_STATE();
-    case 599:
       if (lookahead == 't') ADVANCE(360);
       END_STATE();
+    case 590:
+      if (lookahead == 't') ADVANCE(453);
+      END_STATE();
+    case 591:
+      if (lookahead == 't') ADVANCE(297);
+      END_STATE();
+    case 592:
+      if (lookahead == 't') ADVANCE(326);
+      END_STATE();
+    case 593:
+      if (lookahead == 't') ADVANCE(294);
+      END_STATE();
+    case 594:
+      if (lookahead == 't') ADVANCE(176);
+      END_STATE();
+    case 595:
+      if (lookahead == 't') ADVANCE(357);
+      END_STATE();
+    case 596:
+      if (lookahead == 't') ADVANCE(295);
+      END_STATE();
+    case 597:
+      if (lookahead == 't') ADVANCE(358);
+      END_STATE();
+    case 598:
+      if (lookahead == 't') ADVANCE(359);
+      END_STATE();
+    case 599:
+      if (lookahead == 'u') ADVANCE(305);
+      END_STATE();
     case 600:
-      if (lookahead == 't') ADVANCE(361);
+      if (lookahead == 'u') ADVANCE(402);
       END_STATE();
     case 601:
-      if (lookahead == 'u') ADVANCE(307);
+      if (lookahead == 'u') ADVANCE(487);
       END_STATE();
     case 602:
-      if (lookahead == 'u') ADVANCE(404);
+      if (lookahead == 'u') ADVANCE(231);
       END_STATE();
     case 603:
-      if (lookahead == 'u') ADVANCE(489);
+      if (lookahead == 'u') ADVANCE(531);
       END_STATE();
     case 604:
       if (lookahead == 'u') ADVANCE(233);
       END_STATE();
     case 605:
-      if (lookahead == 'u') ADVANCE(533);
+      if (lookahead == 'u') ADVANCE(549);
       END_STATE();
     case 606:
-      if (lookahead == 'u') ADVANCE(235);
+      if (lookahead == 'u') ADVANCE(249);
       END_STATE();
     case 607:
-      if (lookahead == 'u') ADVANCE(551);
+      if (lookahead == 'u') ADVANCE(581);
+      if (lookahead == 'v') ADVANCE(164);
       END_STATE();
     case 608:
-      if (lookahead == 'u') ADVANCE(251);
+      if (lookahead == 'u') ADVANCE(583);
       END_STATE();
     case 609:
-      if (lookahead == 'u') ADVANCE(583);
-      if (lookahead == 'v') ADVANCE(166);
+      if (lookahead == 'u') ADVANCE(287);
       END_STATE();
     case 610:
-      if (lookahead == 'u') ADVANCE(585);
+      if (lookahead == 'u') ADVANCE(290);
       END_STATE();
     case 611:
-      if (lookahead == 'u') ADVANCE(289);
+      if (lookahead == 'u') ADVANCE(351);
       END_STATE();
     case 612:
-      if (lookahead == 'u') ADVANCE(292);
+      if (lookahead == 'u') ADVANCE(592);
       END_STATE();
     case 613:
-      if (lookahead == 'u') ADVANCE(353);
+      if (lookahead == 'u') ADVANCE(490);
       END_STATE();
     case 614:
-      if (lookahead == 'u') ADVANCE(594);
+      if (lookahead == 'v') ADVANCE(343);
       END_STATE();
     case 615:
-      if (lookahead == 'u') ADVANCE(492);
-      END_STATE();
-    case 616:
-      if (lookahead == 'v') ADVANCE(345);
-      END_STATE();
-    case 617:
-      if (lookahead == 'v') ADVANCE(283);
-      END_STATE();
-    case 618:
-      if (lookahead == 'v') ADVANCE(290);
-      END_STATE();
-    case 619:
       if (lookahead == 'v') ADVANCE(281);
       END_STATE();
+    case 616:
+      if (lookahead == 'v') ADVANCE(288);
+      END_STATE();
+    case 617:
+      if (lookahead == 'v') ADVANCE(279);
+      END_STATE();
+    case 618:
+      if (lookahead == 'v') ADVANCE(181);
+      END_STATE();
+    case 619:
+      if (lookahead == 'w') ADVANCE(438);
+      END_STATE();
     case 620:
-      if (lookahead == 'v') ADVANCE(183);
+      if (lookahead == 'w') ADVANCE(170);
       END_STATE();
     case 621:
-      if (lookahead == 'w') ADVANCE(440);
+      if (lookahead == 'w') ADVANCE(241);
       END_STATE();
     case 622:
-      if (lookahead == 'w') ADVANCE(172);
+      if (lookahead == 'w') ADVANCE(146);
       END_STATE();
     case 623:
-      if (lookahead == 'w') ADVANCE(243);
+      if (lookahead == 'x') ADVANCE(390);
       END_STATE();
     case 624:
-      if (lookahead == 'w') ADVANCE(148);
+      if (lookahead == 'x') ADVANCE(627);
       END_STATE();
     case 625:
-      if (lookahead == 'x') ADVANCE(392);
+      if (lookahead == 'x') ADVANCE(478);
       END_STATE();
     case 626:
-      if (lookahead == 'x') ADVANCE(629);
+      if (lookahead == 'x') ADVANCE(575);
       END_STATE();
     case 627:
-      if (lookahead == 'x') ADVANCE(480);
+      if (lookahead == 'y') ADVANCE(661);
       END_STATE();
     case 628:
-      if (lookahead == 'x') ADVANCE(577);
+      if (lookahead == 'y') ADVANCE(60);
       END_STATE();
     case 629:
-      if (lookahead == 'y') ADVANCE(665);
+      if (lookahead == 'y') ADVANCE(55);
       END_STATE();
     case 630:
-      if (lookahead == 'y') ADVANCE(62);
+      if (lookahead == 'y') ADVANCE(63);
       END_STATE();
     case 631:
-      if (lookahead == 'y') ADVANCE(57);
+      if (lookahead == 'y') ADVANCE(479);
       END_STATE();
     case 632:
       if (lookahead == 'y') ADVANCE(65);
       END_STATE();
     case 633:
-      if (lookahead == 'y') ADVANCE(481);
+      if (lookahead == 'y') ADVANCE(66);
       END_STATE();
     case 634:
-      if (lookahead == 'y') ADVANCE(67);
+      if (lookahead == 'z') ADVANCE(241);
       END_STATE();
     case 635:
-      if (lookahead == 'y') ADVANCE(68);
+      if (lookahead == '{') ADVANCE(680);
       END_STATE();
     case 636:
-      if (lookahead == 'z') ADVANCE(243);
+      if (lookahead == '}') ADVANCE(681);
       END_STATE();
     case 637:
-      if (lookahead == '{') ADVANCE(683);
+      if (lookahead == '\n' ||
+          lookahead == '\r') ADVANCE(666);
+      if (('\t' <= lookahead && lookahead <= 11) ||
+          lookahead == ' ') ADVANCE(722);
+      if (('1' <= lookahead && lookahead <= '5')) ADVANCE(642);
       END_STATE();
     case 638:
-      if (lookahead == '}') ADVANCE(685);
+      if (lookahead == '\n' ||
+          lookahead == '\r') ADVANCE(666);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(648);
+      if (lookahead == '$' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (161 <= lookahead && lookahead <= 55295) ||
+          (57344 <= lookahead && lookahead <= 65535)) ADVANCE(713);
       END_STATE();
     case 639:
       if (lookahead == '\n' ||
-          lookahead == '\r') ADVANCE(671);
-      if (('\t' <= lookahead && lookahead <= 0x0b) ||
-          lookahead == ' ') ADVANCE(729);
-      if (('1' <= lookahead && lookahead <= '5')) ADVANCE(644);
+          lookahead == '\r') ADVANCE(666);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(649);
       END_STATE();
     case 640:
       if (lookahead == '\n' ||
-          lookahead == '\r') ADVANCE(671);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(650);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(717);
+          lookahead == '\r') ADVANCE(666);
+      if (lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9')) ADVANCE(657);
       END_STATE();
     case 641:
-      if (lookahead == '\n' ||
-          lookahead == '\r') ADVANCE(671);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(651);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(660);
       END_STATE();
     case 642:
-      if (lookahead == '\n' ||
-          lookahead == '\r') ADVANCE(671);
-      if (lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9')) ADVANCE(660);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(641);
       END_STATE();
     case 643:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(664);
+      if (eof) ADVANCE(645);
+      if (lookahead == '\n') ADVANCE(666);
+      if (lookahead == '\r') ADVANCE(666);
+      if (lookahead == '#') ADVANCE(646);
+      if (lookahead == '&') ADVANCE(667);
+      if (lookahead == '-') ADVANCE(696);
+      if (lookahead == ':') ADVANCE(647);
+      if (lookahead == '<') ADVANCE(693);
+      if (lookahead == '=') ADVANCE(670);
+      if (lookahead == '@') ADVANCE(655);
+      if (lookahead == '[') ADVANCE(13);
+      if (lookahead == '{') ADVANCE(15);
+      if (lookahead == '}') ADVANCE(636);
+      if (('\t' <= lookahead && lookahead <= 11) ||
+          lookahead == ' ') ADVANCE(722);
+      if (lookahead == '$' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (161 <= lookahead && lookahead <= 55295) ||
+          (57344 <= lookahead && lookahead <= 65535)) ADVANCE(713);
       END_STATE();
     case 644:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(643);
+      if (eof) ADVANCE(645);
+      if (lookahead == '#') ADVANCE(646);
+      if (lookahead == '-') ADVANCE(696);
+      if (lookahead == ':') ADVANCE(81);
+      if (lookahead == '<') ADVANCE(693);
+      if (lookahead == '@') ADVANCE(655);
+      if (lookahead == 'H') ADVANCE(700);
+      if (lookahead == '[') ADVANCE(13);
+      if (lookahead == '{') ADVANCE(15);
+      if (lookahead == '\n' ||
+          lookahead == '\r') ADVANCE(666);
+      if (('\t' <= lookahead && lookahead <= 11) ||
+          lookahead == ' ') ADVANCE(722);
+      if (lookahead == '$' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (161 <= lookahead && lookahead <= 55295) ||
+          (57344 <= lookahead && lookahead <= 65535)) ADVANCE(713);
       END_STATE();
     case 645:
-      if (eof) ADVANCE(647);
-      ADVANCE_MAP(
-        '\n', 671,
-        '\r', 671,
-        '#', 648,
-        '&', 672,
-        '-', 700,
-        ':', 649,
-        '<', 697,
-        '=', 673,
-        '@', 658,
-        '[', 15,
-        '{', 17,
-        '}', 638,
-        '\t', 729,
-        0x0b, 729,
-        ' ', 729,
-      );
-      if (lookahead == '$' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(717);
-      END_STATE();
-    case 646:
-      if (eof) ADVANCE(647);
-      ADVANCE_MAP(
-        '#', 648,
-        '-', 700,
-        ':', 83,
-        '<', 697,
-        '@', 658,
-        'H', 704,
-        '[', 15,
-        '{', 17,
-        '\n', 671,
-        '\r', 671,
-        '\t', 729,
-        0x0b, 729,
-        ' ', 729,
-      );
-      if (lookahead == '$' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(717);
-      END_STATE();
-    case 647:
       ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
-    case 648:
+    case 646:
       ACCEPT_TOKEN(sym_comment);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(648);
+          lookahead != '\n') ADVANCE(646);
       END_STATE();
-    case 649:
+    case 647:
       ACCEPT_TOKEN(anon_sym_COLON);
       END_STATE();
-    case 650:
+    case 648:
       ACCEPT_TOKEN(aux_sym_port_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(650);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(648);
       if (lookahead == '$' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(717);
+          (161 <= lookahead && lookahead <= 55295) ||
+          (57344 <= lookahead && lookahead <= 65535)) ADVANCE(713);
+      END_STATE();
+    case 649:
+      ACCEPT_TOKEN(aux_sym_port_token1);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(649);
+      END_STATE();
+    case 650:
+      ACCEPT_TOKEN(anon_sym_SLASH);
       END_STATE();
     case 651:
-      ACCEPT_TOKEN(aux_sym_port_token1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(651);
-      END_STATE();
-    case 652:
-      ACCEPT_TOKEN(anon_sym_SLASH);
-      END_STATE();
-    case 653:
-      ACCEPT_TOKEN(anon_sym_SLASH);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '#' &&
-          lookahead != '&' &&
-          lookahead != '=') ADVANCE(721);
-      END_STATE();
-    case 654:
       ACCEPT_TOKEN(anon_sym_coap_PLUStcp);
       END_STATE();
-    case 655:
+    case 652:
       ACCEPT_TOKEN(anon_sym_coap_PLUSws);
       END_STATE();
-    case 656:
+    case 653:
       ACCEPT_TOKEN(anon_sym_coaps_PLUStcp);
       END_STATE();
-    case 657:
+    case 654:
       ACCEPT_TOKEN(anon_sym_coaps_PLUSws);
       END_STATE();
-    case 658:
+    case 655:
       ACCEPT_TOKEN(anon_sym_AT);
       END_STATE();
-    case 659:
+    case 656:
       ACCEPT_TOKEN(anon_sym_HTTP_SLASH);
       END_STATE();
-    case 660:
+    case 657:
       ACCEPT_TOKEN(aux_sym_http_version_token1);
       if (lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9')) ADVANCE(660);
+          ('0' <= lookahead && lookahead <= '9')) ADVANCE(657);
       END_STATE();
-    case 661:
+    case 658:
       ACCEPT_TOKEN(anon_sym_POUND);
       END_STATE();
-    case 662:
+    case 659:
       ACCEPT_TOKEN(anon_sym_COLON_SLASH_SLASH);
       END_STATE();
-    case 663:
-      ACCEPT_TOKEN(anon_sym_QMARK);
-      END_STATE();
-    case 664:
+    case 660:
       ACCEPT_TOKEN(sym_status_code);
       END_STATE();
-    case 665:
+    case 661:
       ACCEPT_TOKEN(sym_status_text);
       END_STATE();
-    case 666:
+    case 662:
       ACCEPT_TOKEN(aux_sym_request_token1);
-      if (lookahead == '\n') ADVANCE(671);
-      if (lookahead == '\r') ADVANCE(666);
+      if (lookahead == '\n') ADVANCE(666);
+      if (lookahead == '\r') ADVANCE(662);
       if (lookahead != 0 &&
           lookahead != '#' &&
           lookahead != '&' &&
-          lookahead != '=') ADVANCE(721);
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(715);
       END_STATE();
-    case 667:
+    case 663:
       ACCEPT_TOKEN(aux_sym_request_token1);
-      if (lookahead == '\n') ADVANCE(671);
-      if (lookahead == '\r') ADVANCE(667);
-      if (lookahead == '=') ADVANCE(722);
+      if (lookahead == '\n') ADVANCE(666);
+      if (lookahead == '\r') ADVANCE(663);
+      if (lookahead != 0) ADVANCE(734);
+      END_STATE();
+    case 664:
+      ACCEPT_TOKEN(aux_sym_request_token1);
+      if (lookahead == '\n') ADVANCE(666);
+      if (lookahead == '\r') ADVANCE(664);
       if (lookahead != 0 &&
           lookahead != '#' &&
-          lookahead != '&') ADVANCE(719);
+          lookahead != '&' &&
+          lookahead != '=') ADVANCE(714);
       END_STATE();
-    case 668:
+    case 665:
       ACCEPT_TOKEN(aux_sym_request_token1);
-      if (lookahead == '\n') ADVANCE(671);
-      if (lookahead == '\r') ADVANCE(668);
-      if (lookahead != 0) ADVANCE(741);
-      END_STATE();
-    case 669:
-      ACCEPT_TOKEN(aux_sym_request_token1);
-      if (lookahead == '\n') ADVANCE(671);
-      if (lookahead == '\r') ADVANCE(669);
-      if (lookahead != 0 &&
-          lookahead != '#' &&
-          lookahead != '&') ADVANCE(722);
-      END_STATE();
-    case 670:
-      ACCEPT_TOKEN(aux_sym_request_token1);
-      if (lookahead == '\n') ADVANCE(670);
-      if (lookahead == '\r') ADVANCE(670);
+      if (lookahead == '\n') ADVANCE(665);
+      if (lookahead == '\r') ADVANCE(665);
       if (('\t' <= lookahead && lookahead <= '\f') ||
           lookahead == ' ' ||
           lookahead == '-' ||
           ('/' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(21);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(19);
       END_STATE();
-    case 671:
+    case 666:
       ACCEPT_TOKEN(aux_sym_request_token1);
       if (lookahead == '\n' ||
-          lookahead == '\r') ADVANCE(671);
+          lookahead == '\r') ADVANCE(666);
       END_STATE();
-    case 672:
+    case 667:
       ACCEPT_TOKEN(anon_sym_AMP);
       END_STATE();
-    case 673:
+    case 668:
+      ACCEPT_TOKEN(anon_sym_QMARK);
+      END_STATE();
+    case 669:
+      ACCEPT_TOKEN(anon_sym_QMARK);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '#' &&
+          lookahead != '&' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(715);
+      END_STATE();
+    case 670:
       ACCEPT_TOKEN(anon_sym_EQ);
       END_STATE();
-    case 674:
+    case 671:
       ACCEPT_TOKEN(anon_sym_EQ);
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != '#' &&
-          lookahead != '&') ADVANCE(722);
+          lookahead != '&' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(715);
       END_STATE();
-    case 675:
+    case 672:
       ACCEPT_TOKEN(aux_sym_header_token1);
-      if (lookahead == '\n') ADVANCE(675);
+      if (lookahead == '\n') ADVANCE(672);
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ' ||
           lookahead == '-' ||
           ('/' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(21);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(19);
+      END_STATE();
+    case 673:
+      ACCEPT_TOKEN(aux_sym_header_token2);
+      if (lookahead == '\n') ADVANCE(672);
+      if (lookahead == '+') ADVANCE(548);
+      if (lookahead == '/') ADVANCE(679);
+      if (lookahead == 's') ADVANCE(674);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(19);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(678);
+      if (lookahead == '$' ||
+          lookahead == '.' ||
+          (161 <= lookahead && lookahead <= 55295) ||
+          (57344 <= lookahead && lookahead <= 65535)) ADVANCE(713);
+      END_STATE();
+    case 674:
+      ACCEPT_TOKEN(aux_sym_header_token2);
+      if (lookahead == '\n') ADVANCE(672);
+      if (lookahead == '+') ADVANCE(579);
+      if (lookahead == '/') ADVANCE(679);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(19);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(678);
+      if (lookahead == '$' ||
+          lookahead == '.' ||
+          (161 <= lookahead && lookahead <= 55295) ||
+          (57344 <= lookahead && lookahead <= 65535)) ADVANCE(713);
+      END_STATE();
+    case 675:
+      ACCEPT_TOKEN(aux_sym_header_token2);
+      if (lookahead == '\n') ADVANCE(672);
+      if (lookahead == '/') ADVANCE(679);
+      if (lookahead == 'a') ADVANCE(677);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(19);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(678);
+      if (lookahead == '$' ||
+          lookahead == '.' ||
+          (161 <= lookahead && lookahead <= 55295) ||
+          (57344 <= lookahead && lookahead <= 65535)) ADVANCE(713);
       END_STATE();
     case 676:
       ACCEPT_TOKEN(aux_sym_header_token2);
-      if (lookahead == '\n') ADVANCE(675);
-      if (lookahead == '+') ADVANCE(550);
-      if (lookahead == '/') ADVANCE(682);
-      if (lookahead == 's') ADVANCE(677);
+      if (lookahead == '\n') ADVANCE(672);
+      if (lookahead == '/') ADVANCE(679);
+      if (lookahead == 'o') ADVANCE(675);
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(21);
+          lookahead == ' ') ADVANCE(19);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(681);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(678);
       if (lookahead == '$' ||
           lookahead == '.' ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(717);
+          (161 <= lookahead && lookahead <= 55295) ||
+          (57344 <= lookahead && lookahead <= 65535)) ADVANCE(713);
       END_STATE();
     case 677:
       ACCEPT_TOKEN(aux_sym_header_token2);
-      if (lookahead == '\n') ADVANCE(675);
-      if (lookahead == '+') ADVANCE(581);
-      if (lookahead == '/') ADVANCE(682);
+      if (lookahead == '\n') ADVANCE(672);
+      if (lookahead == '/') ADVANCE(679);
+      if (lookahead == 'p') ADVANCE(673);
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(21);
+          lookahead == ' ') ADVANCE(19);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(681);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(678);
       if (lookahead == '$' ||
           lookahead == '.' ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(717);
+          (161 <= lookahead && lookahead <= 55295) ||
+          (57344 <= lookahead && lookahead <= 65535)) ADVANCE(713);
       END_STATE();
     case 678:
       ACCEPT_TOKEN(aux_sym_header_token2);
-      if (lookahead == '\n') ADVANCE(675);
-      if (lookahead == '/') ADVANCE(682);
-      if (lookahead == 'a') ADVANCE(680);
+      if (lookahead == '\n') ADVANCE(672);
+      if (lookahead == '/') ADVANCE(679);
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(21);
+          lookahead == ' ') ADVANCE(19);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(681);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(678);
       if (lookahead == '$' ||
           lookahead == '.' ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(717);
+          (161 <= lookahead && lookahead <= 55295) ||
+          (57344 <= lookahead && lookahead <= 65535)) ADVANCE(713);
       END_STATE();
     case 679:
       ACCEPT_TOKEN(aux_sym_header_token2);
-      if (lookahead == '\n') ADVANCE(675);
-      if (lookahead == '/') ADVANCE(682);
-      if (lookahead == 'o') ADVANCE(678);
+      if (lookahead == '\n') ADVANCE(672);
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(681);
-      if (lookahead == '$' ||
-          lookahead == '.' ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(717);
-      END_STATE();
-    case 680:
-      ACCEPT_TOKEN(aux_sym_header_token2);
-      if (lookahead == '\n') ADVANCE(675);
-      if (lookahead == '/') ADVANCE(682);
-      if (lookahead == 'p') ADVANCE(676);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(681);
-      if (lookahead == '$' ||
-          lookahead == '.' ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(717);
-      END_STATE();
-    case 681:
-      ACCEPT_TOKEN(aux_sym_header_token2);
-      if (lookahead == '\n') ADVANCE(675);
-      if (lookahead == '/') ADVANCE(682);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(681);
-      if (lookahead == '$' ||
-          lookahead == '.' ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(717);
-      END_STATE();
-    case 682:
-      ACCEPT_TOKEN(aux_sym_header_token2);
-      if (lookahead == '\n') ADVANCE(675);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(21);
+          lookahead == ' ') ADVANCE(19);
       if (lookahead == '-' ||
           ('/' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(682);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(679);
       END_STATE();
-    case 683:
+    case 680:
       ACCEPT_TOKEN(anon_sym_LBRACE_LBRACE);
       END_STATE();
-    case 684:
-      ACCEPT_TOKEN(anon_sym_LBRACE_LBRACE);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '#' &&
-          lookahead != '&' &&
-          lookahead != '=') ADVANCE(721);
-      END_STATE();
-    case 685:
+    case 681:
       ACCEPT_TOKEN(anon_sym_RBRACE_RBRACE);
       END_STATE();
-    case 686:
+    case 682:
       ACCEPT_TOKEN(aux_sym_script_variable_token1);
       END_STATE();
-    case 687:
+    case 683:
       ACCEPT_TOKEN(aux_sym_script_variable_token2);
       END_STATE();
-    case 688:
+    case 684:
       ACCEPT_TOKEN(aux_sym_xml_body_token1);
-      if (lookahead == '?') ADVANCE(85);
+      if (lookahead == '?') ADVANCE(83);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(86);
+          lookahead != '\n') ADVANCE(84);
       END_STATE();
-    case 689:
+    case 685:
       ACCEPT_TOKEN(aux_sym_xml_body_token2);
       END_STATE();
-    case 690:
+    case 686:
       ACCEPT_TOKEN(aux_sym_json_body_token1);
       END_STATE();
-    case 691:
+    case 687:
       ACCEPT_TOKEN(aux_sym_json_body_token2);
       END_STATE();
-    case 692:
+    case 688:
       ACCEPT_TOKEN(aux_sym_json_body_token3);
       END_STATE();
-    case 693:
+    case 689:
       ACCEPT_TOKEN(aux_sym_json_body_token4);
       END_STATE();
-    case 694:
+    case 690:
       ACCEPT_TOKEN(anon_sym_LPAREN);
       END_STATE();
-    case 695:
+    case 691:
       ACCEPT_TOKEN(anon_sym_LPAREN);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(741);
+          lookahead != '\n') ADVANCE(734);
+      END_STATE();
+    case 692:
+      ACCEPT_TOKEN(anon_sym_LT);
+      if (lookahead == '/') ADVANCE(82);
+      if (lookahead == '?') ADVANCE(623);
+      END_STATE();
+    case 693:
+      ACCEPT_TOKEN(anon_sym_LT);
+      if (lookahead == '?') ADVANCE(623);
+      END_STATE();
+    case 694:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '+') ADVANCE(548);
+      if (lookahead == 's') ADVANCE(695);
+      if (lookahead == '$' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (161 <= lookahead && lookahead <= 55295) ||
+          (57344 <= lookahead && lookahead <= 65535)) ADVANCE(713);
+      END_STATE();
+    case 695:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '+') ADVANCE(579);
+      if (lookahead == '$' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (161 <= lookahead && lookahead <= 55295) ||
+          (57344 <= lookahead && lookahead <= 65535)) ADVANCE(713);
       END_STATE();
     case 696:
-      ACCEPT_TOKEN(anon_sym_LT);
-      if (lookahead == '/') ADVANCE(84);
-      if (lookahead == '?') ADVANCE(625);
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '-') ADVANCE(711);
+      if (lookahead == '$' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (161 <= lookahead && lookahead <= 55295) ||
+          (57344 <= lookahead && lookahead <= 65535)) ADVANCE(713);
       END_STATE();
     case 697:
-      ACCEPT_TOKEN(anon_sym_LT);
-      if (lookahead == '?') ADVANCE(625);
-      END_STATE();
-    case 698:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '+') ADVANCE(550);
-      if (lookahead == 's') ADVANCE(699);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(717);
-      END_STATE();
-    case 699:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '+') ADVANCE(581);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(717);
-      END_STATE();
-    case 700:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '-') ADVANCE(715);
-      if (lookahead == '$' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(717);
-      END_STATE();
-    case 701:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '/') ADVANCE(659);
+      if (lookahead == '/') ADVANCE(656);
       if (lookahead == '$' ||
           ('-' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(717);
+          (161 <= lookahead && lookahead <= 55295) ||
+          (57344 <= lookahead && lookahead <= 65535)) ADVANCE(713);
+      END_STATE();
+    case 698:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'P') ADVANCE(697);
+      if (lookahead == '$' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (161 <= lookahead && lookahead <= 55295) ||
+          (57344 <= lookahead && lookahead <= 65535)) ADVANCE(713);
+      END_STATE();
+    case 699:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'T') ADVANCE(698);
+      if (lookahead == '$' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (161 <= lookahead && lookahead <= 55295) ||
+          (57344 <= lookahead && lookahead <= 65535)) ADVANCE(713);
+      END_STATE();
+    case 700:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'T') ADVANCE(699);
+      if (lookahead == '$' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (161 <= lookahead && lookahead <= 55295) ||
+          (57344 <= lookahead && lookahead <= 65535)) ADVANCE(713);
+      END_STATE();
+    case 701:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(705);
+      if (lookahead == '$' ||
+          lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z') ||
+          (161 <= lookahead && lookahead <= 55295) ||
+          (57344 <= lookahead && lookahead <= 65535)) ADVANCE(713);
       END_STATE();
     case 702:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'P') ADVANCE(701);
+      if (lookahead == 'a') ADVANCE(707);
       if (lookahead == '$' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(717);
+          ('b' <= lookahead && lookahead <= 'z') ||
+          (161 <= lookahead && lookahead <= 55295) ||
+          (57344 <= lookahead && lookahead <= 65535)) ADVANCE(713);
       END_STATE();
     case 703:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'T') ADVANCE(702);
+      if (lookahead == 'e') ADVANCE(719);
       if (lookahead == '$' ||
           lookahead == '-' ||
           lookahead == '.' ||
@@ -3917,11 +3884,12 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(717);
+          (161 <= lookahead && lookahead <= 55295) ||
+          (57344 <= lookahead && lookahead <= 65535)) ADVANCE(713);
       END_STATE();
     case 704:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'T') ADVANCE(703);
+      if (lookahead == 'e') ADVANCE(721);
       if (lookahead == '$' ||
           lookahead == '-' ||
           lookahead == '.' ||
@@ -3929,35 +3897,38 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(717);
+          (161 <= lookahead && lookahead <= 55295) ||
+          (57344 <= lookahead && lookahead <= 65535)) ADVANCE(713);
       END_STATE();
     case 705:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(709);
+      if (lookahead == 'l') ADVANCE(709);
       if (lookahead == '$' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z') ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(717);
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (161 <= lookahead && lookahead <= 55295) ||
+          (57344 <= lookahead && lookahead <= 65535)) ADVANCE(713);
       END_STATE();
     case 706:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(711);
+      if (lookahead == 'o') ADVANCE(702);
       if (lookahead == '$' ||
           lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z') ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(717);
+          ('a' <= lookahead && lookahead <= 'z') ||
+          (161 <= lookahead && lookahead <= 55295) ||
+          (57344 <= lookahead && lookahead <= 65535)) ADVANCE(713);
       END_STATE();
     case 707:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(726);
+      if (lookahead == 'p') ADVANCE(694);
       if (lookahead == '$' ||
           lookahead == '-' ||
           lookahead == '.' ||
@@ -3965,11 +3936,12 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(717);
+          (161 <= lookahead && lookahead <= 55295) ||
+          (57344 <= lookahead && lookahead <= 65535)) ADVANCE(713);
       END_STATE();
     case 708:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(728);
+      if (lookahead == 'r') ADVANCE(710);
       if (lookahead == '$' ||
           lookahead == '-' ||
           lookahead == '.' ||
@@ -3977,11 +3949,12 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(717);
+          (161 <= lookahead && lookahead <= 55295) ||
+          (57344 <= lookahead && lookahead <= 65535)) ADVANCE(713);
       END_STATE();
     case 709:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(713);
+      if (lookahead == 's') ADVANCE(704);
       if (lookahead == '$' ||
           lookahead == '-' ||
           lookahead == '.' ||
@@ -3989,11 +3962,12 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(717);
+          (161 <= lookahead && lookahead <= 55295) ||
+          (57344 <= lookahead && lookahead <= 65535)) ADVANCE(713);
       END_STATE();
     case 710:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'o') ADVANCE(706);
+      if (lookahead == 'u') ADVANCE(703);
       if (lookahead == '$' ||
           lookahead == '-' ||
           lookahead == '.' ||
@@ -4001,11 +3975,12 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(717);
+          (161 <= lookahead && lookahead <= 55295) ||
+          (57344 <= lookahead && lookahead <= 65535)) ADVANCE(713);
       END_STATE();
     case 711:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'p') ADVANCE(698);
+      if (lookahead == '{') ADVANCE(76);
       if (lookahead == '$' ||
           lookahead == '-' ||
           lookahead == '.' ||
@@ -4013,23 +3988,23 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(717);
+          (161 <= lookahead && lookahead <= 55295) ||
+          (57344 <= lookahead && lookahead <= 65535)) ADVANCE(713);
       END_STATE();
     case 712:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(714);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(712);
       if (lookahead == '$' ||
           lookahead == '-' ||
           lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(717);
+          (161 <= lookahead && lookahead <= 55295) ||
+          (57344 <= lookahead && lookahead <= 65535)) ADVANCE(713);
       END_STATE();
     case 713:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 's') ADVANCE(708);
       if (lookahead == '$' ||
           lookahead == '-' ||
           lookahead == '.' ||
@@ -4037,114 +4012,37 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(717);
+          (161 <= lookahead && lookahead <= 55295) ||
+          (57344 <= lookahead && lookahead <= 65535)) ADVANCE(713);
       END_STATE();
     case 714:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'u') ADVANCE(707);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(717);
+      ACCEPT_TOKEN(sym_query_key);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '#' &&
+          lookahead != '&' &&
+          lookahead != '=') ADVANCE(714);
       END_STATE();
     case 715:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '{') ADVANCE(78);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(717);
-      END_STATE();
-    case 716:
-      ACCEPT_TOKEN(sym_identifier);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(716);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(717);
-      END_STATE();
-    case 717:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(717);
-      END_STATE();
-    case 718:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(718);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '#' &&
-          lookahead != '$' &&
-          lookahead != '&' &&
-          lookahead != '=') ADVANCE(721);
-      END_STATE();
-    case 719:
-      ACCEPT_TOKEN(sym_query_key);
-      if (lookahead == '=') ADVANCE(722);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '#' &&
-          lookahead != '&') ADVANCE(719);
-      END_STATE();
-    case 720:
-      ACCEPT_TOKEN(sym_query_key);
-      if (lookahead == '{') ADVANCE(684);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '#' &&
-          lookahead != '&' &&
-          lookahead != '=') ADVANCE(721);
-      END_STATE();
-    case 721:
-      ACCEPT_TOKEN(sym_query_key);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '#' &&
-          lookahead != '&' &&
-          lookahead != '=') ADVANCE(721);
-      END_STATE();
-    case 722:
       ACCEPT_TOKEN(sym_param);
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != '#' &&
-          lookahead != '&') ADVANCE(722);
+          lookahead != '&' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(715);
       END_STATE();
-    case 723:
+    case 716:
       ACCEPT_TOKEN(sym_number);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(723);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(716);
       END_STATE();
-    case 724:
+    case 717:
       ACCEPT_TOKEN(sym_string);
       END_STATE();
-    case 725:
+    case 718:
       ACCEPT_TOKEN(anon_sym_true);
       END_STATE();
-    case 726:
+    case 719:
       ACCEPT_TOKEN(anon_sym_true);
       if (lookahead == '$' ||
           lookahead == '-' ||
@@ -4153,12 +4051,13 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(717);
+          (161 <= lookahead && lookahead <= 55295) ||
+          (57344 <= lookahead && lookahead <= 65535)) ADVANCE(713);
       END_STATE();
-    case 727:
+    case 720:
       ACCEPT_TOKEN(anon_sym_false);
       END_STATE();
-    case 728:
+    case 721:
       ACCEPT_TOKEN(anon_sym_false);
       if (lookahead == '$' ||
           lookahead == '-' ||
@@ -4167,82 +4066,83 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(717);
+          (161 <= lookahead && lookahead <= 55295) ||
+          (57344 <= lookahead && lookahead <= 65535)) ADVANCE(713);
       END_STATE();
-    case 729:
+    case 722:
       ACCEPT_TOKEN(aux_sym__whitespace_token1);
       END_STATE();
-    case 730:
+    case 723:
       ACCEPT_TOKEN(aux_sym__whitespace_token1);
-      if (lookahead == '\n') ADVANCE(675);
+      if (lookahead == '\n') ADVANCE(672);
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ' ||
           lookahead == '-' ||
           ('/' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(21);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(19);
       END_STATE();
-    case 731:
+    case 724:
       ACCEPT_TOKEN(aux_sym__whitespace_token1);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(741);
+          lookahead != '\n') ADVANCE(734);
+      END_STATE();
+    case 725:
+      ACCEPT_TOKEN(sym__line);
+      if (lookahead == '\n') ADVANCE(689);
+      if (lookahead != 0) ADVANCE(734);
+      END_STATE();
+    case 726:
+      ACCEPT_TOKEN(sym__line);
+      if (lookahead == '\n') ADVANCE(688);
+      if (lookahead != 0) ADVANCE(734);
+      END_STATE();
+    case 727:
+      ACCEPT_TOKEN(sym__line);
+      if (lookahead == '\n') ADVANCE(685);
+      if (lookahead == '>') ADVANCE(727);
+      if (lookahead != 0) ADVANCE(732);
+      END_STATE();
+    case 728:
+      ACCEPT_TOKEN(sym__line);
+      if (lookahead == '\n') ADVANCE(683);
+      if (lookahead != 0) ADVANCE(734);
+      END_STATE();
+    case 729:
+      ACCEPT_TOKEN(sym__line);
+      if (lookahead == '%') ADVANCE(733);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(734);
+      END_STATE();
+    case 730:
+      ACCEPT_TOKEN(sym__line);
+      if (lookahead == '-') ADVANCE(729);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(734);
+      END_STATE();
+    case 731:
+      ACCEPT_TOKEN(sym__line);
+      if (lookahead == '/') ADVANCE(732);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(734);
       END_STATE();
     case 732:
       ACCEPT_TOKEN(sym__line);
-      if (lookahead == '\n') ADVANCE(693);
-      if (lookahead != 0) ADVANCE(741);
+      if (lookahead == '>') ADVANCE(727);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(732);
       END_STATE();
     case 733:
       ACCEPT_TOKEN(sym__line);
-      if (lookahead == '\n') ADVANCE(692);
-      if (lookahead != 0) ADVANCE(741);
+      if (lookahead == '}') ADVANCE(728);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(734);
       END_STATE();
     case 734:
       ACCEPT_TOKEN(sym__line);
-      if (lookahead == '\n') ADVANCE(689);
-      if (lookahead == '>') ADVANCE(734);
-      if (lookahead != 0) ADVANCE(739);
-      END_STATE();
-    case 735:
-      ACCEPT_TOKEN(sym__line);
-      if (lookahead == '\n') ADVANCE(687);
-      if (lookahead != 0) ADVANCE(741);
-      END_STATE();
-    case 736:
-      ACCEPT_TOKEN(sym__line);
-      if (lookahead == '%') ADVANCE(740);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(741);
-      END_STATE();
-    case 737:
-      ACCEPT_TOKEN(sym__line);
-      if (lookahead == '-') ADVANCE(736);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(741);
-      END_STATE();
-    case 738:
-      ACCEPT_TOKEN(sym__line);
-      if (lookahead == '/') ADVANCE(739);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(741);
-      END_STATE();
-    case 739:
-      ACCEPT_TOKEN(sym__line);
-      if (lookahead == '>') ADVANCE(734);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(739);
-      END_STATE();
-    case 740:
-      ACCEPT_TOKEN(sym__line);
-      if (lookahead == '}') ADVANCE(735);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(741);
-      END_STATE();
-    case 741:
-      ACCEPT_TOKEN(sym__line);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(741);
+          lookahead != '\n') ADVANCE(734);
       END_STATE();
     default:
       return false;
@@ -4254,33 +4154,31 @@ static bool ts_lex_keywords(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      ADVANCE_MAP(
-        'C', 1,
-        'D', 2,
-        'G', 3,
-        'H', 4,
-        'L', 5,
-        'O', 6,
-        'P', 7,
-        'T', 8,
-        'a', 9,
-        'c', 10,
-        'd', 11,
-        'e', 12,
-        'f', 13,
-        'g', 14,
-        'h', 15,
-        'i', 16,
-        'm', 17,
-        'n', 18,
-        'p', 19,
-        'q', 20,
-        'r', 21,
-        's', 22,
-        't', 23,
-        'u', 24,
-        'w', 25,
-      );
+      if (lookahead == 'C') ADVANCE(1);
+      if (lookahead == 'D') ADVANCE(2);
+      if (lookahead == 'G') ADVANCE(3);
+      if (lookahead == 'H') ADVANCE(4);
+      if (lookahead == 'L') ADVANCE(5);
+      if (lookahead == 'O') ADVANCE(6);
+      if (lookahead == 'P') ADVANCE(7);
+      if (lookahead == 'T') ADVANCE(8);
+      if (lookahead == 'a') ADVANCE(9);
+      if (lookahead == 'c') ADVANCE(10);
+      if (lookahead == 'd') ADVANCE(11);
+      if (lookahead == 'e') ADVANCE(12);
+      if (lookahead == 'f') ADVANCE(13);
+      if (lookahead == 'g') ADVANCE(14);
+      if (lookahead == 'h') ADVANCE(15);
+      if (lookahead == 'i') ADVANCE(16);
+      if (lookahead == 'm') ADVANCE(17);
+      if (lookahead == 'n') ADVANCE(18);
+      if (lookahead == 'p') ADVANCE(19);
+      if (lookahead == 'q') ADVANCE(20);
+      if (lookahead == 'r') ADVANCE(21);
+      if (lookahead == 's') ADVANCE(22);
+      if (lookahead == 't') ADVANCE(23);
+      if (lookahead == 'u') ADVANCE(24);
+      if (lookahead == 'w') ADVANCE(25);
       END_STATE();
     case 1:
       if (lookahead == 'O') ADVANCE(26);
@@ -4804,245 +4702,218 @@ static bool ts_lex_keywords(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 645},
-  [2] = {.lex_state = 77},
-  [3] = {.lex_state = 22},
-  [4] = {.lex_state = 22},
-  [5] = {.lex_state = 77},
-  [6] = {.lex_state = 22},
-  [7] = {.lex_state = 77},
-  [8] = {.lex_state = 22},
-  [9] = {.lex_state = 646},
-  [10] = {.lex_state = 646},
-  [11] = {.lex_state = 645},
-  [12] = {.lex_state = 645},
-  [13] = {.lex_state = 645},
-  [14] = {.lex_state = 645},
-  [15] = {.lex_state = 645},
-  [16] = {.lex_state = 645},
-  [17] = {.lex_state = 645},
-  [18] = {.lex_state = 645},
-  [19] = {.lex_state = 645},
-  [20] = {.lex_state = 645},
-  [21] = {.lex_state = 645},
-  [22] = {.lex_state = 645},
-  [23] = {.lex_state = 645},
-  [24] = {.lex_state = 645},
-  [25] = {.lex_state = 645},
-  [26] = {.lex_state = 645},
-  [27] = {.lex_state = 645},
-  [28] = {.lex_state = 645},
-  [29] = {.lex_state = 645},
-  [30] = {.lex_state = 645},
-  [31] = {.lex_state = 645},
-  [32] = {.lex_state = 645},
-  [33] = {.lex_state = 645},
-  [34] = {.lex_state = 645},
-  [35] = {.lex_state = 645},
-  [36] = {.lex_state = 645},
-  [37] = {.lex_state = 645},
-  [38] = {.lex_state = 645},
-  [39] = {.lex_state = 645},
-  [40] = {.lex_state = 645},
-  [41] = {.lex_state = 645},
-  [42] = {.lex_state = 645},
-  [43] = {.lex_state = 645},
-  [44] = {.lex_state = 645},
-  [45] = {.lex_state = 645},
-  [46] = {.lex_state = 645},
-  [47] = {.lex_state = 645},
-  [48] = {.lex_state = 645},
-  [49] = {.lex_state = 645},
-  [50] = {.lex_state = 645},
-  [51] = {.lex_state = 645},
-  [52] = {.lex_state = 645},
-  [53] = {.lex_state = 645},
-  [54] = {.lex_state = 645},
-  [55] = {.lex_state = 645},
-  [56] = {.lex_state = 645},
-  [57] = {.lex_state = 645},
-  [58] = {.lex_state = 645},
-  [59] = {.lex_state = 645},
-  [60] = {.lex_state = 645},
-  [61] = {.lex_state = 1},
-  [62] = {.lex_state = 2},
-  [63] = {.lex_state = 74},
-  [64] = {.lex_state = 74},
-  [65] = {.lex_state = 74},
-  [66] = {.lex_state = 74},
-  [67] = {.lex_state = 74},
-  [68] = {.lex_state = 1},
-  [69] = {.lex_state = 74},
-  [70] = {.lex_state = 5},
-  [71] = {.lex_state = 3},
-  [72] = {.lex_state = 645},
-  [73] = {.lex_state = 3},
-  [74] = {.lex_state = 4},
-  [75] = {.lex_state = 645},
+  [1] = {.lex_state = 643},
+  [2] = {.lex_state = 75},
+  [3] = {.lex_state = 20},
+  [4] = {.lex_state = 20},
+  [5] = {.lex_state = 75},
+  [6] = {.lex_state = 20},
+  [7] = {.lex_state = 75},
+  [8] = {.lex_state = 20},
+  [9] = {.lex_state = 644},
+  [10] = {.lex_state = 644},
+  [11] = {.lex_state = 643},
+  [12] = {.lex_state = 643},
+  [13] = {.lex_state = 643},
+  [14] = {.lex_state = 643},
+  [15] = {.lex_state = 643},
+  [16] = {.lex_state = 643},
+  [17] = {.lex_state = 643},
+  [18] = {.lex_state = 643},
+  [19] = {.lex_state = 643},
+  [20] = {.lex_state = 643},
+  [21] = {.lex_state = 643},
+  [22] = {.lex_state = 643},
+  [23] = {.lex_state = 643},
+  [24] = {.lex_state = 643},
+  [25] = {.lex_state = 643},
+  [26] = {.lex_state = 643},
+  [27] = {.lex_state = 643},
+  [28] = {.lex_state = 643},
+  [29] = {.lex_state = 643},
+  [30] = {.lex_state = 643},
+  [31] = {.lex_state = 643},
+  [32] = {.lex_state = 643},
+  [33] = {.lex_state = 643},
+  [34] = {.lex_state = 643},
+  [35] = {.lex_state = 643},
+  [36] = {.lex_state = 643},
+  [37] = {.lex_state = 643},
+  [38] = {.lex_state = 643},
+  [39] = {.lex_state = 643},
+  [40] = {.lex_state = 643},
+  [41] = {.lex_state = 643},
+  [42] = {.lex_state = 1},
+  [43] = {.lex_state = 643},
+  [44] = {.lex_state = 643},
+  [45] = {.lex_state = 643},
+  [46] = {.lex_state = 643},
+  [47] = {.lex_state = 643},
+  [48] = {.lex_state = 643},
+  [49] = {.lex_state = 643},
+  [50] = {.lex_state = 643},
+  [51] = {.lex_state = 643},
+  [52] = {.lex_state = 643},
+  [53] = {.lex_state = 643},
+  [54] = {.lex_state = 643},
+  [55] = {.lex_state = 643},
+  [56] = {.lex_state = 643},
+  [57] = {.lex_state = 643},
+  [58] = {.lex_state = 643},
+  [59] = {.lex_state = 643},
+  [60] = {.lex_state = 643},
+  [61] = {.lex_state = 643},
+  [62] = {.lex_state = 75},
+  [63] = {.lex_state = 75},
+  [64] = {.lex_state = 75},
+  [65] = {.lex_state = 75},
+  [66] = {.lex_state = 2},
+  [67] = {.lex_state = 1},
+  [68] = {.lex_state = 72},
+  [69] = {.lex_state = 72},
+  [70] = {.lex_state = 72},
+  [71] = {.lex_state = 72},
+  [72] = {.lex_state = 72},
+  [73] = {.lex_state = 1},
+  [74] = {.lex_state = 1},
+  [75] = {.lex_state = 1},
   [76] = {.lex_state = 75},
-  [77] = {.lex_state = 4},
-  [78] = {.lex_state = 75},
-  [79] = {.lex_state = 4},
-  [80] = {.lex_state = 4},
-  [81] = {.lex_state = 1},
-  [82] = {.lex_state = 645},
-  [83] = {.lex_state = 1},
-  [84] = {.lex_state = 1},
-  [85] = {.lex_state = 77},
-  [86] = {.lex_state = 77},
-  [87] = {.lex_state = 645},
-  [88] = {.lex_state = 77},
-  [89] = {.lex_state = 77},
-  [90] = {.lex_state = 4},
-  [91] = {.lex_state = 4},
-  [92] = {.lex_state = 4},
-  [93] = {.lex_state = 77},
-  [94] = {.lex_state = 4},
-  [95] = {.lex_state = 1},
-  [96] = {.lex_state = 5},
-  [97] = {.lex_state = 77},
-  [98] = {.lex_state = 3},
-  [99] = {.lex_state = 6},
-  [100] = {.lex_state = 77},
-  [101] = {.lex_state = 6},
-  [102] = {.lex_state = 77},
-  [103] = {.lex_state = 1},
-  [104] = {.lex_state = 3},
-  [105] = {.lex_state = 1},
-  [106] = {.lex_state = 3},
-  [107] = {.lex_state = 3},
-  [108] = {.lex_state = 3},
-  [109] = {.lex_state = 3},
-  [110] = {.lex_state = 10},
-  [111] = {.lex_state = 645},
-  [112] = {.lex_state = 77},
-  [113] = {.lex_state = 77},
-  [114] = {.lex_state = 10},
-  [115] = {.lex_state = 4},
-  [116] = {.lex_state = 1},
-  [117] = {.lex_state = 4},
-  [118] = {.lex_state = 77},
-  [119] = {.lex_state = 4},
-  [120] = {.lex_state = 4},
-  [121] = {.lex_state = 1},
-  [122] = {.lex_state = 4},
-  [123] = {.lex_state = 4},
-  [124] = {.lex_state = 4},
-  [125] = {.lex_state = 77},
-  [126] = {.lex_state = 646},
-  [127] = {.lex_state = 77},
-  [128] = {.lex_state = 77},
-  [129] = {.lex_state = 4},
-  [130] = {.lex_state = 645},
-  [131] = {.lex_state = 4},
-  [132] = {.lex_state = 77},
-  [133] = {.lex_state = 1},
-  [134] = {.lex_state = 1},
+  [77] = {.lex_state = 1},
+  [78] = {.lex_state = 3},
+  [79] = {.lex_state = 75},
+  [80] = {.lex_state = 72},
+  [81] = {.lex_state = 75},
+  [82] = {.lex_state = 75},
+  [83] = {.lex_state = 643},
+  [84] = {.lex_state = 73},
+  [85] = {.lex_state = 75},
+  [86] = {.lex_state = 75},
+  [87] = {.lex_state = 643},
+  [88] = {.lex_state = 643},
+  [89] = {.lex_state = 643},
+  [90] = {.lex_state = 75},
+  [91] = {.lex_state = 75},
+  [92] = {.lex_state = 75},
+  [93] = {.lex_state = 75},
+  [94] = {.lex_state = 75},
+  [95] = {.lex_state = 75},
+  [96] = {.lex_state = 75},
+  [97] = {.lex_state = 73},
+  [98] = {.lex_state = 75},
+  [99] = {.lex_state = 75},
+  [100] = {.lex_state = 1},
+  [101] = {.lex_state = 75},
+  [102] = {.lex_state = 1},
+  [103] = {.lex_state = 75},
+  [104] = {.lex_state = 75},
+  [105] = {.lex_state = 75},
+  [106] = {.lex_state = 75},
+  [107] = {.lex_state = 75},
+  [108] = {.lex_state = 75},
+  [109] = {.lex_state = 643},
+  [110] = {.lex_state = 1},
+  [111] = {.lex_state = 75},
+  [112] = {.lex_state = 643},
+  [113] = {.lex_state = 1},
+  [114] = {.lex_state = 8},
+  [115] = {.lex_state = 8},
+  [116] = {.lex_state = 644},
+  [117] = {.lex_state = 1},
+  [118] = {.lex_state = 1},
+  [119] = {.lex_state = 643},
+  [120] = {.lex_state = 1},
+  [121] = {.lex_state = 5},
+  [122] = {.lex_state = 1},
+  [123] = {.lex_state = 643},
+  [124] = {.lex_state = 643},
+  [125] = {.lex_state = 7},
+  [126] = {.lex_state = 643},
+  [127] = {.lex_state = 643},
+  [128] = {.lex_state = 637},
+  [129] = {.lex_state = 1},
+  [130] = {.lex_state = 9},
+  [131] = {.lex_state = 10},
+  [132] = {.lex_state = 7},
+  [133] = {.lex_state = 6},
+  [134] = {.lex_state = 643},
   [135] = {.lex_state = 1},
-  [136] = {.lex_state = 1},
+  [136] = {.lex_state = 643},
   [137] = {.lex_state = 9},
-  [138] = {.lex_state = 1},
-  [139] = {.lex_state = 645},
-  [140] = {.lex_state = 645},
-  [141] = {.lex_state = 645},
-  [142] = {.lex_state = 645},
-  [143] = {.lex_state = 645},
-  [144] = {.lex_state = 645},
-  [145] = {.lex_state = 645},
-  [146] = {.lex_state = 11},
-  [147] = {.lex_state = 645},
-  [148] = {.lex_state = 12},
-  [149] = {.lex_state = 639},
+  [138] = {.lex_state = 643},
+  [139] = {.lex_state = 10},
+  [140] = {.lex_state = 643},
+  [141] = {.lex_state = 643},
+  [142] = {.lex_state = 643},
+  [143] = {.lex_state = 637},
+  [144] = {.lex_state = 10},
+  [145] = {.lex_state = 6},
+  [146] = {.lex_state = 72},
+  [147] = {.lex_state = 9},
+  [148] = {.lex_state = 1},
+  [149] = {.lex_state = 643},
   [150] = {.lex_state = 1},
-  [151] = {.lex_state = 11},
-  [152] = {.lex_state = 639},
-  [153] = {.lex_state = 12},
-  [154] = {.lex_state = 12},
-  [155] = {.lex_state = 645},
-  [156] = {.lex_state = 9},
-  [157] = {.lex_state = 1},
-  [158] = {.lex_state = 7},
-  [159] = {.lex_state = 74},
-  [160] = {.lex_state = 645},
-  [161] = {.lex_state = 77},
+  [151] = {.lex_state = 1},
+  [152] = {.lex_state = 11},
+  [153] = {.lex_state = 11},
+  [154] = {.lex_state = 4},
+  [155] = {.lex_state = 638},
+  [156] = {.lex_state = 4},
+  [157] = {.lex_state = 643},
+  [158] = {.lex_state = 643},
+  [159] = {.lex_state = 637},
+  [160] = {.lex_state = 1},
+  [161] = {.lex_state = 10},
   [162] = {.lex_state = 1},
-  [163] = {.lex_state = 8},
-  [164] = {.lex_state = 645},
-  [165] = {.lex_state = 645},
-  [166] = {.lex_state = 645},
-  [167] = {.lex_state = 11},
-  [168] = {.lex_state = 8},
-  [169] = {.lex_state = 77},
-  [170] = {.lex_state = 645},
-  [171] = {.lex_state = 1},
-  [172] = {.lex_state = 645},
-  [173] = {.lex_state = 77},
-  [174] = {.lex_state = 13},
-  [175] = {.lex_state = 639},
-  [176] = {.lex_state = 645},
-  [177] = {.lex_state = 14},
-  [178] = {.lex_state = 645},
-  [179] = {.lex_state = 13},
-  [180] = {.lex_state = 14},
-  [181] = {.lex_state = 14},
-  [182] = {.lex_state = 645},
-  [183] = {.lex_state = 640},
-  [184] = {.lex_state = 1},
-  [185] = {.lex_state = 1},
-  [186] = {.lex_state = 14},
-  [187] = {.lex_state = 13},
-  [188] = {.lex_state = 13},
-  [189] = {.lex_state = 645},
-  [190] = {.lex_state = 645},
-  [191] = {.lex_state = 645},
-  [192] = {.lex_state = 1},
-  [193] = {.lex_state = 645},
-  [194] = {.lex_state = 12},
-  [195] = {.lex_state = 13},
-  [196] = {.lex_state = 645},
-  [197] = {.lex_state = 14},
-  [198] = {.lex_state = 640},
-  [199] = {.lex_state = 14},
-  [200] = {.lex_state = 1},
-  [201] = {.lex_state = 645},
-  [202] = {.lex_state = 14},
-  [203] = {.lex_state = 646},
-  [204] = {.lex_state = 645},
-  [205] = {.lex_state = 645},
-  [206] = {.lex_state = 646},
-  [207] = {.lex_state = 1},
-  [208] = {.lex_state = 645},
-  [209] = {.lex_state = 646},
-  [210] = {.lex_state = 645},
-  [211] = {.lex_state = 645},
-  [212] = {.lex_state = 645},
-  [213] = {.lex_state = 645},
-  [214] = {.lex_state = 645},
-  [215] = {.lex_state = 1},
-  [216] = {.lex_state = 645},
-  [217] = {.lex_state = 4},
-  [218] = {.lex_state = 1},
-  [219] = {.lex_state = 1},
-  [220] = {.lex_state = 645},
-  [221] = {.lex_state = 1},
-  [222] = {.lex_state = 645},
-  [223] = {.lex_state = 641},
-  [224] = {.lex_state = 1},
-  [225] = {.lex_state = 645},
-  [226] = {.lex_state = 645},
-  [227] = {.lex_state = 645},
-  [228] = {.lex_state = 641},
-  [229] = {.lex_state = 642},
-  [230] = {.lex_state = 645},
-  [231] = {.lex_state = 642},
-  [232] = {.lex_state = 645},
-  [233] = {.lex_state = 645},
-  [234] = {.lex_state = 645},
-  [235] = {.lex_state = 645},
-  [236] = {.lex_state = 645},
-  [237] = {.lex_state = 645},
-  [238] = {.lex_state = 645},
-  [239] = {.lex_state = 645},
+  [163] = {.lex_state = 4},
+  [164] = {.lex_state = 4},
+  [165] = {.lex_state = 643},
+  [166] = {.lex_state = 638},
+  [167] = {.lex_state = 643},
+  [168] = {.lex_state = 643},
+  [169] = {.lex_state = 4},
+  [170] = {.lex_state = 643},
+  [171] = {.lex_state = 643},
+  [172] = {.lex_state = 11},
+  [173] = {.lex_state = 643},
+  [174] = {.lex_state = 11},
+  [175] = {.lex_state = 4},
+  [176] = {.lex_state = 11},
+  [177] = {.lex_state = 643},
+  [178] = {.lex_state = 1},
+  [179] = {.lex_state = 639},
+  [180] = {.lex_state = 643},
+  [181] = {.lex_state = 643},
+  [182] = {.lex_state = 1},
+  [183] = {.lex_state = 643},
+  [184] = {.lex_state = 643},
+  [185] = {.lex_state = 643},
+  [186] = {.lex_state = 644},
+  [187] = {.lex_state = 644},
+  [188] = {.lex_state = 643},
+  [189] = {.lex_state = 1},
+  [190] = {.lex_state = 12},
+  [191] = {.lex_state = 639},
+  [192] = {.lex_state = 643},
+  [193] = {.lex_state = 643},
+  [194] = {.lex_state = 643},
+  [195] = {.lex_state = 640},
+  [196] = {.lex_state = 1},
+  [197] = {.lex_state = 643},
+  [198] = {.lex_state = 643},
+  [199] = {.lex_state = 643},
+  [200] = {.lex_state = 643},
+  [201] = {.lex_state = 643},
+  [202] = {.lex_state = 640},
+  [203] = {.lex_state = 1},
+  [204] = {.lex_state = 644},
+  [205] = {.lex_state = 643},
+  [206] = {.lex_state = 1},
+  [207] = {.lex_state = 643},
+  [208] = {.lex_state = 643},
+  [209] = {.lex_state = 643},
+  [210] = {.lex_state = 643},
+  [211] = {.lex_state = 643},
+  [212] = {.lex_state = 643},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -5093,10 +4964,10 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_AT] = ACTIONS(1),
     [anon_sym_HTTP_SLASH] = ACTIONS(1),
     [anon_sym_POUND] = ACTIONS(1),
-    [anon_sym_QMARK] = ACTIONS(1),
     [sym_status_code] = ACTIONS(1),
     [aux_sym_request_token1] = ACTIONS(3),
     [anon_sym_AMP] = ACTIONS(1),
+    [anon_sym_QMARK] = ACTIONS(1),
     [anon_sym_EQ] = ACTIONS(1),
     [anon_sym_LBRACE_LBRACE] = ACTIONS(1),
     [anon_sym_RBRACE_RBRACE] = ACTIONS(1),
@@ -5120,7 +4991,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym__newline_token1] = ACTIONS(1),
   },
   [1] = {
-    [sym_document] = STATE(216),
+    [sym_document] = STATE(181),
     [sym_request] = STATE(60),
     [sym_variable] = STATE(60),
     [sym_script_variable] = STATE(60),
@@ -5152,21 +5023,21 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym__whitespace_token1,
     STATE(5), 1,
       aux_sym__whitespace,
-    STATE(61), 1,
+    STATE(42), 1,
       sym_variable,
-    STATE(73), 1,
-      aux_sym_path_repeat1,
-    STATE(93), 1,
+    STATE(64), 1,
       sym_host,
     STATE(94), 1,
+      aux_sym_path_repeat1,
+    STATE(95), 1,
       sym_path,
-    STATE(200), 1,
-      sym_authority,
-    STATE(201), 1,
+    STATE(158), 1,
       sym_target_url,
-    STATE(206), 1,
+    STATE(160), 1,
+      sym_authority,
+    STATE(187), 1,
       sym_scheme,
-    STATE(230), 1,
+    STATE(201), 1,
       sym_pair,
     ACTIONS(23), 4,
       anon_sym_coap_PLUStcp,
@@ -5224,17 +5095,17 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym__whitespace_token1,
     STATE(4), 1,
       aux_sym__whitespace,
-    STATE(49), 1,
+    STATE(39), 1,
       sym_host_url,
-    STATE(51), 1,
+    STATE(40), 1,
       sym_host,
-    STATE(53), 1,
+    STATE(41), 1,
       sym_variable,
-    STATE(184), 1,
+    STATE(151), 1,
       sym_authority,
-    STATE(203), 1,
+    STATE(186), 1,
       sym_scheme,
-    STATE(230), 1,
+    STATE(201), 1,
       sym_pair,
     ACTIONS(23), 4,
       anon_sym_coap_PLUStcp,
@@ -5293,16 +5164,16 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(6), 1,
       aux_sym__whitespace,
     STATE(40), 1,
-      sym_host_url,
-    STATE(51), 1,
       sym_host,
-    STATE(54), 1,
+    STATE(48), 1,
+      sym_host_url,
+    STATE(49), 1,
       sym_variable,
-    STATE(184), 1,
+    STATE(151), 1,
       sym_authority,
-    STATE(203), 1,
+    STATE(186), 1,
       sym_scheme,
-    STATE(230), 1,
+    STATE(201), 1,
       sym_pair,
     ACTIONS(23), 4,
       anon_sym_coap_PLUStcp,
@@ -5556,9 +5427,9 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_xml_body_token1,
     ACTIONS(73), 1,
       anon_sym_LT,
-    STATE(196), 1,
+    STATE(149), 1,
       sym_http_version,
-    STATE(235), 1,
+    STATE(209), 1,
       sym_response,
     ACTIONS(69), 2,
       aux_sym_json_body_token1,
@@ -5566,7 +5437,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(71), 2,
       anon_sym_query,
       anon_sym_mutation,
-    STATE(11), 2,
+    STATE(13), 2,
       sym_header,
       aux_sym_request_repeat1,
     ACTIONS(59), 5,
@@ -5575,7 +5446,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AT,
       anon_sym_LBRACE_LBRACE,
       aux_sym_script_variable_token1,
-    STATE(17), 6,
+    STATE(22), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
@@ -5595,9 +5466,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
     ACTIONS(77), 1,
       sym_method,
-    STATE(196), 1,
+    STATE(149), 1,
       sym_http_version,
-    STATE(236), 1,
+    STATE(208), 1,
       sym_response,
     ACTIONS(69), 2,
       aux_sym_json_body_token1,
@@ -5614,7 +5485,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AT,
       anon_sym_LBRACE_LBRACE,
       aux_sym_script_variable_token1,
-    STATE(22), 6,
+    STATE(17), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
@@ -5638,7 +5509,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(71), 2,
       anon_sym_query,
       anon_sym_mutation,
-    STATE(30), 2,
+    STATE(14), 2,
       sym_header,
       aux_sym_request_repeat1,
     ACTIONS(79), 5,
@@ -5647,7 +5518,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AT,
       anon_sym_LBRACE_LBRACE,
       aux_sym_script_variable_token1,
-    STATE(21), 6,
+    STATE(18), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
@@ -5680,7 +5551,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AT,
       anon_sym_LBRACE_LBRACE,
       aux_sym_script_variable_token1,
-    STATE(22), 6,
+    STATE(17), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
@@ -5704,7 +5575,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(71), 2,
       anon_sym_query,
       anon_sym_mutation,
-    STATE(14), 2,
+    STATE(28), 2,
       sym_header,
       aux_sym_request_repeat1,
     ACTIONS(83), 5,
@@ -5713,7 +5584,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AT,
       anon_sym_LBRACE_LBRACE,
       aux_sym_script_variable_token1,
-    STATE(18), 6,
+    STATE(20), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
@@ -5737,7 +5608,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(71), 2,
       anon_sym_query,
       anon_sym_mutation,
-    STATE(30), 2,
+    STATE(28), 2,
       sym_header,
       aux_sym_request_repeat1,
     ACTIONS(87), 5,
@@ -5746,7 +5617,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AT,
       anon_sym_LBRACE_LBRACE,
       aux_sym_script_variable_token1,
-    STATE(20), 6,
+    STATE(21), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
@@ -5770,40 +5641,10 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(71), 2,
       anon_sym_query,
       anon_sym_mutation,
-    STATE(30), 2,
+    STATE(28), 2,
       sym_header,
       aux_sym_request_repeat1,
     ACTIONS(91), 5,
-      ts_builtin_sym_end,
-      sym_comment,
-      anon_sym_AT,
-      anon_sym_LBRACE_LBRACE,
-      aux_sym_script_variable_token1,
-    STATE(19), 6,
-      sym_xml_body,
-      sym_json_body,
-      sym_graphql_body,
-      sym_external_body,
-      sym_form_data,
-      aux_sym_request_repeat2,
-  [790] = 9,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(97), 1,
-      sym_identifier,
-    ACTIONS(100), 1,
-      sym_method,
-    ACTIONS(102), 1,
-      aux_sym_xml_body_token1,
-    ACTIONS(111), 1,
-      anon_sym_LT,
-    ACTIONS(105), 2,
-      aux_sym_json_body_token1,
-      aux_sym_json_body_token2,
-    ACTIONS(108), 2,
-      anon_sym_query,
-      anon_sym_mutation,
-    ACTIONS(95), 5,
       ts_builtin_sym_end,
       sym_comment,
       anon_sym_AT,
@@ -5816,7 +5657,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_external_body,
       sym_form_data,
       aux_sym_request_repeat2,
-  [829] = 9,
+  [790] = 9,
     ACTIONS(3), 1,
       aux_sym_request_token1,
     ACTIONS(67), 1,
@@ -5825,7 +5666,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
     ACTIONS(81), 1,
       sym_method,
-    ACTIONS(114), 1,
+    ACTIONS(95), 1,
       sym_identifier,
     ACTIONS(69), 2,
       aux_sym_json_body_token1,
@@ -5839,7 +5680,37 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AT,
       anon_sym_LBRACE_LBRACE,
       aux_sym_script_variable_token1,
-    STATE(16), 6,
+    STATE(19), 6,
+      sym_xml_body,
+      sym_json_body,
+      sym_graphql_body,
+      sym_external_body,
+      sym_form_data,
+      aux_sym_request_repeat2,
+  [829] = 9,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(67), 1,
+      aux_sym_xml_body_token1,
+    ACTIONS(73), 1,
+      anon_sym_LT,
+    ACTIONS(93), 1,
+      sym_method,
+    ACTIONS(95), 1,
+      sym_identifier,
+    ACTIONS(69), 2,
+      aux_sym_json_body_token1,
+      aux_sym_json_body_token2,
+    ACTIONS(71), 2,
+      anon_sym_query,
+      anon_sym_mutation,
+    ACTIONS(91), 5,
+      ts_builtin_sym_end,
+      sym_comment,
+      anon_sym_AT,
+      anon_sym_LBRACE_LBRACE,
+      aux_sym_script_variable_token1,
+    STATE(19), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
@@ -5855,7 +5726,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
     ACTIONS(89), 1,
       sym_method,
-    ACTIONS(114), 1,
+    ACTIONS(95), 1,
       sym_identifier,
     ACTIONS(69), 2,
       aux_sym_json_body_token1,
@@ -5869,7 +5740,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AT,
       anon_sym_LBRACE_LBRACE,
       aux_sym_script_variable_token1,
-    STATE(16), 6,
+    STATE(19), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
@@ -5879,27 +5750,27 @@ static const uint16_t ts_small_parse_table[] = {
   [907] = 9,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(67), 1,
-      aux_sym_xml_body_token1,
-    ACTIONS(73), 1,
-      anon_sym_LT,
-    ACTIONS(85), 1,
-      sym_method,
-    ACTIONS(114), 1,
+    ACTIONS(99), 1,
       sym_identifier,
-    ACTIONS(69), 2,
+    ACTIONS(102), 1,
+      sym_method,
+    ACTIONS(104), 1,
+      aux_sym_xml_body_token1,
+    ACTIONS(113), 1,
+      anon_sym_LT,
+    ACTIONS(107), 2,
       aux_sym_json_body_token1,
       aux_sym_json_body_token2,
-    ACTIONS(71), 2,
+    ACTIONS(110), 2,
       anon_sym_query,
       anon_sym_mutation,
-    ACTIONS(83), 5,
+    ACTIONS(97), 5,
       ts_builtin_sym_end,
       sym_comment,
       anon_sym_AT,
       anon_sym_LBRACE_LBRACE,
       aux_sym_script_variable_token1,
-    STATE(16), 6,
+    STATE(19), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
@@ -5913,7 +5784,37 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_xml_body_token1,
     ACTIONS(73), 1,
       anon_sym_LT,
-    ACTIONS(114), 1,
+    ACTIONS(77), 1,
+      sym_method,
+    ACTIONS(95), 1,
+      sym_identifier,
+    ACTIONS(69), 2,
+      aux_sym_json_body_token1,
+      aux_sym_json_body_token2,
+    ACTIONS(71), 2,
+      anon_sym_query,
+      anon_sym_mutation,
+    ACTIONS(75), 5,
+      ts_builtin_sym_end,
+      sym_comment,
+      anon_sym_AT,
+      anon_sym_LBRACE_LBRACE,
+      aux_sym_script_variable_token1,
+    STATE(19), 6,
+      sym_xml_body,
+      sym_json_body,
+      sym_graphql_body,
+      sym_external_body,
+      sym_form_data,
+      aux_sym_request_repeat2,
+  [985] = 9,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(67), 1,
+      aux_sym_xml_body_token1,
+    ACTIONS(73), 1,
+      anon_sym_LT,
+    ACTIONS(95), 1,
       sym_identifier,
     ACTIONS(118), 1,
       sym_method,
@@ -5929,37 +5830,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AT,
       anon_sym_LBRACE_LBRACE,
       aux_sym_script_variable_token1,
-    STATE(16), 6,
-      sym_xml_body,
-      sym_json_body,
-      sym_graphql_body,
-      sym_external_body,
-      sym_form_data,
-      aux_sym_request_repeat2,
-  [985] = 9,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(67), 1,
-      aux_sym_xml_body_token1,
-    ACTIONS(73), 1,
-      anon_sym_LT,
-    ACTIONS(77), 1,
-      sym_method,
-    ACTIONS(114), 1,
-      sym_identifier,
-    ACTIONS(69), 2,
-      aux_sym_json_body_token1,
-      aux_sym_json_body_token2,
-    ACTIONS(71), 2,
-      anon_sym_query,
-      anon_sym_mutation,
-    ACTIONS(75), 5,
-      ts_builtin_sym_end,
-      sym_comment,
-      anon_sym_AT,
-      anon_sym_LBRACE_LBRACE,
-      aux_sym_script_variable_token1,
-    STATE(16), 6,
+    STATE(19), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
@@ -5973,9 +5844,9 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_xml_body_token1,
     ACTIONS(73), 1,
       anon_sym_LT,
-    ACTIONS(93), 1,
+    ACTIONS(85), 1,
       sym_method,
-    ACTIONS(114), 1,
+    ACTIONS(95), 1,
       sym_identifier,
     ACTIONS(69), 2,
       aux_sym_json_body_token1,
@@ -5983,13 +5854,13 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(71), 2,
       anon_sym_query,
       anon_sym_mutation,
-    ACTIONS(91), 5,
+    ACTIONS(83), 5,
       ts_builtin_sym_end,
       sym_comment,
       anon_sym_AT,
       anon_sym_LBRACE_LBRACE,
       aux_sym_script_variable_token1,
-    STATE(16), 6,
+    STATE(19), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
@@ -6005,7 +5876,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_xml_body_token3,
     STATE(25), 1,
       aux_sym_form_data_repeat2,
-    STATE(157), 1,
+    STATE(148), 1,
       aux_sym_form_data_repeat1,
     ACTIONS(122), 5,
       sym_method,
@@ -6025,13 +5896,13 @@ static const uint16_t ts_small_parse_table[] = {
   [1096] = 7,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(132), 1,
+    ACTIONS(124), 1,
       anon_sym_AMP,
-    ACTIONS(135), 1,
+    ACTIONS(126), 1,
       aux_sym_xml_body_token3,
-    STATE(24), 1,
+    STATE(23), 1,
       aux_sym_form_data_repeat2,
-    STATE(157), 1,
+    STATE(148), 1,
       aux_sym_form_data_repeat1,
     ACTIONS(130), 5,
       sym_method,
@@ -6051,21 +5922,21 @@ static const uint16_t ts_small_parse_table[] = {
   [1129] = 7,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(124), 1,
+    ACTIONS(136), 1,
       anon_sym_AMP,
-    ACTIONS(126), 1,
+    ACTIONS(139), 1,
       aux_sym_xml_body_token3,
-    STATE(24), 1,
+    STATE(25), 1,
       aux_sym_form_data_repeat2,
-    STATE(157), 1,
+    STATE(148), 1,
       aux_sym_form_data_repeat1,
-    ACTIONS(140), 5,
+    ACTIONS(134), 5,
       sym_method,
       anon_sym_query,
       anon_sym_mutation,
       anon_sym_LT,
       sym_identifier,
-    ACTIONS(138), 8,
+    ACTIONS(132), 8,
       ts_builtin_sym_end,
       sym_comment,
       anon_sym_AT,
@@ -6094,17 +5965,61 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_xml_body_token1,
       aux_sym_json_body_token1,
       aux_sym_json_body_token2,
-  [1185] = 3,
+  [1185] = 5,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(148), 6,
+    ACTIONS(150), 1,
+      anon_sym_COLON,
+    STATE(53), 1,
+      sym_port,
+    ACTIONS(148), 5,
+      sym_method,
+      anon_sym_query,
+      anon_sym_mutation,
+      anon_sym_LT,
+      sym_identifier,
+    ACTIONS(146), 8,
+      ts_builtin_sym_end,
+      sym_comment,
+      anon_sym_AT,
+      anon_sym_LBRACE_LBRACE,
+      aux_sym_script_variable_token1,
+      aux_sym_xml_body_token1,
+      aux_sym_json_body_token1,
+      aux_sym_json_body_token2,
+  [1212] = 5,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(154), 1,
+      sym_identifier,
+    STATE(28), 2,
+      sym_header,
+      aux_sym_request_repeat1,
+    ACTIONS(157), 4,
+      sym_method,
+      anon_sym_query,
+      anon_sym_mutation,
+      anon_sym_LT,
+    ACTIONS(152), 8,
+      ts_builtin_sym_end,
+      sym_comment,
+      anon_sym_AT,
+      anon_sym_LBRACE_LBRACE,
+      aux_sym_script_variable_token1,
+      aux_sym_xml_body_token1,
+      aux_sym_json_body_token1,
+      aux_sym_json_body_token2,
+  [1239] = 3,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(161), 6,
       sym_method,
       aux_sym_xml_body_token3,
       anon_sym_query,
       anon_sym_mutation,
       anon_sym_LT,
       sym_identifier,
-    ACTIONS(146), 9,
+    ACTIONS(159), 9,
       ts_builtin_sym_end,
       sym_comment,
       anon_sym_AT,
@@ -6114,64 +6029,20 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_xml_body_token1,
       aux_sym_json_body_token1,
       aux_sym_json_body_token2,
-  [1208] = 5,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(154), 1,
-      anon_sym_COLON,
-    STATE(42), 1,
-      sym_port,
-    ACTIONS(152), 5,
-      sym_method,
-      anon_sym_query,
-      anon_sym_mutation,
-      anon_sym_LT,
-      sym_identifier,
-    ACTIONS(150), 8,
-      ts_builtin_sym_end,
-      sym_comment,
-      anon_sym_AT,
-      anon_sym_LBRACE_LBRACE,
-      aux_sym_script_variable_token1,
-      aux_sym_xml_body_token1,
-      aux_sym_json_body_token1,
-      aux_sym_json_body_token2,
-  [1235] = 5,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(156), 1,
-      anon_sym_COLON,
-    STATE(42), 1,
-      sym_port,
-    ACTIONS(152), 5,
-      sym_method,
-      anon_sym_query,
-      anon_sym_mutation,
-      anon_sym_LT,
-      sym_identifier,
-    ACTIONS(150), 8,
-      ts_builtin_sym_end,
-      sym_comment,
-      anon_sym_AT,
-      anon_sym_LBRACE_LBRACE,
-      aux_sym_script_variable_token1,
-      aux_sym_xml_body_token1,
-      aux_sym_json_body_token1,
-      aux_sym_json_body_token2,
   [1262] = 5,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(160), 1,
-      sym_identifier,
-    STATE(30), 2,
-      sym_header,
-      aux_sym_request_repeat1,
-    ACTIONS(163), 4,
+    ACTIONS(163), 1,
+      anon_sym_COLON,
+    STATE(53), 1,
+      sym_port,
+    ACTIONS(148), 5,
       sym_method,
       anon_sym_query,
       anon_sym_mutation,
       anon_sym_LT,
-    ACTIONS(158), 8,
+      sym_identifier,
+    ACTIONS(146), 8,
       ts_builtin_sym_end,
       sym_comment,
       anon_sym_AT,
@@ -6375,13 +6246,13 @@ static const uint16_t ts_small_parse_table[] = {
   [1517] = 3,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(219), 5,
+    ACTIONS(211), 5,
       sym_method,
       anon_sym_query,
       anon_sym_mutation,
       anon_sym_LT,
       sym_identifier,
-    ACTIONS(217), 8,
+    ACTIONS(209), 8,
       ts_builtin_sym_end,
       sym_comment,
       anon_sym_AT,
@@ -6390,16 +6261,42 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_xml_body_token1,
       aux_sym_json_body_token1,
       aux_sym_json_body_token2,
-  [1538] = 3,
+  [1538] = 11,
+    ACTIONS(19), 1,
+      anon_sym_SLASH,
+    ACTIONS(217), 1,
+      sym_identifier,
+    ACTIONS(219), 1,
+      anon_sym_AT,
+    ACTIONS(221), 1,
+      anon_sym_POUND,
+    STATE(63), 1,
+      sym_authority,
+    STATE(91), 1,
+      sym_path,
+    STATE(94), 1,
+      aux_sym_path_repeat1,
+    STATE(205), 1,
+      sym_pair,
+    ACTIONS(223), 2,
+      aux_sym_request_token1,
+      aux_sym__whitespace_token1,
+    ACTIONS(225), 2,
+      anon_sym_AMP,
+      anon_sym_QMARK,
+    STATE(82), 2,
+      sym_query_param,
+      aux_sym_target_url_repeat1,
+  [1575] = 3,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(223), 5,
+    ACTIONS(229), 5,
       sym_method,
       anon_sym_query,
       anon_sym_mutation,
       anon_sym_LT,
       sym_identifier,
-    ACTIONS(221), 8,
+    ACTIONS(227), 8,
       ts_builtin_sym_end,
       sym_comment,
       anon_sym_AT,
@@ -6408,16 +6305,16 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_xml_body_token1,
       aux_sym_json_body_token1,
       aux_sym_json_body_token2,
-  [1559] = 3,
+  [1596] = 3,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(227), 5,
+    ACTIONS(233), 5,
       sym_method,
       anon_sym_query,
       anon_sym_mutation,
       anon_sym_LT,
       sym_identifier,
-    ACTIONS(225), 8,
+    ACTIONS(231), 8,
       ts_builtin_sym_end,
       sym_comment,
       anon_sym_AT,
@@ -6426,16 +6323,16 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_xml_body_token1,
       aux_sym_json_body_token1,
       aux_sym_json_body_token2,
-  [1580] = 3,
+  [1617] = 3,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(231), 5,
+    ACTIONS(237), 5,
       sym_method,
       anon_sym_query,
       anon_sym_mutation,
       anon_sym_LT,
       sym_identifier,
-    ACTIONS(229), 8,
+    ACTIONS(235), 8,
       ts_builtin_sym_end,
       sym_comment,
       anon_sym_AT,
@@ -6444,16 +6341,16 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_xml_body_token1,
       aux_sym_json_body_token1,
       aux_sym_json_body_token2,
-  [1601] = 3,
+  [1638] = 3,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(235), 5,
+    ACTIONS(241), 5,
       sym_method,
       anon_sym_query,
       anon_sym_mutation,
       anon_sym_LT,
       sym_identifier,
-    ACTIONS(233), 8,
+    ACTIONS(239), 8,
       ts_builtin_sym_end,
       sym_comment,
       anon_sym_AT,
@@ -6462,16 +6359,16 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_xml_body_token1,
       aux_sym_json_body_token1,
       aux_sym_json_body_token2,
-  [1622] = 3,
+  [1659] = 3,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(239), 5,
+    ACTIONS(245), 5,
       sym_method,
       anon_sym_query,
       anon_sym_mutation,
       anon_sym_LT,
       sym_identifier,
-    ACTIONS(237), 8,
+    ACTIONS(243), 8,
       ts_builtin_sym_end,
       sym_comment,
       anon_sym_AT,
@@ -6480,16 +6377,16 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_xml_body_token1,
       aux_sym_json_body_token1,
       aux_sym_json_body_token2,
-  [1643] = 3,
+  [1680] = 3,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(243), 5,
+    ACTIONS(249), 5,
       sym_method,
       anon_sym_query,
       anon_sym_mutation,
       anon_sym_LT,
       sym_identifier,
-    ACTIONS(241), 8,
+    ACTIONS(247), 8,
       ts_builtin_sym_end,
       sym_comment,
       anon_sym_AT,
@@ -6498,16 +6395,16 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_xml_body_token1,
       aux_sym_json_body_token1,
       aux_sym_json_body_token2,
-  [1664] = 3,
+  [1701] = 3,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(247), 5,
+    ACTIONS(253), 5,
       sym_method,
       anon_sym_query,
       anon_sym_mutation,
       anon_sym_LT,
       sym_identifier,
-    ACTIONS(245), 8,
+    ACTIONS(251), 8,
       ts_builtin_sym_end,
       sym_comment,
       anon_sym_AT,
@@ -6516,16 +6413,16 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_xml_body_token1,
       aux_sym_json_body_token1,
       aux_sym_json_body_token2,
-  [1685] = 3,
+  [1722] = 3,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(251), 5,
+    ACTIONS(257), 5,
       sym_method,
       anon_sym_query,
       anon_sym_mutation,
       anon_sym_LT,
       sym_identifier,
-    ACTIONS(249), 8,
+    ACTIONS(255), 8,
       ts_builtin_sym_end,
       sym_comment,
       anon_sym_AT,
@@ -6534,16 +6431,16 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_xml_body_token1,
       aux_sym_json_body_token1,
       aux_sym_json_body_token2,
-  [1706] = 3,
+  [1743] = 3,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(255), 5,
+    ACTIONS(261), 5,
       sym_method,
       anon_sym_query,
       anon_sym_mutation,
       anon_sym_LT,
       sym_identifier,
-    ACTIONS(253), 8,
+    ACTIONS(259), 8,
       ts_builtin_sym_end,
       sym_comment,
       anon_sym_AT,
@@ -6552,16 +6449,16 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_xml_body_token1,
       aux_sym_json_body_token1,
       aux_sym_json_body_token2,
-  [1727] = 3,
+  [1764] = 3,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(259), 5,
+    ACTIONS(265), 5,
       sym_method,
       anon_sym_query,
       anon_sym_mutation,
       anon_sym_LT,
       sym_identifier,
-    ACTIONS(257), 8,
+    ACTIONS(263), 8,
       ts_builtin_sym_end,
       sym_comment,
       anon_sym_AT,
@@ -6570,16 +6467,16 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_xml_body_token1,
       aux_sym_json_body_token1,
       aux_sym_json_body_token2,
-  [1748] = 3,
+  [1785] = 3,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(263), 5,
+    ACTIONS(269), 5,
       sym_method,
       anon_sym_query,
       anon_sym_mutation,
       anon_sym_LT,
       sym_identifier,
-    ACTIONS(261), 8,
+    ACTIONS(267), 8,
       ts_builtin_sym_end,
       sym_comment,
       anon_sym_AT,
@@ -6588,16 +6485,16 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_xml_body_token1,
       aux_sym_json_body_token1,
       aux_sym_json_body_token2,
-  [1769] = 3,
+  [1806] = 3,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(251), 5,
+    ACTIONS(197), 5,
       sym_method,
       anon_sym_query,
       anon_sym_mutation,
       anon_sym_LT,
       sym_identifier,
-    ACTIONS(249), 8,
+    ACTIONS(195), 8,
       ts_builtin_sym_end,
       sym_comment,
       anon_sym_AT,
@@ -6606,16 +6503,16 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_xml_body_token1,
       aux_sym_json_body_token1,
       aux_sym_json_body_token2,
-  [1790] = 3,
+  [1827] = 3,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(267), 5,
+    ACTIONS(273), 5,
       sym_method,
       anon_sym_query,
       anon_sym_mutation,
       anon_sym_LT,
       sym_identifier,
-    ACTIONS(265), 8,
+    ACTIONS(271), 8,
       ts_builtin_sym_end,
       sym_comment,
       anon_sym_AT,
@@ -6624,16 +6521,16 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_xml_body_token1,
       aux_sym_json_body_token1,
       aux_sym_json_body_token2,
-  [1811] = 3,
+  [1848] = 3,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(167), 5,
+    ACTIONS(277), 5,
       sym_method,
       anon_sym_query,
       anon_sym_mutation,
       anon_sym_LT,
       sym_identifier,
-    ACTIONS(165), 8,
+    ACTIONS(275), 8,
       ts_builtin_sym_end,
       sym_comment,
       anon_sym_AT,
@@ -6642,16 +6539,16 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_xml_body_token1,
       aux_sym_json_body_token1,
       aux_sym_json_body_token2,
-  [1832] = 3,
+  [1869] = 3,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(271), 5,
+    ACTIONS(281), 5,
       sym_method,
       anon_sym_query,
       anon_sym_mutation,
       anon_sym_LT,
       sym_identifier,
-    ACTIONS(269), 8,
+    ACTIONS(279), 8,
       ts_builtin_sym_end,
       sym_comment,
       anon_sym_AT,
@@ -6660,16 +6557,16 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_xml_body_token1,
       aux_sym_json_body_token1,
       aux_sym_json_body_token2,
-  [1853] = 3,
+  [1890] = 3,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(275), 5,
+    ACTIONS(285), 5,
       sym_method,
       anon_sym_query,
       anon_sym_mutation,
       anon_sym_LT,
       sym_identifier,
-    ACTIONS(273), 8,
+    ACTIONS(283), 8,
       ts_builtin_sym_end,
       sym_comment,
       anon_sym_AT,
@@ -6678,16 +6575,16 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_xml_body_token1,
       aux_sym_json_body_token1,
       aux_sym_json_body_token2,
-  [1874] = 3,
+  [1911] = 3,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(279), 5,
+    ACTIONS(289), 5,
       sym_method,
       anon_sym_query,
       anon_sym_mutation,
       anon_sym_LT,
       sym_identifier,
-    ACTIONS(277), 8,
+    ACTIONS(287), 8,
       ts_builtin_sym_end,
       sym_comment,
       anon_sym_AT,
@@ -6696,28 +6593,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_xml_body_token1,
       aux_sym_json_body_token1,
       aux_sym_json_body_token2,
-  [1895] = 8,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(281), 1,
-      ts_builtin_sym_end,
-    ACTIONS(283), 1,
-      sym_comment,
-    ACTIONS(286), 1,
-      sym_method,
-    ACTIONS(289), 1,
-      anon_sym_AT,
-    ACTIONS(292), 1,
-      anon_sym_LBRACE_LBRACE,
-    ACTIONS(295), 1,
-      aux_sym_script_variable_token1,
-    STATE(59), 5,
-      sym_request,
-      sym_variable,
-      sym_script_variable,
-      sym_variable_declaration,
-      aux_sym_document_repeat1,
-  [1924] = 8,
+  [1932] = 8,
     ACTIONS(3), 1,
       aux_sym_request_token1,
     ACTIONS(9), 1,
@@ -6728,59 +6604,145 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
     ACTIONS(15), 1,
       aux_sym_script_variable_token1,
-    ACTIONS(298), 1,
+    ACTIONS(291), 1,
       ts_builtin_sym_end,
-    ACTIONS(300), 1,
+    ACTIONS(293), 1,
       sym_comment,
-    STATE(59), 5,
+    STATE(61), 5,
       sym_request,
       sym_variable,
       sym_script_variable,
       sym_variable_declaration,
       aux_sym_document_repeat1,
-  [1953] = 10,
-    ACTIONS(302), 1,
-      sym_identifier,
-    ACTIONS(304), 1,
-      anon_sym_SLASH,
-    ACTIONS(306), 1,
-      anon_sym_AT,
-    ACTIONS(308), 1,
-      anon_sym_POUND,
-    ACTIONS(310), 1,
-      anon_sym_QMARK,
-    STATE(86), 1,
-      sym_authority,
-    STATE(102), 1,
-      aux_sym_path_repeat1,
-    STATE(169), 1,
-      sym_path,
-    STATE(226), 1,
-      sym_pair,
-    ACTIONS(312), 2,
-      aux_sym_request_token1,
-      aux_sym__whitespace_token1,
-  [1985] = 5,
-    ACTIONS(314), 1,
-      sym_identifier,
-    ACTIONS(320), 1,
-      anon_sym_LBRACE_LBRACE,
-    STATE(106), 1,
-      sym_variable,
-    ACTIONS(318), 2,
-      anon_sym_POUND,
-      anon_sym_AMP,
-    ACTIONS(316), 4,
-      anon_sym_SLASH,
-      aux_sym_request_token1,
-      sym_query_key,
-      aux_sym__whitespace_token1,
-  [2005] = 4,
+  [1961] = 8,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(322), 1,
+    ACTIONS(295), 1,
+      ts_builtin_sym_end,
+    ACTIONS(297), 1,
+      sym_comment,
+    ACTIONS(300), 1,
+      sym_method,
+    ACTIONS(303), 1,
+      anon_sym_AT,
+    ACTIONS(306), 1,
+      anon_sym_LBRACE_LBRACE,
+    ACTIONS(309), 1,
+      aux_sym_script_variable_token1,
+    STATE(61), 5,
+      sym_request,
+      sym_variable,
+      sym_script_variable,
+      sym_variable_declaration,
+      aux_sym_document_repeat1,
+  [1990] = 7,
+    ACTIONS(19), 1,
+      anon_sym_SLASH,
+    ACTIONS(312), 1,
+      anon_sym_POUND,
+    STATE(94), 1,
+      aux_sym_path_repeat1,
+    STATE(98), 1,
+      sym_path,
+    ACTIONS(225), 2,
+      anon_sym_AMP,
+      anon_sym_QMARK,
+    ACTIONS(314), 2,
+      aux_sym_request_token1,
       aux_sym__whitespace_token1,
-    STATE(63), 1,
+    STATE(99), 2,
+      sym_query_param,
+      aux_sym_target_url_repeat1,
+  [2015] = 7,
+    ACTIONS(19), 1,
+      anon_sym_SLASH,
+    ACTIONS(316), 1,
+      anon_sym_POUND,
+    STATE(81), 1,
+      sym_path,
+    STATE(94), 1,
+      aux_sym_path_repeat1,
+    ACTIONS(225), 2,
+      anon_sym_AMP,
+      anon_sym_QMARK,
+    ACTIONS(318), 2,
+      aux_sym_request_token1,
+      aux_sym__whitespace_token1,
+    STATE(96), 2,
+      sym_query_param,
+      aux_sym_target_url_repeat1,
+  [2040] = 7,
+    ACTIONS(19), 1,
+      anon_sym_SLASH,
+    ACTIONS(221), 1,
+      anon_sym_POUND,
+    STATE(91), 1,
+      sym_path,
+    STATE(94), 1,
+      aux_sym_path_repeat1,
+    ACTIONS(223), 2,
+      aux_sym_request_token1,
+      aux_sym__whitespace_token1,
+    ACTIONS(225), 2,
+      anon_sym_AMP,
+      anon_sym_QMARK,
+    STATE(82), 2,
+      sym_query_param,
+      aux_sym_target_url_repeat1,
+  [2065] = 7,
+    ACTIONS(19), 1,
+      anon_sym_SLASH,
+    ACTIONS(320), 1,
+      anon_sym_POUND,
+    STATE(92), 1,
+      sym_path,
+    STATE(94), 1,
+      aux_sym_path_repeat1,
+    ACTIONS(225), 2,
+      anon_sym_AMP,
+      anon_sym_QMARK,
+    ACTIONS(322), 2,
+      aux_sym_request_token1,
+      aux_sym__whitespace_token1,
+    STATE(93), 2,
+      sym_query_param,
+      aux_sym_target_url_repeat1,
+  [2090] = 6,
+    ACTIONS(27), 1,
+      anon_sym_LBRACE_LBRACE,
+    ACTIONS(328), 1,
+      anon_sym_EQ,
+    ACTIONS(330), 1,
+      sym_param,
+    STATE(108), 1,
+      sym_variable,
+    ACTIONS(324), 2,
+      anon_sym_POUND,
+      anon_sym_AMP,
+    ACTIONS(326), 3,
+      aux_sym_request_token1,
+      anon_sym_QMARK,
+      aux_sym__whitespace_token1,
+  [2112] = 4,
+    ACTIONS(27), 1,
+      anon_sym_LBRACE_LBRACE,
+    ACTIONS(332), 1,
+      sym_identifier,
+    STATE(101), 1,
+      sym_variable,
+    ACTIONS(334), 6,
+      anon_sym_SLASH,
+      anon_sym_POUND,
+      aux_sym_request_token1,
+      anon_sym_AMP,
+      anon_sym_QMARK,
+      aux_sym__whitespace_token1,
+  [2130] = 4,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(336), 1,
+      aux_sym__whitespace_token1,
+    STATE(68), 1,
       aux_sym__whitespace,
     ACTIONS(47), 6,
       anon_sym_HTTP_SLASH,
@@ -6789,22 +6751,37 @@ static const uint16_t ts_small_parse_table[] = {
       sym_string,
       anon_sym_true,
       anon_sym_false,
-  [2023] = 6,
+  [2148] = 6,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(329), 1,
+    ACTIONS(343), 1,
       aux_sym__whitespace_token1,
-    STATE(63), 1,
+    STATE(68), 1,
       aux_sym__whitespace,
-    STATE(87), 1,
+    STATE(89), 1,
       sym_boolean,
-    ACTIONS(325), 2,
+    ACTIONS(339), 2,
       sym_number,
       sym_string,
-    ACTIONS(327), 2,
+    ACTIONS(341), 2,
       anon_sym_true,
       anon_sym_false,
-  [2044] = 2,
+  [2169] = 6,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(343), 1,
+      aux_sym__whitespace_token1,
+    STATE(80), 1,
+      aux_sym__whitespace,
+    STATE(89), 1,
+      sym_boolean,
+    ACTIONS(339), 2,
+      sym_number,
+      sym_string,
+    ACTIONS(341), 2,
+      anon_sym_true,
+      anon_sym_false,
+  [2190] = 2,
     ACTIONS(3), 1,
       aux_sym_request_token1,
     ACTIONS(57), 7,
@@ -6815,528 +6792,416 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_true,
       anon_sym_false,
       aux_sym__whitespace_token1,
-  [2057] = 6,
+  [2203] = 6,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(329), 1,
+    ACTIONS(343), 1,
       aux_sym__whitespace_token1,
-    STATE(63), 1,
+    STATE(69), 1,
       aux_sym__whitespace,
-    STATE(72), 1,
+    STATE(83), 1,
       sym_boolean,
-    ACTIONS(327), 2,
+    ACTIONS(341), 2,
       anon_sym_true,
       anon_sym_false,
-    ACTIONS(331), 2,
+    ACTIONS(345), 2,
       sym_number,
       sym_string,
-  [2078] = 6,
-    ACTIONS(3), 1,
+  [2224] = 1,
+    ACTIONS(205), 8,
+      anon_sym_SLASH,
+      anon_sym_AT,
+      anon_sym_POUND,
       aux_sym_request_token1,
-    ACTIONS(329), 1,
+      anon_sym_AMP,
+      anon_sym_QMARK,
+      sym_identifier,
       aux_sym__whitespace_token1,
-    STATE(66), 1,
-      aux_sym__whitespace,
-    STATE(87), 1,
-      sym_boolean,
-    ACTIONS(325), 2,
-      sym_number,
-      sym_string,
-    ACTIONS(327), 2,
-      anon_sym_true,
-      anon_sym_false,
-  [2099] = 4,
+  [2235] = 1,
+    ACTIONS(231), 8,
+      anon_sym_SLASH,
+      anon_sym_AT,
+      anon_sym_POUND,
+      aux_sym_request_token1,
+      anon_sym_AMP,
+      anon_sym_QMARK,
+      sym_identifier,
+      aux_sym__whitespace_token1,
+  [2246] = 1,
+    ACTIONS(279), 8,
+      anon_sym_SLASH,
+      anon_sym_AT,
+      anon_sym_POUND,
+      aux_sym_request_token1,
+      anon_sym_AMP,
+      anon_sym_QMARK,
+      sym_identifier,
+      aux_sym__whitespace_token1,
+  [2257] = 3,
+    ACTIONS(347), 1,
+      anon_sym_COLON,
+    STATE(105), 1,
+      sym_port,
+    ACTIONS(146), 6,
+      anon_sym_SLASH,
+      anon_sym_POUND,
+      aux_sym_request_token1,
+      anon_sym_AMP,
+      anon_sym_QMARK,
+      aux_sym__whitespace_token1,
+  [2272] = 1,
+    ACTIONS(287), 8,
+      anon_sym_SLASH,
+      anon_sym_AT,
+      anon_sym_POUND,
+      aux_sym_request_token1,
+      anon_sym_AMP,
+      anon_sym_QMARK,
+      sym_identifier,
+      aux_sym__whitespace_token1,
+  [2283] = 5,
     ACTIONS(27), 1,
       anon_sym_LBRACE_LBRACE,
-    ACTIONS(333), 1,
-      sym_identifier,
-    STATE(112), 1,
+    ACTIONS(353), 1,
+      sym_param,
+    STATE(111), 1,
       sym_variable,
-    ACTIONS(318), 5,
+    ACTIONS(349), 2,
+      anon_sym_POUND,
+      anon_sym_AMP,
+    ACTIONS(351), 3,
+      aux_sym_request_token1,
+      anon_sym_QMARK,
+      aux_sym__whitespace_token1,
+  [2302] = 3,
+    ACTIONS(355), 1,
+      anon_sym_COLON,
+    STATE(105), 1,
+      sym_port,
+    ACTIONS(146), 6,
       anon_sym_SLASH,
       anon_sym_POUND,
-      anon_sym_QMARK,
       aux_sym_request_token1,
+      anon_sym_AMP,
+      anon_sym_QMARK,
       aux_sym__whitespace_token1,
-  [2116] = 6,
+  [2317] = 6,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(329), 1,
-      aux_sym__whitespace_token1,
-    STATE(64), 1,
-      aux_sym__whitespace,
-    STATE(82), 1,
-      sym_boolean,
-    ACTIONS(327), 2,
-      anon_sym_true,
-      anon_sym_false,
-    ACTIONS(335), 2,
-      sym_number,
-      sym_string,
-  [2137] = 4,
-    ACTIONS(341), 1,
-      anon_sym_EQ,
     ACTIONS(343), 1,
-      sym_param,
-    ACTIONS(337), 2,
-      anon_sym_POUND,
-      anon_sym_AMP,
-    ACTIONS(339), 3,
-      aux_sym_request_token1,
-      sym_query_key,
       aux_sym__whitespace_token1,
-  [2153] = 4,
-    ACTIONS(345), 1,
-      anon_sym_SLASH,
-    STATE(71), 1,
-      aux_sym_path_repeat1,
-    ACTIONS(348), 2,
-      anon_sym_POUND,
-      anon_sym_AMP,
-    ACTIONS(350), 3,
-      aux_sym_request_token1,
-      sym_query_key,
-      aux_sym__whitespace_token1,
-  [2169] = 2,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(352), 6,
-      ts_builtin_sym_end,
-      sym_comment,
-      sym_method,
-      anon_sym_AT,
-      anon_sym_LBRACE_LBRACE,
-      aux_sym_script_variable_token1,
-  [2181] = 4,
-    ACTIONS(354), 1,
-      anon_sym_SLASH,
-    STATE(71), 1,
-      aux_sym_path_repeat1,
-    ACTIONS(356), 2,
-      anon_sym_POUND,
-      anon_sym_AMP,
-    ACTIONS(358), 3,
-      aux_sym_request_token1,
-      sym_query_key,
-      aux_sym__whitespace_token1,
-  [2197] = 5,
-    ACTIONS(360), 1,
-      anon_sym_POUND,
-    ACTIONS(364), 1,
-      anon_sym_AMP,
-    ACTIONS(367), 1,
-      sym_query_key,
-    ACTIONS(362), 2,
-      aux_sym_request_token1,
-      aux_sym__whitespace_token1,
-    STATE(74), 2,
-      sym_query_param,
-      aux_sym_target_url_repeat1,
-  [2215] = 2,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(370), 6,
-      ts_builtin_sym_end,
-      sym_comment,
-      sym_method,
-      anon_sym_AT,
-      anon_sym_LBRACE_LBRACE,
-      aux_sym_script_variable_token1,
-  [2227] = 5,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(374), 1,
-      sym_string,
-    STATE(23), 1,
+    STATE(68), 1,
+      aux_sym__whitespace,
+    STATE(88), 1,
       sym_boolean,
-    ACTIONS(372), 2,
-      sym_identifier,
-      sym_number,
-    ACTIONS(376), 2,
+    ACTIONS(341), 2,
       anon_sym_true,
       anon_sym_false,
-  [2245] = 5,
-    ACTIONS(378), 1,
-      anon_sym_POUND,
-    ACTIONS(382), 1,
-      anon_sym_AMP,
-    ACTIONS(384), 1,
-      sym_query_key,
-    ACTIONS(380), 2,
-      aux_sym_request_token1,
-      aux_sym__whitespace_token1,
-    STATE(74), 2,
-      sym_query_param,
-      aux_sym_target_url_repeat1,
-  [2263] = 5,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(388), 1,
-      sym_string,
-    STATE(27), 1,
-      sym_boolean,
-    ACTIONS(376), 2,
-      anon_sym_true,
-      anon_sym_false,
-    ACTIONS(386), 2,
-      sym_identifier,
+    ACTIONS(357), 2,
       sym_number,
-  [2281] = 5,
-    ACTIONS(382), 1,
-      anon_sym_AMP,
-    ACTIONS(384), 1,
-      sym_query_key,
-    ACTIONS(390), 1,
+      sym_string,
+  [2338] = 4,
+    ACTIONS(320), 1,
       anon_sym_POUND,
-    ACTIONS(392), 2,
-      aux_sym_request_token1,
-      aux_sym__whitespace_token1,
-    STATE(74), 2,
-      sym_query_param,
-      aux_sym_target_url_repeat1,
-  [2299] = 5,
-    ACTIONS(382), 1,
-      anon_sym_AMP,
-    ACTIONS(384), 1,
-      sym_query_key,
-    ACTIONS(394), 1,
-      anon_sym_POUND,
-    ACTIONS(396), 2,
-      aux_sym_request_token1,
-      aux_sym__whitespace_token1,
-    STATE(74), 2,
-      sym_query_param,
-      aux_sym_target_url_repeat1,
-  [2317] = 1,
-    ACTIONS(237), 7,
-      anon_sym_SLASH,
-      anon_sym_AT,
-      anon_sym_POUND,
-      anon_sym_QMARK,
-      aux_sym_request_token1,
-      sym_identifier,
-      aux_sym__whitespace_token1,
-  [2327] = 2,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(398), 6,
-      ts_builtin_sym_end,
-      sym_comment,
-      sym_method,
-      anon_sym_AT,
-      anon_sym_LBRACE_LBRACE,
-      aux_sym_script_variable_token1,
-  [2339] = 1,
-    ACTIONS(269), 7,
-      anon_sym_SLASH,
-      anon_sym_AT,
-      anon_sym_POUND,
-      anon_sym_QMARK,
-      aux_sym_request_token1,
-      sym_identifier,
-      aux_sym__whitespace_token1,
-  [2349] = 1,
-    ACTIONS(225), 7,
-      anon_sym_SLASH,
-      anon_sym_AT,
-      anon_sym_POUND,
-      anon_sym_QMARK,
-      aux_sym_request_token1,
-      sym_identifier,
-      aux_sym__whitespace_token1,
-  [2359] = 3,
-    ACTIONS(400), 1,
-      anon_sym_COLON,
-    STATE(113), 1,
-      sym_port,
-    ACTIONS(150), 5,
-      anon_sym_SLASH,
-      anon_sym_POUND,
-      anon_sym_QMARK,
-      aux_sym_request_token1,
-      aux_sym__whitespace_token1,
-  [2373] = 6,
-    ACTIONS(304), 1,
-      anon_sym_SLASH,
-    ACTIONS(402), 1,
-      anon_sym_POUND,
-    ACTIONS(404), 1,
-      anon_sym_QMARK,
-    STATE(102), 1,
-      aux_sym_path_repeat1,
-    STATE(173), 1,
-      sym_path,
-    ACTIONS(406), 2,
-      aux_sym_request_token1,
-      aux_sym__whitespace_token1,
-  [2393] = 2,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(408), 6,
-      ts_builtin_sym_end,
-      sym_comment,
-      sym_method,
-      anon_sym_AT,
-      anon_sym_LBRACE_LBRACE,
-      aux_sym_script_variable_token1,
-  [2405] = 3,
-    ACTIONS(410), 1,
-      anon_sym_COLON,
-    STATE(113), 1,
-      sym_port,
-    ACTIONS(150), 5,
-      anon_sym_SLASH,
-      anon_sym_POUND,
-      anon_sym_QMARK,
-      aux_sym_request_token1,
-      aux_sym__whitespace_token1,
-  [2419] = 6,
-    ACTIONS(304), 1,
-      anon_sym_SLASH,
-    ACTIONS(378), 1,
-      anon_sym_POUND,
-    ACTIONS(412), 1,
-      anon_sym_QMARK,
-    STATE(102), 1,
-      aux_sym_path_repeat1,
-    STATE(161), 1,
-      sym_path,
-    ACTIONS(414), 2,
-      aux_sym_request_token1,
-      aux_sym__whitespace_token1,
-  [2439] = 5,
-    ACTIONS(382), 1,
-      anon_sym_AMP,
-    ACTIONS(384), 1,
-      sym_query_key,
-    ACTIONS(416), 1,
-      anon_sym_POUND,
-    ACTIONS(418), 2,
-      aux_sym_request_token1,
-      aux_sym__whitespace_token1,
-    STATE(74), 2,
-      sym_query_param,
-      aux_sym_target_url_repeat1,
-  [2457] = 5,
-    ACTIONS(382), 1,
-      anon_sym_AMP,
-    ACTIONS(384), 1,
-      sym_query_key,
-    ACTIONS(402), 1,
-      anon_sym_POUND,
-    ACTIONS(420), 2,
-      aux_sym_request_token1,
-      aux_sym__whitespace_token1,
-    STATE(74), 2,
-      sym_query_param,
-      aux_sym_target_url_repeat1,
-  [2475] = 5,
-    ACTIONS(382), 1,
-      anon_sym_AMP,
-    ACTIONS(384), 1,
-      sym_query_key,
-    ACTIONS(422), 1,
-      anon_sym_POUND,
-    ACTIONS(424), 2,
-      aux_sym_request_token1,
-      aux_sym__whitespace_token1,
-    STATE(74), 2,
-      sym_query_param,
-      aux_sym_target_url_repeat1,
-  [2493] = 6,
-    ACTIONS(304), 1,
-      anon_sym_SLASH,
-    ACTIONS(308), 1,
-      anon_sym_POUND,
-    ACTIONS(310), 1,
-      anon_sym_QMARK,
-    STATE(102), 1,
-      aux_sym_path_repeat1,
-    STATE(169), 1,
-      sym_path,
-    ACTIONS(312), 2,
-      aux_sym_request_token1,
-      aux_sym__whitespace_token1,
-  [2513] = 5,
-    ACTIONS(308), 1,
-      anon_sym_POUND,
-    ACTIONS(382), 1,
-      anon_sym_AMP,
-    ACTIONS(384), 1,
-      sym_query_key,
-    ACTIONS(426), 2,
-      aux_sym_request_token1,
-      aux_sym__whitespace_token1,
-    STATE(91), 2,
-      sym_query_param,
-      aux_sym_target_url_repeat1,
-  [2531] = 1,
-    ACTIONS(273), 7,
-      anon_sym_SLASH,
-      anon_sym_AT,
-      anon_sym_POUND,
-      anon_sym_QMARK,
-      aux_sym_request_token1,
-      sym_identifier,
-      aux_sym__whitespace_token1,
-  [2541] = 4,
-    ACTIONS(432), 1,
-      anon_sym_EQ,
-    ACTIONS(434), 1,
-      sym_param,
-    ACTIONS(428), 2,
-      anon_sym_POUND,
-      anon_sym_AMP,
-    ACTIONS(430), 3,
-      aux_sym_request_token1,
-      sym_query_key,
-      aux_sym__whitespace_token1,
-  [2557] = 6,
-    ACTIONS(304), 1,
-      anon_sym_SLASH,
-    ACTIONS(422), 1,
-      anon_sym_POUND,
-    ACTIONS(436), 1,
-      anon_sym_QMARK,
-    STATE(102), 1,
-      aux_sym_path_repeat1,
-    STATE(132), 1,
-      sym_path,
-    ACTIONS(438), 2,
-      aux_sym_request_token1,
-      aux_sym__whitespace_token1,
-  [2577] = 2,
-    ACTIONS(237), 2,
-      anon_sym_POUND,
-      anon_sym_AMP,
-    ACTIONS(239), 4,
-      anon_sym_SLASH,
-      aux_sym_request_token1,
-      sym_query_key,
-      aux_sym__whitespace_token1,
-  [2588] = 3,
-    ACTIONS(444), 1,
-      sym_param,
-    ACTIONS(440), 2,
-      anon_sym_POUND,
-      anon_sym_AMP,
-    ACTIONS(442), 3,
-      aux_sym_request_token1,
-      sym_query_key,
-      aux_sym__whitespace_token1,
-  [2601] = 3,
-    ACTIONS(446), 1,
-      anon_sym_SLASH,
-    STATE(100), 1,
-      aux_sym_path_repeat1,
-    ACTIONS(348), 4,
-      anon_sym_POUND,
-      anon_sym_QMARK,
-      aux_sym_request_token1,
-      aux_sym__whitespace_token1,
-  [2614] = 3,
-    ACTIONS(453), 1,
-      sym_param,
-    ACTIONS(449), 2,
-      anon_sym_POUND,
-      anon_sym_AMP,
-    ACTIONS(451), 3,
-      aux_sym_request_token1,
-      sym_query_key,
-      aux_sym__whitespace_token1,
-  [2627] = 3,
-    ACTIONS(304), 1,
-      anon_sym_SLASH,
-    STATE(100), 1,
-      aux_sym_path_repeat1,
-    ACTIONS(356), 4,
-      anon_sym_POUND,
-      anon_sym_QMARK,
-      aux_sym_request_token1,
-      aux_sym__whitespace_token1,
-  [2640] = 6,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(25), 1,
-      anon_sym_AT,
-    ACTIONS(455), 1,
-      sym_identifier,
-    STATE(89), 1,
-      sym_host,
-    STATE(185), 1,
-      sym_authority,
-    STATE(230), 1,
-      sym_pair,
-  [2659] = 2,
-    ACTIONS(459), 2,
-      anon_sym_POUND,
-      anon_sym_AMP,
-    ACTIONS(457), 4,
-      anon_sym_SLASH,
-      aux_sym_request_token1,
-      sym_query_key,
-      aux_sym__whitespace_token1,
-  [2670] = 6,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(25), 1,
-      anon_sym_AT,
-    ACTIONS(461), 1,
-      sym_identifier,
-    STATE(58), 1,
-      sym_host,
-    STATE(192), 1,
-      sym_authority,
-    STATE(230), 1,
-      sym_pair,
-  [2689] = 3,
-    ACTIONS(463), 1,
-      anon_sym_SLASH,
-    ACTIONS(348), 2,
-      anon_sym_POUND,
-      anon_sym_AMP,
-    ACTIONS(350), 3,
-      aux_sym_request_token1,
-      sym_query_key,
-      aux_sym__whitespace_token1,
-  [2702] = 2,
-    ACTIONS(269), 2,
-      anon_sym_POUND,
-      anon_sym_AMP,
-    ACTIONS(271), 4,
-      anon_sym_SLASH,
-      aux_sym_request_token1,
-      sym_query_key,
-      aux_sym__whitespace_token1,
-  [2713] = 2,
     ACTIONS(225), 2,
-      anon_sym_POUND,
       anon_sym_AMP,
-    ACTIONS(227), 4,
-      anon_sym_SLASH,
+      anon_sym_QMARK,
+    ACTIONS(322), 2,
       aux_sym_request_token1,
-      sym_query_key,
       aux_sym__whitespace_token1,
-  [2724] = 2,
-    ACTIONS(273), 2,
+    STATE(93), 2,
+      sym_query_param,
+      aux_sym_target_url_repeat1,
+  [2354] = 4,
+    ACTIONS(316), 1,
       anon_sym_POUND,
+    ACTIONS(225), 2,
       anon_sym_AMP,
-    ACTIONS(275), 4,
-      anon_sym_SLASH,
+      anon_sym_QMARK,
+    ACTIONS(318), 2,
       aux_sym_request_token1,
-      sym_query_key,
       aux_sym__whitespace_token1,
-  [2735] = 4,
-    ACTIONS(33), 1,
+    STATE(90), 2,
+      sym_query_param,
+      aux_sym_target_url_repeat1,
+  [2370] = 2,
+    ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(468), 1,
-      sym__line,
-    STATE(114), 1,
-      aux_sym_script_variable_repeat1,
-    ACTIONS(466), 2,
-      aux_sym_json_body_token3,
-      aux_sym_json_body_token4,
-  [2749] = 5,
+    ACTIONS(359), 6,
+      ts_builtin_sym_end,
+      sym_comment,
+      sym_method,
+      anon_sym_AT,
+      anon_sym_LBRACE_LBRACE,
+      aux_sym_script_variable_token1,
+  [2382] = 5,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(363), 1,
+      sym_string,
+    STATE(29), 1,
+      sym_boolean,
+    ACTIONS(361), 2,
+      sym_identifier,
+      sym_number,
+    ACTIONS(365), 2,
+      anon_sym_true,
+      anon_sym_false,
+  [2400] = 3,
+    ACTIONS(367), 1,
+      anon_sym_SLASH,
+    STATE(85), 1,
+      aux_sym_path_repeat1,
+    ACTIONS(370), 5,
+      anon_sym_POUND,
+      aux_sym_request_token1,
+      anon_sym_AMP,
+      anon_sym_QMARK,
+      aux_sym__whitespace_token1,
+  [2414] = 4,
+    ACTIONS(372), 1,
+      anon_sym_POUND,
+    ACTIONS(225), 2,
+      anon_sym_AMP,
+      anon_sym_QMARK,
+    ACTIONS(374), 2,
+      aux_sym_request_token1,
+      aux_sym__whitespace_token1,
+    STATE(90), 2,
+      sym_query_param,
+      aux_sym_target_url_repeat1,
+  [2430] = 2,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(376), 6,
+      ts_builtin_sym_end,
+      sym_comment,
+      sym_method,
+      anon_sym_AT,
+      anon_sym_LBRACE_LBRACE,
+      aux_sym_script_variable_token1,
+  [2442] = 2,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(378), 6,
+      ts_builtin_sym_end,
+      sym_comment,
+      sym_method,
+      anon_sym_AT,
+      anon_sym_LBRACE_LBRACE,
+      aux_sym_script_variable_token1,
+  [2454] = 2,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(380), 6,
+      ts_builtin_sym_end,
+      sym_comment,
+      sym_method,
+      anon_sym_AT,
+      anon_sym_LBRACE_LBRACE,
+      aux_sym_script_variable_token1,
+  [2466] = 3,
+    ACTIONS(384), 2,
+      anon_sym_AMP,
+      anon_sym_QMARK,
+    STATE(90), 2,
+      sym_query_param,
+      aux_sym_target_url_repeat1,
+    ACTIONS(382), 3,
+      anon_sym_POUND,
+      aux_sym_request_token1,
+      aux_sym__whitespace_token1,
+  [2480] = 4,
+    ACTIONS(316), 1,
+      anon_sym_POUND,
+    ACTIONS(225), 2,
+      anon_sym_AMP,
+      anon_sym_QMARK,
+    ACTIONS(318), 2,
+      aux_sym_request_token1,
+      aux_sym__whitespace_token1,
+    STATE(96), 2,
+      sym_query_param,
+      aux_sym_target_url_repeat1,
+  [2496] = 4,
+    ACTIONS(312), 1,
+      anon_sym_POUND,
+    ACTIONS(225), 2,
+      anon_sym_AMP,
+      anon_sym_QMARK,
+    ACTIONS(314), 2,
+      aux_sym_request_token1,
+      aux_sym__whitespace_token1,
+    STATE(99), 2,
+      sym_query_param,
+      aux_sym_target_url_repeat1,
+  [2512] = 4,
+    ACTIONS(312), 1,
+      anon_sym_POUND,
+    ACTIONS(225), 2,
+      anon_sym_AMP,
+      anon_sym_QMARK,
+    ACTIONS(314), 2,
+      aux_sym_request_token1,
+      aux_sym__whitespace_token1,
+    STATE(90), 2,
+      sym_query_param,
+      aux_sym_target_url_repeat1,
+  [2528] = 3,
+    ACTIONS(19), 1,
+      anon_sym_SLASH,
+    STATE(85), 1,
+      aux_sym_path_repeat1,
+    ACTIONS(387), 5,
+      anon_sym_POUND,
+      aux_sym_request_token1,
+      anon_sym_AMP,
+      anon_sym_QMARK,
+      aux_sym__whitespace_token1,
+  [2542] = 4,
+    ACTIONS(221), 1,
+      anon_sym_POUND,
+    ACTIONS(223), 2,
+      aux_sym_request_token1,
+      aux_sym__whitespace_token1,
+    ACTIONS(225), 2,
+      anon_sym_AMP,
+      anon_sym_QMARK,
+    STATE(82), 2,
+      sym_query_param,
+      aux_sym_target_url_repeat1,
+  [2558] = 4,
+    ACTIONS(320), 1,
+      anon_sym_POUND,
+    ACTIONS(225), 2,
+      anon_sym_AMP,
+      anon_sym_QMARK,
+    ACTIONS(322), 2,
+      aux_sym_request_token1,
+      aux_sym__whitespace_token1,
+    STATE(90), 2,
+      sym_query_param,
+      aux_sym_target_url_repeat1,
+  [2574] = 5,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(391), 1,
+      sym_string,
+    STATE(24), 1,
+      sym_boolean,
+    ACTIONS(365), 2,
+      anon_sym_true,
+      anon_sym_false,
+    ACTIONS(389), 2,
+      sym_identifier,
+      sym_number,
+  [2592] = 4,
+    ACTIONS(393), 1,
+      anon_sym_POUND,
+    ACTIONS(225), 2,
+      anon_sym_AMP,
+      anon_sym_QMARK,
+    ACTIONS(395), 2,
+      aux_sym_request_token1,
+      aux_sym__whitespace_token1,
+    STATE(86), 2,
+      sym_query_param,
+      aux_sym_target_url_repeat1,
+  [2608] = 4,
+    ACTIONS(393), 1,
+      anon_sym_POUND,
+    ACTIONS(225), 2,
+      anon_sym_AMP,
+      anon_sym_QMARK,
+    ACTIONS(395), 2,
+      aux_sym_request_token1,
+      aux_sym__whitespace_token1,
+    STATE(90), 2,
+      sym_query_param,
+      aux_sym_target_url_repeat1,
+  [2624] = 6,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(25), 1,
+      anon_sym_AT,
+    ACTIONS(397), 1,
+      sym_identifier,
+    STATE(65), 1,
+      sym_host,
+    STATE(150), 1,
+      sym_authority,
+    STATE(201), 1,
+      sym_pair,
+  [2643] = 2,
+    ACTIONS(399), 1,
+      anon_sym_SLASH,
+    ACTIONS(370), 5,
+      anon_sym_POUND,
+      aux_sym_request_token1,
+      anon_sym_AMP,
+      anon_sym_QMARK,
+      aux_sym__whitespace_token1,
+  [2654] = 6,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(25), 1,
+      anon_sym_AT,
+    ACTIONS(402), 1,
+      sym_identifier,
+    STATE(52), 1,
+      sym_host,
+    STATE(162), 1,
+      sym_authority,
+    STATE(201), 1,
+      sym_pair,
+  [2673] = 1,
+    ACTIONS(404), 6,
+      anon_sym_SLASH,
+      anon_sym_POUND,
+      aux_sym_request_token1,
+      anon_sym_AMP,
+      anon_sym_QMARK,
+      aux_sym__whitespace_token1,
+  [2682] = 1,
+    ACTIONS(406), 6,
+      anon_sym_SLASH,
+      anon_sym_POUND,
+      aux_sym_request_token1,
+      anon_sym_AMP,
+      anon_sym_QMARK,
+      aux_sym__whitespace_token1,
+  [2691] = 1,
+    ACTIONS(267), 6,
+      anon_sym_SLASH,
+      anon_sym_POUND,
+      aux_sym_request_token1,
+      anon_sym_AMP,
+      anon_sym_QMARK,
+      aux_sym__whitespace_token1,
+  [2700] = 1,
+    ACTIONS(235), 6,
+      anon_sym_SLASH,
+      anon_sym_POUND,
+      aux_sym_request_token1,
+      anon_sym_AMP,
+      anon_sym_QMARK,
+      aux_sym__whitespace_token1,
+  [2709] = 1,
+    ACTIONS(408), 6,
+      anon_sym_SLASH,
+      anon_sym_POUND,
+      aux_sym_request_token1,
+      anon_sym_AMP,
+      anon_sym_QMARK,
+      aux_sym__whitespace_token1,
+  [2718] = 1,
+    ACTIONS(410), 5,
+      anon_sym_POUND,
+      aux_sym_request_token1,
+      anon_sym_AMP,
+      anon_sym_QMARK,
+      aux_sym__whitespace_token1,
+  [2726] = 5,
     ACTIONS(3), 1,
       aux_sym_request_token1,
     ACTIONS(13), 1,
@@ -7345,166 +7210,26 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym__whitespace_token1,
     STATE(5), 1,
       aux_sym__whitespace,
-    STATE(52), 1,
+    STATE(37), 1,
       sym_variable,
-  [2765] = 2,
-    ACTIONS(470), 1,
-      anon_sym_SLASH,
-    ACTIONS(348), 4,
-      anon_sym_POUND,
-      anon_sym_QMARK,
-      aux_sym_request_token1,
-      aux_sym__whitespace_token1,
-  [2775] = 1,
-    ACTIONS(221), 5,
-      anon_sym_SLASH,
-      anon_sym_POUND,
-      anon_sym_QMARK,
-      aux_sym_request_token1,
-      aux_sym__whitespace_token1,
-  [2783] = 4,
-    ACTIONS(33), 1,
-      aux_sym_request_token1,
-    ACTIONS(475), 1,
-      sym__line,
-    STATE(114), 1,
-      aux_sym_script_variable_repeat1,
-    ACTIONS(473), 2,
-      aux_sym_json_body_token3,
-      aux_sym_json_body_token4,
-  [2797] = 2,
-    ACTIONS(478), 2,
-      anon_sym_POUND,
-      anon_sym_AMP,
-    ACTIONS(480), 3,
-      aux_sym_request_token1,
-      sym_query_key,
-      aux_sym__whitespace_token1,
-  [2807] = 5,
+  [2742] = 4,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(482), 1,
-      sym_identifier,
-    ACTIONS(484), 1,
-      anon_sym_LPAREN,
-    ACTIONS(486), 1,
+    ACTIONS(412), 1,
       aux_sym__whitespace_token1,
-    STATE(121), 1,
-      aux_sym__whitespace,
-  [2823] = 4,
-    ACTIONS(33), 1,
-      aux_sym_request_token1,
-    ACTIONS(382), 1,
-      anon_sym_AMP,
-    ACTIONS(384), 1,
-      sym_query_key,
-    STATE(79), 2,
-      sym_query_param,
-      aux_sym_target_url_repeat1,
-  [2837] = 1,
-    ACTIONS(488), 5,
-      anon_sym_SLASH,
-      anon_sym_POUND,
-      anon_sym_QMARK,
-      aux_sym_request_token1,
-      aux_sym__whitespace_token1,
-  [2845] = 2,
-    ACTIONS(490), 2,
-      anon_sym_POUND,
-      anon_sym_AMP,
-    ACTIONS(492), 3,
-      aux_sym_request_token1,
-      sym_query_key,
-      aux_sym__whitespace_token1,
-  [2855] = 4,
-    ACTIONS(33), 1,
-      aux_sym_request_token1,
-    ACTIONS(382), 1,
-      anon_sym_AMP,
-    ACTIONS(384), 1,
-      sym_query_key,
-    STATE(77), 2,
-      sym_query_param,
-      aux_sym_target_url_repeat1,
-  [2869] = 4,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(494), 1,
-      aux_sym__whitespace_token1,
-    STATE(121), 1,
+    STATE(110), 1,
       aux_sym__whitespace,
     ACTIONS(47), 2,
       anon_sym_LPAREN,
       sym_identifier,
-  [2883] = 4,
-    ACTIONS(33), 1,
-      aux_sym_request_token1,
-    ACTIONS(382), 1,
-      anon_sym_AMP,
-    ACTIONS(384), 1,
-      sym_query_key,
-    STATE(80), 2,
-      sym_query_param,
-      aux_sym_target_url_repeat1,
-  [2897] = 2,
-    ACTIONS(497), 2,
+  [2756] = 1,
+    ACTIONS(415), 5,
       anon_sym_POUND,
-      anon_sym_AMP,
-    ACTIONS(499), 3,
       aux_sym_request_token1,
-      sym_query_key,
-      aux_sym__whitespace_token1,
-  [2907] = 2,
-    ACTIONS(501), 2,
-      anon_sym_POUND,
       anon_sym_AMP,
-    ACTIONS(503), 3,
-      aux_sym_request_token1,
-      sym_query_key,
-      aux_sym__whitespace_token1,
-  [2917] = 1,
-    ACTIONS(459), 5,
-      anon_sym_SLASH,
-      anon_sym_POUND,
       anon_sym_QMARK,
-      aux_sym_request_token1,
       aux_sym__whitespace_token1,
-  [2925] = 5,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(329), 1,
-      aux_sym__whitespace_token1,
-    ACTIONS(505), 1,
-      anon_sym_HTTP_SLASH,
-    STATE(63), 1,
-      aux_sym__whitespace,
-    STATE(239), 1,
-      sym_http_version,
-  [2941] = 1,
-    ACTIONS(507), 5,
-      anon_sym_SLASH,
-      anon_sym_POUND,
-      anon_sym_QMARK,
-      aux_sym_request_token1,
-      aux_sym__whitespace_token1,
-  [2949] = 1,
-    ACTIONS(201), 5,
-      anon_sym_SLASH,
-      anon_sym_POUND,
-      anon_sym_QMARK,
-      aux_sym_request_token1,
-      aux_sym__whitespace_token1,
-  [2957] = 4,
-    ACTIONS(33), 1,
-      aux_sym_request_token1,
-    ACTIONS(382), 1,
-      anon_sym_AMP,
-    ACTIONS(384), 1,
-      sym_query_key,
-    STATE(90), 2,
-      sym_query_param,
-      aux_sym_target_url_repeat1,
-  [2971] = 5,
+  [2764] = 5,
     ACTIONS(3), 1,
       aux_sym_request_token1,
     ACTIONS(13), 1,
@@ -7515,753 +7240,688 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym__whitespace,
     STATE(50), 1,
       sym_variable,
-  [2987] = 4,
+  [2780] = 5,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(417), 1,
+      sym_identifier,
+    ACTIONS(419), 1,
+      anon_sym_LPAREN,
+    ACTIONS(421), 1,
+      aux_sym__whitespace_token1,
+    STATE(110), 1,
+      aux_sym__whitespace,
+  [2796] = 4,
     ACTIONS(33), 1,
       aux_sym_request_token1,
-    ACTIONS(382), 1,
-      anon_sym_AMP,
-    ACTIONS(384), 1,
-      sym_query_key,
-    STATE(92), 2,
-      sym_query_param,
-      aux_sym_target_url_repeat1,
-  [3001] = 3,
-    ACTIONS(394), 1,
-      anon_sym_POUND,
-    ACTIONS(509), 1,
-      anon_sym_QMARK,
-    ACTIONS(511), 2,
+    ACTIONS(425), 1,
+      sym__line,
+    STATE(114), 1,
+      aux_sym_script_variable_repeat1,
+    ACTIONS(423), 2,
+      aux_sym_json_body_token3,
+      aux_sym_json_body_token4,
+  [2810] = 4,
+    ACTIONS(33), 1,
       aux_sym_request_token1,
-      aux_sym__whitespace_token1,
-  [3012] = 4,
+    ACTIONS(430), 1,
+      sym__line,
+    STATE(114), 1,
+      aux_sym_script_variable_repeat1,
+    ACTIONS(428), 2,
+      aux_sym_json_body_token3,
+      aux_sym_json_body_token4,
+  [2824] = 5,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(513), 1,
-      sym_identifier,
-    ACTIONS(515), 1,
-      aux_sym_xml_body_token3,
-    STATE(133), 1,
-      aux_sym_form_data_repeat1,
-  [3025] = 4,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(486), 1,
+    ACTIONS(343), 1,
       aux_sym__whitespace_token1,
-    ACTIONS(518), 1,
-      sym_identifier,
-    STATE(121), 1,
+    ACTIONS(432), 1,
+      anon_sym_HTTP_SLASH,
+    STATE(68), 1,
       aux_sym__whitespace,
-  [3038] = 4,
+    STATE(207), 1,
+      sym_http_version,
+  [2840] = 4,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(486), 1,
+    ACTIONS(421), 1,
       aux_sym__whitespace_token1,
-    ACTIONS(520), 1,
+    ACTIONS(434), 1,
       sym_identifier,
+    STATE(110), 1,
+      aux_sym__whitespace,
+  [2853] = 4,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(436), 1,
+      sym_identifier,
+    ACTIONS(438), 1,
+      aux_sym_xml_body_token3,
+    STATE(118), 1,
+      aux_sym_form_data_repeat1,
+  [2866] = 4,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(29), 1,
+      aux_sym__whitespace_token1,
+    ACTIONS(441), 1,
+      anon_sym_RBRACE_RBRACE,
     STATE(134), 1,
       aux_sym__whitespace,
-  [3051] = 4,
+  [2879] = 4,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(486), 1,
+    ACTIONS(421), 1,
       aux_sym__whitespace_token1,
-    ACTIONS(522), 1,
+    ACTIONS(443), 1,
       sym_identifier,
-    STATE(121), 1,
+    STATE(110), 1,
       aux_sym__whitespace,
-  [3064] = 4,
+  [2892] = 4,
     ACTIONS(33), 1,
       aux_sym_request_token1,
-    ACTIONS(524), 1,
+    ACTIONS(445), 1,
+      anon_sym_LPAREN,
+    ACTIONS(447), 1,
+      sym__line,
+    STATE(137), 1,
+      aux_sym_script_variable_repeat1,
+  [2905] = 4,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(421), 1,
+      aux_sym__whitespace_token1,
+    ACTIONS(449), 1,
+      sym_identifier,
+    STATE(120), 1,
+      aux_sym__whitespace,
+  [2918] = 4,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(29), 1,
+      aux_sym__whitespace_token1,
+    ACTIONS(451), 1,
+      anon_sym_RBRACE_RBRACE,
+    STATE(5), 1,
+      aux_sym__whitespace,
+  [2931] = 4,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(29), 1,
+      aux_sym__whitespace_token1,
+    ACTIONS(453), 1,
+      anon_sym_RBRACE_RBRACE,
+    STATE(123), 1,
+      aux_sym__whitespace,
+  [2944] = 4,
+    ACTIONS(33), 1,
+      aux_sym_request_token1,
+    ACTIONS(455), 1,
       aux_sym_xml_body_token2,
-    ACTIONS(526), 1,
+    ACTIONS(457), 1,
       sym__line,
-    STATE(156), 1,
+    STATE(132), 1,
       aux_sym_script_variable_repeat1,
-  [3077] = 4,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(486), 1,
-      aux_sym__whitespace_token1,
-    ACTIONS(528), 1,
-      sym_identifier,
-    STATE(136), 1,
-      aux_sym__whitespace,
-  [3090] = 4,
+  [2957] = 4,
     ACTIONS(3), 1,
       aux_sym_request_token1,
     ACTIONS(29), 1,
       aux_sym__whitespace_token1,
-    ACTIONS(530), 1,
+    ACTIONS(459), 1,
       anon_sym_RBRACE_RBRACE,
     STATE(5), 1,
       aux_sym__whitespace,
-  [3103] = 4,
+  [2970] = 4,
     ACTIONS(3), 1,
       aux_sym_request_token1,
     ACTIONS(29), 1,
       aux_sym__whitespace_token1,
-    ACTIONS(532), 1,
+    ACTIONS(461), 1,
       anon_sym_RBRACE_RBRACE,
-    STATE(139), 1,
+    STATE(126), 1,
       aux_sym__whitespace,
-  [3116] = 4,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(29), 1,
-      aux_sym__whitespace_token1,
-    ACTIONS(534), 1,
-      anon_sym_RBRACE_RBRACE,
-    STATE(5), 1,
-      aux_sym__whitespace,
-  [3129] = 4,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(29), 1,
-      aux_sym__whitespace_token1,
-    ACTIONS(536), 1,
-      anon_sym_RBRACE_RBRACE,
-    STATE(141), 1,
-      aux_sym__whitespace,
-  [3142] = 4,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(29), 1,
-      aux_sym__whitespace_token1,
-    ACTIONS(538), 1,
-      anon_sym_RBRACE_RBRACE,
-    STATE(5), 1,
-      aux_sym__whitespace,
-  [3155] = 4,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(29), 1,
-      aux_sym__whitespace_token1,
-    ACTIONS(540), 1,
-      anon_sym_RBRACE_RBRACE,
-    STATE(143), 1,
-      aux_sym__whitespace,
-  [3168] = 4,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(29), 1,
-      aux_sym__whitespace_token1,
-    ACTIONS(542), 1,
-      anon_sym_RBRACE_RBRACE,
-    STATE(5), 1,
-      aux_sym__whitespace,
-  [3181] = 4,
-    ACTIONS(33), 1,
-      aux_sym_request_token1,
-    ACTIONS(544), 1,
-      aux_sym_json_body_token3,
-    ACTIONS(546), 1,
-      sym__line,
-    STATE(151), 1,
-      aux_sym_script_variable_repeat1,
-  [3194] = 4,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(29), 1,
-      aux_sym__whitespace_token1,
-    ACTIONS(548), 1,
-      anon_sym_RBRACE_RBRACE,
-    STATE(145), 1,
-      aux_sym__whitespace,
-  [3207] = 4,
-    ACTIONS(33), 1,
-      aux_sym_request_token1,
-    ACTIONS(550), 1,
-      aux_sym__whitespace_token1,
-    ACTIONS(552), 1,
-      sym__line,
-    STATE(154), 1,
-      aux_sym__whitespace,
-  [3220] = 4,
+  [2983] = 4,
     ACTIONS(3), 1,
       aux_sym_request_token1,
     ACTIONS(47), 1,
       sym_status_code,
-    ACTIONS(554), 1,
+    ACTIONS(463), 1,
       aux_sym__whitespace_token1,
-    STATE(149), 1,
+    STATE(128), 1,
       aux_sym__whitespace,
-  [3233] = 4,
+  [2996] = 4,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(486), 1,
+    ACTIONS(421), 1,
       aux_sym__whitespace_token1,
-    ACTIONS(557), 1,
+    ACTIONS(466), 1,
       sym_identifier,
-    STATE(162), 1,
+    STATE(117), 1,
       aux_sym__whitespace,
-  [3246] = 4,
+  [3009] = 4,
     ACTIONS(33), 1,
       aux_sym_request_token1,
-    ACTIONS(473), 1,
+    ACTIONS(423), 1,
       aux_sym_json_body_token3,
-    ACTIONS(559), 1,
+    ACTIONS(468), 1,
       sym__line,
-    STATE(151), 1,
+    STATE(130), 1,
       aux_sym_script_variable_repeat1,
-  [3259] = 4,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(562), 1,
-      sym_status_code,
-    ACTIONS(564), 1,
-      aux_sym__whitespace_token1,
-    STATE(149), 1,
-      aux_sym__whitespace,
-  [3272] = 4,
-    ACTIONS(33), 1,
-      aux_sym_request_token1,
-    ACTIONS(550), 1,
-      aux_sym__whitespace_token1,
-    ACTIONS(566), 1,
-      sym__line,
-    STATE(154), 1,
-      aux_sym__whitespace,
-  [3285] = 4,
+  [3022] = 4,
     ACTIONS(33), 1,
       aux_sym_request_token1,
     ACTIONS(45), 1,
       sym__line,
-    ACTIONS(568), 1,
+    ACTIONS(471), 1,
       aux_sym__whitespace_token1,
-    STATE(154), 1,
+    STATE(131), 1,
       aux_sym__whitespace,
-  [3298] = 4,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(29), 1,
-      aux_sym__whitespace_token1,
-    ACTIONS(571), 1,
-      anon_sym_EQ,
-    STATE(164), 1,
-      aux_sym__whitespace,
-  [3311] = 4,
+  [3035] = 4,
     ACTIONS(33), 1,
       aux_sym_request_token1,
-    ACTIONS(473), 1,
+    ACTIONS(423), 1,
       aux_sym_xml_body_token2,
-    ACTIONS(573), 1,
+    ACTIONS(474), 1,
       sym__line,
-    STATE(156), 1,
+    STATE(132), 1,
       aux_sym_script_variable_repeat1,
-  [3324] = 4,
-    ACTIONS(3), 1,
+  [3048] = 4,
+    ACTIONS(33), 1,
       aux_sym_request_token1,
-    ACTIONS(576), 1,
-      sym_identifier,
-    ACTIONS(578), 1,
-      aux_sym_xml_body_token3,
+    ACTIONS(423), 1,
+      aux_sym_script_variable_token2,
+    ACTIONS(477), 1,
+      sym__line,
     STATE(133), 1,
-      aux_sym_form_data_repeat1,
-  [3337] = 4,
-    ACTIONS(33), 1,
-      aux_sym_request_token1,
-    ACTIONS(580), 1,
-      anon_sym_LPAREN,
-    ACTIONS(582), 1,
-      sym__line,
-    STATE(146), 1,
       aux_sym_script_variable_repeat1,
-  [3350] = 4,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(329), 1,
-      aux_sym__whitespace_token1,
-    ACTIONS(584), 1,
-      sym_status_text,
-    STATE(63), 1,
-      aux_sym__whitespace,
-  [3363] = 4,
+  [3061] = 4,
     ACTIONS(3), 1,
       aux_sym_request_token1,
     ACTIONS(29), 1,
       aux_sym__whitespace_token1,
-    ACTIONS(586), 1,
-      anon_sym_RBRACE_RBRACE,
-    STATE(165), 1,
-      aux_sym__whitespace,
-  [3376] = 3,
-    ACTIONS(422), 1,
-      anon_sym_POUND,
-    ACTIONS(436), 1,
-      anon_sym_QMARK,
-    ACTIONS(438), 2,
-      aux_sym_request_token1,
-      aux_sym__whitespace_token1,
-  [3387] = 4,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(486), 1,
-      aux_sym__whitespace_token1,
-    ACTIONS(588), 1,
-      sym_identifier,
-    STATE(121), 1,
-      aux_sym__whitespace,
-  [3400] = 4,
-    ACTIONS(33), 1,
-      aux_sym_request_token1,
-    ACTIONS(590), 1,
-      aux_sym_script_variable_token2,
-    ACTIONS(592), 1,
-      sym__line,
-    STATE(168), 1,
-      aux_sym_script_variable_repeat1,
-  [3413] = 4,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(29), 1,
-      aux_sym__whitespace_token1,
-    ACTIONS(594), 1,
-      anon_sym_EQ,
-    STATE(5), 1,
-      aux_sym__whitespace,
-  [3426] = 4,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(29), 1,
-      aux_sym__whitespace_token1,
-    ACTIONS(596), 1,
+    ACTIONS(480), 1,
       anon_sym_RBRACE_RBRACE,
     STATE(5), 1,
       aux_sym__whitespace,
-  [3439] = 4,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(29), 1,
-      aux_sym__whitespace_token1,
-    ACTIONS(598), 1,
-      anon_sym_RBRACE_RBRACE,
-    STATE(170), 1,
-      aux_sym__whitespace,
-  [3452] = 4,
-    ACTIONS(33), 1,
-      aux_sym_request_token1,
-    ACTIONS(546), 1,
-      sym__line,
-    ACTIONS(600), 1,
-      aux_sym_json_body_token3,
-    STATE(151), 1,
-      aux_sym_script_variable_repeat1,
-  [3465] = 4,
-    ACTIONS(33), 1,
-      aux_sym_request_token1,
-    ACTIONS(473), 1,
-      aux_sym_script_variable_token2,
-    ACTIONS(602), 1,
-      sym__line,
-    STATE(168), 1,
-      aux_sym_script_variable_repeat1,
-  [3478] = 3,
-    ACTIONS(402), 1,
-      anon_sym_POUND,
-    ACTIONS(404), 1,
-      anon_sym_QMARK,
-    ACTIONS(406), 2,
-      aux_sym_request_token1,
-      aux_sym__whitespace_token1,
-  [3489] = 4,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(29), 1,
-      aux_sym__whitespace_token1,
-    ACTIONS(605), 1,
-      anon_sym_RBRACE_RBRACE,
-    STATE(5), 1,
-      aux_sym__whitespace,
-  [3502] = 2,
+  [3074] = 2,
     ACTIONS(3), 1,
       aux_sym_request_token1,
     ACTIONS(57), 3,
       anon_sym_LPAREN,
       sym_identifier,
       aux_sym__whitespace_token1,
-  [3511] = 4,
+  [3083] = 4,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(607), 1,
-      anon_sym_AT,
-    ACTIONS(609), 1,
+    ACTIONS(29), 1,
       aux_sym__whitespace_token1,
-    STATE(153), 1,
+    ACTIONS(482), 1,
+      anon_sym_EQ,
+    STATE(140), 1,
       aux_sym__whitespace,
-  [3524] = 3,
-    ACTIONS(378), 1,
-      anon_sym_POUND,
-    ACTIONS(412), 1,
-      anon_sym_QMARK,
-    ACTIONS(414), 2,
-      aux_sym_request_token1,
-      aux_sym__whitespace_token1,
-  [3535] = 3,
+  [3096] = 4,
     ACTIONS(33), 1,
       aux_sym_request_token1,
-    ACTIONS(611), 1,
+    ACTIONS(484), 1,
+      aux_sym_json_body_token3,
+    ACTIONS(486), 1,
+      sym__line,
+    STATE(130), 1,
+      aux_sym_script_variable_repeat1,
+  [3109] = 4,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(488), 1,
+      anon_sym_AT,
+    ACTIONS(490), 1,
+      aux_sym__whitespace_token1,
+    STATE(144), 1,
+      aux_sym__whitespace,
+  [3122] = 4,
+    ACTIONS(33), 1,
+      aux_sym_request_token1,
+    ACTIONS(492), 1,
+      aux_sym__whitespace_token1,
+    ACTIONS(494), 1,
+      sym__line,
+    STATE(131), 1,
+      aux_sym__whitespace,
+  [3135] = 4,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(29), 1,
+      aux_sym__whitespace_token1,
+    ACTIONS(496), 1,
+      anon_sym_EQ,
+    STATE(5), 1,
+      aux_sym__whitespace,
+  [3148] = 4,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(29), 1,
+      aux_sym__whitespace_token1,
+    ACTIONS(498), 1,
+      anon_sym_RBRACE_RBRACE,
+    STATE(142), 1,
+      aux_sym__whitespace,
+  [3161] = 4,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(29), 1,
+      aux_sym__whitespace_token1,
+    ACTIONS(500), 1,
+      anon_sym_RBRACE_RBRACE,
+    STATE(5), 1,
+      aux_sym__whitespace,
+  [3174] = 4,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(502), 1,
+      sym_status_code,
+    ACTIONS(504), 1,
+      aux_sym__whitespace_token1,
+    STATE(128), 1,
+      aux_sym__whitespace,
+  [3187] = 4,
+    ACTIONS(33), 1,
+      aux_sym_request_token1,
+    ACTIONS(492), 1,
+      aux_sym__whitespace_token1,
+    ACTIONS(506), 1,
+      sym__line,
+    STATE(131), 1,
+      aux_sym__whitespace,
+  [3200] = 4,
+    ACTIONS(33), 1,
+      aux_sym_request_token1,
+    ACTIONS(508), 1,
+      aux_sym_script_variable_token2,
+    ACTIONS(510), 1,
+      sym__line,
+    STATE(133), 1,
+      aux_sym_script_variable_repeat1,
+  [3213] = 4,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(343), 1,
+      aux_sym__whitespace_token1,
+    ACTIONS(512), 1,
+      sym_status_text,
+    STATE(68), 1,
+      aux_sym__whitespace,
+  [3226] = 4,
+    ACTIONS(33), 1,
+      aux_sym_request_token1,
+    ACTIONS(486), 1,
+      sym__line,
+    ACTIONS(514), 1,
+      aux_sym_json_body_token3,
+    STATE(130), 1,
+      aux_sym_script_variable_repeat1,
+  [3239] = 4,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(516), 1,
+      sym_identifier,
+    ACTIONS(518), 1,
+      aux_sym_xml_body_token3,
+    STATE(118), 1,
+      aux_sym_form_data_repeat1,
+  [3252] = 3,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(504), 1,
+      aux_sym__whitespace_token1,
+    STATE(143), 1,
+      aux_sym__whitespace,
+  [3262] = 3,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(520), 1,
+      sym_identifier,
+    STATE(62), 1,
+      sym_host,
+  [3272] = 3,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(522), 1,
+      sym_identifier,
+    STATE(47), 1,
+      sym_host,
+  [3282] = 3,
+    ACTIONS(33), 1,
+      aux_sym_request_token1,
+    ACTIONS(524), 1,
+      sym__line,
+    STATE(125), 1,
+      aux_sym_script_variable_repeat1,
+  [3292] = 3,
+    ACTIONS(33), 1,
+      aux_sym_request_token1,
+    ACTIONS(447), 1,
       sym__line,
     STATE(137), 1,
       aux_sym_script_variable_repeat1,
-  [3545] = 2,
+  [3302] = 3,
+    ACTIONS(33), 1,
+      aux_sym_request_token1,
+    ACTIONS(526), 1,
+      sym_param,
+    STATE(180), 1,
+      sym_fragment,
+  [3312] = 3,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(528), 1,
+      sym_identifier,
+    ACTIONS(530), 1,
+      aux_sym_port_token1,
+  [3322] = 3,
+    ACTIONS(33), 1,
+      aux_sym_request_token1,
+    ACTIONS(526), 1,
+      sym_param,
+    STATE(194), 1,
+      sym_fragment,
+  [3332] = 3,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(343), 1,
+      aux_sym__whitespace_token1,
+    STATE(146), 1,
+      aux_sym__whitespace,
+  [3342] = 3,
+    ACTIONS(343), 1,
+      aux_sym__whitespace_token1,
+    ACTIONS(532), 1,
+      aux_sym_request_token1,
+    STATE(116), 1,
+      aux_sym__whitespace,
+  [3352] = 2,
     ACTIONS(3), 1,
       aux_sym_request_token1,
     ACTIONS(57), 2,
       sym_status_code,
       aux_sym__whitespace_token1,
-  [3553] = 3,
+  [3360] = 3,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(329), 1,
-      aux_sym__whitespace_token1,
-    STATE(159), 1,
-      aux_sym__whitespace,
-  [3563] = 3,
+    ACTIONS(520), 1,
+      sym_identifier,
+    STATE(63), 1,
+      sym_host,
+  [3370] = 2,
     ACTIONS(33), 1,
       aux_sym_request_token1,
-    ACTIONS(613), 1,
-      sym_param,
-    STATE(212), 1,
-      sym_fragment,
-  [3573] = 3,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(486), 1,
+    ACTIONS(55), 2,
       aux_sym__whitespace_token1,
-    STATE(116), 1,
-      aux_sym__whitespace,
-  [3583] = 3,
-    ACTIONS(33), 1,
-      aux_sym_request_token1,
-    ACTIONS(615), 1,
       sym__line,
-    STATE(110), 1,
-      aux_sym_script_variable_repeat1,
-  [3593] = 3,
+  [3378] = 3,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(522), 1,
+      sym_identifier,
+    STATE(56), 1,
+      sym_host,
+  [3388] = 3,
     ACTIONS(33), 1,
       aux_sym_request_token1,
-    ACTIONS(613), 1,
+    ACTIONS(526), 1,
       sym_param,
-    STATE(213), 1,
+    STATE(197), 1,
       sym_fragment,
-  [3603] = 3,
+  [3398] = 3,
     ACTIONS(33), 1,
       aux_sym_request_token1,
-    ACTIONS(613), 1,
+    ACTIONS(526), 1,
       sym_param,
-    STATE(225), 1,
+    STATE(198), 1,
       sym_fragment,
-  [3613] = 3,
+  [3408] = 3,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(490), 1,
+      aux_sym__whitespace_token1,
+    STATE(139), 1,
+      aux_sym__whitespace,
+  [3418] = 3,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(528), 1,
+      sym_identifier,
+    ACTIONS(534), 1,
+      aux_sym_port_token1,
+  [3428] = 3,
     ACTIONS(3), 1,
       aux_sym_request_token1,
     ACTIONS(29), 1,
       aux_sym__whitespace_token1,
-    STATE(111), 1,
+    STATE(109), 1,
       aux_sym__whitespace,
-  [3623] = 3,
+  [3438] = 3,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(617), 1,
-      sym_identifier,
-    ACTIONS(619), 1,
-      aux_sym_port_token1,
-  [3633] = 3,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(621), 1,
-      sym_identifier,
-    STATE(39), 1,
-      sym_host,
-  [3643] = 3,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(623), 1,
-      sym_identifier,
-    STATE(97), 1,
-      sym_host,
-  [3653] = 3,
+    ACTIONS(29), 1,
+      aux_sym__whitespace_token1,
+    STATE(112), 1,
+      aux_sym__whitespace,
+  [3448] = 3,
     ACTIONS(33), 1,
       aux_sym_request_token1,
-    ACTIONS(613), 1,
+    ACTIONS(526), 1,
       sym_param,
-    STATE(211), 1,
+    STATE(183), 1,
       sym_fragment,
-  [3663] = 3,
-    ACTIONS(33), 1,
-      aux_sym_request_token1,
-    ACTIONS(625), 1,
-      sym__line,
-    STATE(167), 1,
-      aux_sym_script_variable_repeat1,
-  [3673] = 3,
-    ACTIONS(33), 1,
-      aux_sym_request_token1,
-    ACTIONS(582), 1,
-      sym__line,
-    STATE(146), 1,
-      aux_sym_script_variable_repeat1,
-  [3683] = 3,
+  [3458] = 3,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(627), 1,
+    ACTIONS(536), 1,
       anon_sym_COLON,
-    ACTIONS(629), 1,
+    ACTIONS(538), 1,
       anon_sym_EQ,
-  [3693] = 3,
+  [3468] = 3,
     ACTIONS(3), 1,
       aux_sym_request_token1,
     ACTIONS(29), 1,
       aux_sym__whitespace_token1,
     STATE(2), 1,
       aux_sym__whitespace,
-  [3703] = 3,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(609), 1,
-      aux_sym__whitespace_token1,
-    STATE(148), 1,
-      aux_sym__whitespace,
-  [3713] = 3,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(621), 1,
-      sym_identifier,
-    STATE(47), 1,
-      sym_host,
-  [3723] = 3,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(29), 1,
-      aux_sym__whitespace_token1,
-    STATE(130), 1,
-      aux_sym__whitespace,
-  [3733] = 2,
+  [3478] = 3,
     ACTIONS(33), 1,
       aux_sym_request_token1,
-    ACTIONS(55), 2,
-      aux_sym__whitespace_token1,
+    ACTIONS(540), 1,
       sym__line,
-  [3741] = 3,
-    ACTIONS(33), 1,
-      aux_sym_request_token1,
-    ACTIONS(631), 1,
-      sym__line,
-    STATE(163), 1,
+    STATE(145), 1,
       aux_sym_script_variable_repeat1,
-  [3751] = 3,
+  [3488] = 3,
     ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(421), 1,
+      aux_sym__whitespace_token1,
+    STATE(113), 1,
+      aux_sym__whitespace,
+  [3498] = 3,
+    ACTIONS(33), 1,
+      aux_sym_request_token1,
+    ACTIONS(542), 1,
+      sym__line,
+    STATE(115), 1,
+      aux_sym_script_variable_repeat1,
+  [3508] = 3,
+    ACTIONS(33), 1,
+      aux_sym_request_token1,
+    ACTIONS(526), 1,
+      sym_param,
+    STATE(199), 1,
+      sym_fragment,
+  [3518] = 3,
+    ACTIONS(33), 1,
+      aux_sym_request_token1,
+    ACTIONS(544), 1,
+      sym__line,
+    STATE(147), 1,
+      aux_sym_script_variable_repeat1,
+  [3528] = 2,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(546), 1,
+      anon_sym_EQ,
+  [3535] = 2,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(548), 1,
+      sym_identifier,
+  [3542] = 2,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(550), 1,
+      aux_sym_port_token1,
+  [3549] = 1,
+    ACTIONS(395), 2,
+      aux_sym_request_token1,
+      aux_sym__whitespace_token1,
+  [3554] = 2,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(552), 1,
+      ts_builtin_sym_end,
+  [3561] = 2,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(516), 1,
+      sym_identifier,
+  [3568] = 1,
+    ACTIONS(322), 2,
+      aux_sym_request_token1,
+      aux_sym__whitespace_token1,
+  [3573] = 1,
+    ACTIONS(554), 2,
+      aux_sym_request_token1,
+      aux_sym__whitespace_token1,
+  [3578] = 2,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(556), 1,
+      anon_sym_AT,
+  [3585] = 2,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(558), 1,
+      anon_sym_COLON_SLASH_SLASH,
+  [3592] = 2,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(560), 1,
+      anon_sym_COLON_SLASH_SLASH,
+  [3599] = 2,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(562), 1,
+      anon_sym_COLON,
+  [3606] = 2,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(408), 1,
+      sym_identifier,
+  [3613] = 2,
+    ACTIONS(33), 1,
       aux_sym_request_token1,
     ACTIONS(564), 1,
-      aux_sym__whitespace_token1,
-    STATE(152), 1,
-      aux_sym__whitespace,
-  [3761] = 3,
-    ACTIONS(33), 1,
-      aux_sym_request_token1,
-    ACTIONS(613), 1,
-      sym_param,
-    STATE(227), 1,
-      sym_fragment,
-  [3771] = 3,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(617), 1,
-      sym_identifier,
-    ACTIONS(633), 1,
-      aux_sym_port_token1,
-  [3781] = 3,
-    ACTIONS(33), 1,
-      aux_sym_request_token1,
-    ACTIONS(613), 1,
-      sym_param,
-    STATE(233), 1,
-      sym_fragment,
-  [3791] = 3,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(623), 1,
-      sym_identifier,
-    STATE(86), 1,
-      sym_host,
-  [3801] = 3,
-    ACTIONS(329), 1,
-      aux_sym__whitespace_token1,
-    ACTIONS(635), 1,
-      aux_sym_request_token1,
-    STATE(126), 1,
-      aux_sym__whitespace,
-  [3811] = 3,
-    ACTIONS(33), 1,
-      aux_sym_request_token1,
-    ACTIONS(613), 1,
-      sym_param,
-    STATE(232), 1,
-      sym_fragment,
-  [3821] = 2,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(637), 1,
-      anon_sym_COLON_SLASH_SLASH,
-  [3828] = 2,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(639), 1,
-      anon_sym_AT,
-  [3835] = 2,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(641), 1,
-      anon_sym_EQ,
-  [3842] = 2,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(643), 1,
-      anon_sym_COLON_SLASH_SLASH,
-  [3849] = 2,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(507), 1,
-      sym_identifier,
-  [3856] = 1,
-    ACTIONS(645), 2,
-      aux_sym_request_token1,
-      aux_sym__whitespace_token1,
-  [3861] = 2,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(647), 1,
-      anon_sym_COLON_SLASH_SLASH,
-  [3868] = 2,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(627), 1,
-      anon_sym_COLON,
-  [3875] = 1,
-    ACTIONS(438), 2,
-      aux_sym_request_token1,
-      aux_sym__whitespace_token1,
-  [3880] = 1,
-    ACTIONS(649), 2,
-      aux_sym_request_token1,
-      aux_sym__whitespace_token1,
-  [3885] = 1,
-    ACTIONS(651), 2,
-      aux_sym_request_token1,
-      aux_sym__whitespace_token1,
-  [3890] = 2,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(653), 1,
-      aux_sym__whitespace_token1,
-  [3897] = 2,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(576), 1,
-      sym_identifier,
-  [3904] = 2,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(655), 1,
-      ts_builtin_sym_end,
-  [3911] = 2,
-    ACTIONS(33), 1,
-      aux_sym_request_token1,
-    ACTIONS(657), 1,
       sym_query_key,
-  [3918] = 2,
+  [3620] = 2,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(488), 1,
-      sym_identifier,
-  [3925] = 2,
+    ACTIONS(566), 1,
+      aux_sym_port_token1,
+  [3627] = 2,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(659), 1,
-      sym_identifier,
-  [3932] = 2,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(661), 1,
-      anon_sym_COLON,
-  [3939] = 2,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(663), 1,
-      sym_identifier,
-  [3946] = 2,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(629), 1,
+    ACTIONS(538), 1,
       anon_sym_EQ,
-  [3953] = 2,
+  [3634] = 2,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(665), 1,
-      aux_sym_port_token1,
-  [3960] = 2,
+    ACTIONS(568), 1,
+      aux_sym__whitespace_token1,
+  [3641] = 1,
+    ACTIONS(570), 2,
+      aux_sym_request_token1,
+      aux_sym__whitespace_token1,
+  [3646] = 2,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(667), 1,
+    ACTIONS(572), 1,
+      aux_sym_http_version_token1,
+  [3653] = 2,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(574), 1,
       sym_identifier,
-  [3967] = 1,
-    ACTIONS(669), 2,
+  [3660] = 1,
+    ACTIONS(576), 2,
       aux_sym_request_token1,
       aux_sym__whitespace_token1,
-  [3972] = 2,
+  [3665] = 1,
+    ACTIONS(374), 2,
+      aux_sym_request_token1,
+      aux_sym__whitespace_token1,
+  [3670] = 1,
+    ACTIONS(314), 2,
+      aux_sym_request_token1,
+      aux_sym__whitespace_token1,
+  [3675] = 2,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(671), 1,
+    ACTIONS(536), 1,
+      anon_sym_COLON,
+  [3682] = 2,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(578), 1,
       anon_sym_AT,
-  [3979] = 1,
-    ACTIONS(414), 2,
-      aux_sym_request_token1,
-      aux_sym__whitespace_token1,
-  [3984] = 2,
+  [3689] = 2,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(673), 1,
-      aux_sym_port_token1,
-  [3991] = 2,
-    ACTIONS(3), 1,
-      aux_sym_request_token1,
-    ACTIONS(675), 1,
+    ACTIONS(580), 1,
       aux_sym_http_version_token1,
-  [3998] = 2,
+  [3696] = 2,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(677), 1,
+    ACTIONS(582), 1,
+      sym_identifier,
+  [3703] = 2,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(584), 1,
+      anon_sym_COLON_SLASH_SLASH,
+  [3710] = 2,
+    ACTIONS(3), 1,
+      aux_sym_request_token1,
+    ACTIONS(586), 1,
       anon_sym_AT,
-  [4005] = 2,
+  [3717] = 2,
     ACTIONS(3), 1,
       aux_sym_request_token1,
-    ACTIONS(679), 1,
-      aux_sym_http_version_token1,
-  [4012] = 1,
-    ACTIONS(511), 2,
+    ACTIONS(406), 1,
+      sym_identifier,
+  [3724] = 1,
+    ACTIONS(588), 1,
       aux_sym_request_token1,
-      aux_sym__whitespace_token1,
-  [4017] = 1,
-    ACTIONS(681), 2,
+  [3728] = 1,
+    ACTIONS(590), 1,
       aux_sym_request_token1,
-      aux_sym__whitespace_token1,
-  [4022] = 1,
-    ACTIONS(683), 1,
+  [3732] = 1,
+    ACTIONS(592), 1,
       aux_sym_request_token1,
-  [4026] = 1,
-    ACTIONS(685), 1,
+  [3736] = 1,
+    ACTIONS(594), 1,
       aux_sym_request_token1,
-  [4030] = 1,
-    ACTIONS(687), 1,
+  [3740] = 1,
+    ACTIONS(568), 1,
       aux_sym_request_token1,
-  [4034] = 1,
-    ACTIONS(653), 1,
-      aux_sym_request_token1,
-  [4038] = 1,
-    ACTIONS(689), 1,
-      aux_sym_request_token1,
-  [4042] = 1,
-    ACTIONS(691), 1,
+  [3744] = 1,
+    ACTIONS(596), 1,
       aux_sym_request_token1,
 };
 
@@ -8292,8 +7952,8 @@ static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(25)] = 1129,
   [SMALL_STATE(26)] = 1162,
   [SMALL_STATE(27)] = 1185,
-  [SMALL_STATE(28)] = 1208,
-  [SMALL_STATE(29)] = 1235,
+  [SMALL_STATE(28)] = 1212,
+  [SMALL_STATE(29)] = 1239,
   [SMALL_STATE(30)] = 1262,
   [SMALL_STATE(31)] = 1289,
   [SMALL_STATE(32)] = 1313,
@@ -8307,538 +7967,465 @@ static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(40)] = 1496,
   [SMALL_STATE(41)] = 1517,
   [SMALL_STATE(42)] = 1538,
-  [SMALL_STATE(43)] = 1559,
-  [SMALL_STATE(44)] = 1580,
-  [SMALL_STATE(45)] = 1601,
-  [SMALL_STATE(46)] = 1622,
-  [SMALL_STATE(47)] = 1643,
-  [SMALL_STATE(48)] = 1664,
-  [SMALL_STATE(49)] = 1685,
-  [SMALL_STATE(50)] = 1706,
-  [SMALL_STATE(51)] = 1727,
-  [SMALL_STATE(52)] = 1748,
-  [SMALL_STATE(53)] = 1769,
-  [SMALL_STATE(54)] = 1790,
-  [SMALL_STATE(55)] = 1811,
-  [SMALL_STATE(56)] = 1832,
-  [SMALL_STATE(57)] = 1853,
-  [SMALL_STATE(58)] = 1874,
-  [SMALL_STATE(59)] = 1895,
-  [SMALL_STATE(60)] = 1924,
-  [SMALL_STATE(61)] = 1953,
-  [SMALL_STATE(62)] = 1985,
-  [SMALL_STATE(63)] = 2005,
-  [SMALL_STATE(64)] = 2023,
-  [SMALL_STATE(65)] = 2044,
-  [SMALL_STATE(66)] = 2057,
-  [SMALL_STATE(67)] = 2078,
-  [SMALL_STATE(68)] = 2099,
-  [SMALL_STATE(69)] = 2116,
-  [SMALL_STATE(70)] = 2137,
-  [SMALL_STATE(71)] = 2153,
-  [SMALL_STATE(72)] = 2169,
-  [SMALL_STATE(73)] = 2181,
-  [SMALL_STATE(74)] = 2197,
-  [SMALL_STATE(75)] = 2215,
-  [SMALL_STATE(76)] = 2227,
-  [SMALL_STATE(77)] = 2245,
-  [SMALL_STATE(78)] = 2263,
-  [SMALL_STATE(79)] = 2281,
-  [SMALL_STATE(80)] = 2299,
-  [SMALL_STATE(81)] = 2317,
-  [SMALL_STATE(82)] = 2327,
-  [SMALL_STATE(83)] = 2339,
-  [SMALL_STATE(84)] = 2349,
-  [SMALL_STATE(85)] = 2359,
-  [SMALL_STATE(86)] = 2373,
-  [SMALL_STATE(87)] = 2393,
-  [SMALL_STATE(88)] = 2405,
-  [SMALL_STATE(89)] = 2419,
-  [SMALL_STATE(90)] = 2439,
-  [SMALL_STATE(91)] = 2457,
-  [SMALL_STATE(92)] = 2475,
-  [SMALL_STATE(93)] = 2493,
-  [SMALL_STATE(94)] = 2513,
-  [SMALL_STATE(95)] = 2531,
-  [SMALL_STATE(96)] = 2541,
-  [SMALL_STATE(97)] = 2557,
-  [SMALL_STATE(98)] = 2577,
-  [SMALL_STATE(99)] = 2588,
-  [SMALL_STATE(100)] = 2601,
-  [SMALL_STATE(101)] = 2614,
-  [SMALL_STATE(102)] = 2627,
-  [SMALL_STATE(103)] = 2640,
-  [SMALL_STATE(104)] = 2659,
-  [SMALL_STATE(105)] = 2670,
-  [SMALL_STATE(106)] = 2689,
-  [SMALL_STATE(107)] = 2702,
-  [SMALL_STATE(108)] = 2713,
-  [SMALL_STATE(109)] = 2724,
-  [SMALL_STATE(110)] = 2735,
-  [SMALL_STATE(111)] = 2749,
-  [SMALL_STATE(112)] = 2765,
-  [SMALL_STATE(113)] = 2775,
-  [SMALL_STATE(114)] = 2783,
-  [SMALL_STATE(115)] = 2797,
-  [SMALL_STATE(116)] = 2807,
-  [SMALL_STATE(117)] = 2823,
-  [SMALL_STATE(118)] = 2837,
-  [SMALL_STATE(119)] = 2845,
-  [SMALL_STATE(120)] = 2855,
-  [SMALL_STATE(121)] = 2869,
-  [SMALL_STATE(122)] = 2883,
-  [SMALL_STATE(123)] = 2897,
-  [SMALL_STATE(124)] = 2907,
-  [SMALL_STATE(125)] = 2917,
-  [SMALL_STATE(126)] = 2925,
-  [SMALL_STATE(127)] = 2941,
-  [SMALL_STATE(128)] = 2949,
-  [SMALL_STATE(129)] = 2957,
-  [SMALL_STATE(130)] = 2971,
-  [SMALL_STATE(131)] = 2987,
-  [SMALL_STATE(132)] = 3001,
-  [SMALL_STATE(133)] = 3012,
-  [SMALL_STATE(134)] = 3025,
-  [SMALL_STATE(135)] = 3038,
-  [SMALL_STATE(136)] = 3051,
-  [SMALL_STATE(137)] = 3064,
-  [SMALL_STATE(138)] = 3077,
-  [SMALL_STATE(139)] = 3090,
-  [SMALL_STATE(140)] = 3103,
-  [SMALL_STATE(141)] = 3116,
-  [SMALL_STATE(142)] = 3129,
-  [SMALL_STATE(143)] = 3142,
-  [SMALL_STATE(144)] = 3155,
-  [SMALL_STATE(145)] = 3168,
-  [SMALL_STATE(146)] = 3181,
-  [SMALL_STATE(147)] = 3194,
-  [SMALL_STATE(148)] = 3207,
-  [SMALL_STATE(149)] = 3220,
-  [SMALL_STATE(150)] = 3233,
-  [SMALL_STATE(151)] = 3246,
-  [SMALL_STATE(152)] = 3259,
-  [SMALL_STATE(153)] = 3272,
-  [SMALL_STATE(154)] = 3285,
-  [SMALL_STATE(155)] = 3298,
-  [SMALL_STATE(156)] = 3311,
-  [SMALL_STATE(157)] = 3324,
-  [SMALL_STATE(158)] = 3337,
-  [SMALL_STATE(159)] = 3350,
-  [SMALL_STATE(160)] = 3363,
-  [SMALL_STATE(161)] = 3376,
-  [SMALL_STATE(162)] = 3387,
-  [SMALL_STATE(163)] = 3400,
-  [SMALL_STATE(164)] = 3413,
-  [SMALL_STATE(165)] = 3426,
-  [SMALL_STATE(166)] = 3439,
-  [SMALL_STATE(167)] = 3452,
-  [SMALL_STATE(168)] = 3465,
-  [SMALL_STATE(169)] = 3478,
-  [SMALL_STATE(170)] = 3489,
-  [SMALL_STATE(171)] = 3502,
-  [SMALL_STATE(172)] = 3511,
-  [SMALL_STATE(173)] = 3524,
-  [SMALL_STATE(174)] = 3535,
-  [SMALL_STATE(175)] = 3545,
-  [SMALL_STATE(176)] = 3553,
-  [SMALL_STATE(177)] = 3563,
-  [SMALL_STATE(178)] = 3573,
-  [SMALL_STATE(179)] = 3583,
-  [SMALL_STATE(180)] = 3593,
-  [SMALL_STATE(181)] = 3603,
-  [SMALL_STATE(182)] = 3613,
-  [SMALL_STATE(183)] = 3623,
-  [SMALL_STATE(184)] = 3633,
-  [SMALL_STATE(185)] = 3643,
-  [SMALL_STATE(186)] = 3653,
-  [SMALL_STATE(187)] = 3663,
-  [SMALL_STATE(188)] = 3673,
-  [SMALL_STATE(189)] = 3683,
-  [SMALL_STATE(190)] = 3693,
-  [SMALL_STATE(191)] = 3703,
-  [SMALL_STATE(192)] = 3713,
-  [SMALL_STATE(193)] = 3723,
-  [SMALL_STATE(194)] = 3733,
-  [SMALL_STATE(195)] = 3741,
-  [SMALL_STATE(196)] = 3751,
-  [SMALL_STATE(197)] = 3761,
-  [SMALL_STATE(198)] = 3771,
-  [SMALL_STATE(199)] = 3781,
-  [SMALL_STATE(200)] = 3791,
-  [SMALL_STATE(201)] = 3801,
-  [SMALL_STATE(202)] = 3811,
-  [SMALL_STATE(203)] = 3821,
-  [SMALL_STATE(204)] = 3828,
-  [SMALL_STATE(205)] = 3835,
-  [SMALL_STATE(206)] = 3842,
-  [SMALL_STATE(207)] = 3849,
-  [SMALL_STATE(208)] = 3856,
-  [SMALL_STATE(209)] = 3861,
-  [SMALL_STATE(210)] = 3868,
-  [SMALL_STATE(211)] = 3875,
-  [SMALL_STATE(212)] = 3880,
-  [SMALL_STATE(213)] = 3885,
-  [SMALL_STATE(214)] = 3890,
-  [SMALL_STATE(215)] = 3897,
-  [SMALL_STATE(216)] = 3904,
-  [SMALL_STATE(217)] = 3911,
-  [SMALL_STATE(218)] = 3918,
-  [SMALL_STATE(219)] = 3925,
-  [SMALL_STATE(220)] = 3932,
-  [SMALL_STATE(221)] = 3939,
-  [SMALL_STATE(222)] = 3946,
-  [SMALL_STATE(223)] = 3953,
-  [SMALL_STATE(224)] = 3960,
-  [SMALL_STATE(225)] = 3967,
-  [SMALL_STATE(226)] = 3972,
-  [SMALL_STATE(227)] = 3979,
-  [SMALL_STATE(228)] = 3984,
-  [SMALL_STATE(229)] = 3991,
-  [SMALL_STATE(230)] = 3998,
-  [SMALL_STATE(231)] = 4005,
-  [SMALL_STATE(232)] = 4012,
-  [SMALL_STATE(233)] = 4017,
-  [SMALL_STATE(234)] = 4022,
-  [SMALL_STATE(235)] = 4026,
-  [SMALL_STATE(236)] = 4030,
-  [SMALL_STATE(237)] = 4034,
-  [SMALL_STATE(238)] = 4038,
-  [SMALL_STATE(239)] = 4042,
+  [SMALL_STATE(43)] = 1575,
+  [SMALL_STATE(44)] = 1596,
+  [SMALL_STATE(45)] = 1617,
+  [SMALL_STATE(46)] = 1638,
+  [SMALL_STATE(47)] = 1659,
+  [SMALL_STATE(48)] = 1680,
+  [SMALL_STATE(49)] = 1701,
+  [SMALL_STATE(50)] = 1722,
+  [SMALL_STATE(51)] = 1743,
+  [SMALL_STATE(52)] = 1764,
+  [SMALL_STATE(53)] = 1785,
+  [SMALL_STATE(54)] = 1806,
+  [SMALL_STATE(55)] = 1827,
+  [SMALL_STATE(56)] = 1848,
+  [SMALL_STATE(57)] = 1869,
+  [SMALL_STATE(58)] = 1890,
+  [SMALL_STATE(59)] = 1911,
+  [SMALL_STATE(60)] = 1932,
+  [SMALL_STATE(61)] = 1961,
+  [SMALL_STATE(62)] = 1990,
+  [SMALL_STATE(63)] = 2015,
+  [SMALL_STATE(64)] = 2040,
+  [SMALL_STATE(65)] = 2065,
+  [SMALL_STATE(66)] = 2090,
+  [SMALL_STATE(67)] = 2112,
+  [SMALL_STATE(68)] = 2130,
+  [SMALL_STATE(69)] = 2148,
+  [SMALL_STATE(70)] = 2169,
+  [SMALL_STATE(71)] = 2190,
+  [SMALL_STATE(72)] = 2203,
+  [SMALL_STATE(73)] = 2224,
+  [SMALL_STATE(74)] = 2235,
+  [SMALL_STATE(75)] = 2246,
+  [SMALL_STATE(76)] = 2257,
+  [SMALL_STATE(77)] = 2272,
+  [SMALL_STATE(78)] = 2283,
+  [SMALL_STATE(79)] = 2302,
+  [SMALL_STATE(80)] = 2317,
+  [SMALL_STATE(81)] = 2338,
+  [SMALL_STATE(82)] = 2354,
+  [SMALL_STATE(83)] = 2370,
+  [SMALL_STATE(84)] = 2382,
+  [SMALL_STATE(85)] = 2400,
+  [SMALL_STATE(86)] = 2414,
+  [SMALL_STATE(87)] = 2430,
+  [SMALL_STATE(88)] = 2442,
+  [SMALL_STATE(89)] = 2454,
+  [SMALL_STATE(90)] = 2466,
+  [SMALL_STATE(91)] = 2480,
+  [SMALL_STATE(92)] = 2496,
+  [SMALL_STATE(93)] = 2512,
+  [SMALL_STATE(94)] = 2528,
+  [SMALL_STATE(95)] = 2542,
+  [SMALL_STATE(96)] = 2558,
+  [SMALL_STATE(97)] = 2574,
+  [SMALL_STATE(98)] = 2592,
+  [SMALL_STATE(99)] = 2608,
+  [SMALL_STATE(100)] = 2624,
+  [SMALL_STATE(101)] = 2643,
+  [SMALL_STATE(102)] = 2654,
+  [SMALL_STATE(103)] = 2673,
+  [SMALL_STATE(104)] = 2682,
+  [SMALL_STATE(105)] = 2691,
+  [SMALL_STATE(106)] = 2700,
+  [SMALL_STATE(107)] = 2709,
+  [SMALL_STATE(108)] = 2718,
+  [SMALL_STATE(109)] = 2726,
+  [SMALL_STATE(110)] = 2742,
+  [SMALL_STATE(111)] = 2756,
+  [SMALL_STATE(112)] = 2764,
+  [SMALL_STATE(113)] = 2780,
+  [SMALL_STATE(114)] = 2796,
+  [SMALL_STATE(115)] = 2810,
+  [SMALL_STATE(116)] = 2824,
+  [SMALL_STATE(117)] = 2840,
+  [SMALL_STATE(118)] = 2853,
+  [SMALL_STATE(119)] = 2866,
+  [SMALL_STATE(120)] = 2879,
+  [SMALL_STATE(121)] = 2892,
+  [SMALL_STATE(122)] = 2905,
+  [SMALL_STATE(123)] = 2918,
+  [SMALL_STATE(124)] = 2931,
+  [SMALL_STATE(125)] = 2944,
+  [SMALL_STATE(126)] = 2957,
+  [SMALL_STATE(127)] = 2970,
+  [SMALL_STATE(128)] = 2983,
+  [SMALL_STATE(129)] = 2996,
+  [SMALL_STATE(130)] = 3009,
+  [SMALL_STATE(131)] = 3022,
+  [SMALL_STATE(132)] = 3035,
+  [SMALL_STATE(133)] = 3048,
+  [SMALL_STATE(134)] = 3061,
+  [SMALL_STATE(135)] = 3074,
+  [SMALL_STATE(136)] = 3083,
+  [SMALL_STATE(137)] = 3096,
+  [SMALL_STATE(138)] = 3109,
+  [SMALL_STATE(139)] = 3122,
+  [SMALL_STATE(140)] = 3135,
+  [SMALL_STATE(141)] = 3148,
+  [SMALL_STATE(142)] = 3161,
+  [SMALL_STATE(143)] = 3174,
+  [SMALL_STATE(144)] = 3187,
+  [SMALL_STATE(145)] = 3200,
+  [SMALL_STATE(146)] = 3213,
+  [SMALL_STATE(147)] = 3226,
+  [SMALL_STATE(148)] = 3239,
+  [SMALL_STATE(149)] = 3252,
+  [SMALL_STATE(150)] = 3262,
+  [SMALL_STATE(151)] = 3272,
+  [SMALL_STATE(152)] = 3282,
+  [SMALL_STATE(153)] = 3292,
+  [SMALL_STATE(154)] = 3302,
+  [SMALL_STATE(155)] = 3312,
+  [SMALL_STATE(156)] = 3322,
+  [SMALL_STATE(157)] = 3332,
+  [SMALL_STATE(158)] = 3342,
+  [SMALL_STATE(159)] = 3352,
+  [SMALL_STATE(160)] = 3360,
+  [SMALL_STATE(161)] = 3370,
+  [SMALL_STATE(162)] = 3378,
+  [SMALL_STATE(163)] = 3388,
+  [SMALL_STATE(164)] = 3398,
+  [SMALL_STATE(165)] = 3408,
+  [SMALL_STATE(166)] = 3418,
+  [SMALL_STATE(167)] = 3428,
+  [SMALL_STATE(168)] = 3438,
+  [SMALL_STATE(169)] = 3448,
+  [SMALL_STATE(170)] = 3458,
+  [SMALL_STATE(171)] = 3468,
+  [SMALL_STATE(172)] = 3478,
+  [SMALL_STATE(173)] = 3488,
+  [SMALL_STATE(174)] = 3498,
+  [SMALL_STATE(175)] = 3508,
+  [SMALL_STATE(176)] = 3518,
+  [SMALL_STATE(177)] = 3528,
+  [SMALL_STATE(178)] = 3535,
+  [SMALL_STATE(179)] = 3542,
+  [SMALL_STATE(180)] = 3549,
+  [SMALL_STATE(181)] = 3554,
+  [SMALL_STATE(182)] = 3561,
+  [SMALL_STATE(183)] = 3568,
+  [SMALL_STATE(184)] = 3573,
+  [SMALL_STATE(185)] = 3578,
+  [SMALL_STATE(186)] = 3585,
+  [SMALL_STATE(187)] = 3592,
+  [SMALL_STATE(188)] = 3599,
+  [SMALL_STATE(189)] = 3606,
+  [SMALL_STATE(190)] = 3613,
+  [SMALL_STATE(191)] = 3620,
+  [SMALL_STATE(192)] = 3627,
+  [SMALL_STATE(193)] = 3634,
+  [SMALL_STATE(194)] = 3641,
+  [SMALL_STATE(195)] = 3646,
+  [SMALL_STATE(196)] = 3653,
+  [SMALL_STATE(197)] = 3660,
+  [SMALL_STATE(198)] = 3665,
+  [SMALL_STATE(199)] = 3670,
+  [SMALL_STATE(200)] = 3675,
+  [SMALL_STATE(201)] = 3682,
+  [SMALL_STATE(202)] = 3689,
+  [SMALL_STATE(203)] = 3696,
+  [SMALL_STATE(204)] = 3703,
+  [SMALL_STATE(205)] = 3710,
+  [SMALL_STATE(206)] = 3717,
+  [SMALL_STATE(207)] = 3724,
+  [SMALL_STATE(208)] = 3728,
+  [SMALL_STATE(209)] = 3732,
+  [SMALL_STATE(210)] = 3736,
+  [SMALL_STATE(211)] = 3740,
+  [SMALL_STATE(212)] = 3744,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
   [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT_EXTRA(),
-  [5] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 0, 0, 0),
+  [5] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 0),
   [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
-  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(190),
-  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(224),
-  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(150),
-  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(195),
-  [17] = {.entry = {.count = 1, .reusable = false}}, SHIFT(85),
-  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(62),
-  [21] = {.entry = {.count = 1, .reusable = false}}, SHIFT(209),
-  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(209),
-  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(207),
-  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(138),
+  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(171),
+  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(203),
+  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(129),
+  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(172),
+  [17] = {.entry = {.count = 1, .reusable = false}}, SHIFT(79),
+  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(67),
+  [21] = {.entry = {.count = 1, .reusable = false}}, SHIFT(204),
+  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(204),
+  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(206),
+  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(122),
   [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
-  [31] = {.entry = {.count = 1, .reusable = false}}, SHIFT(29),
+  [31] = {.entry = {.count = 1, .reusable = false}}, SHIFT(30),
   [33] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
-  [35] = {.entry = {.count = 1, .reusable = false}}, SHIFT(49),
-  [37] = {.entry = {.count = 1, .reusable = false}}, SHIFT(182),
+  [35] = {.entry = {.count = 1, .reusable = false}}, SHIFT(39),
+  [37] = {.entry = {.count = 1, .reusable = false}}, SHIFT(167),
   [39] = {.entry = {.count = 1, .reusable = false}}, SHIFT(8),
-  [41] = {.entry = {.count = 1, .reusable = false}}, SHIFT(40),
-  [43] = {.entry = {.count = 1, .reusable = false}}, SHIFT(193),
-  [45] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym__whitespace, 2, 0, 0),
-  [47] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__whitespace, 2, 0, 0),
-  [49] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__whitespace, 2, 0, 0), SHIFT_REPEAT(7),
-  [52] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__whitespace, 2, 0, 0), SHIFT_REPEAT(8),
-  [55] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym__whitespace, 1, 0, 0),
-  [57] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__whitespace, 1, 0, 0),
-  [59] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 4, 0, 0),
-  [61] = {.entry = {.count = 1, .reusable = false}}, SHIFT(189),
-  [63] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 4, 0, 0),
-  [65] = {.entry = {.count = 1, .reusable = true}}, SHIFT(229),
-  [67] = {.entry = {.count = 1, .reusable = true}}, SHIFT(234),
-  [69] = {.entry = {.count = 1, .reusable = true}}, SHIFT(179),
-  [71] = {.entry = {.count = 1, .reusable = false}}, SHIFT(178),
-  [73] = {.entry = {.count = 1, .reusable = false}}, SHIFT(172),
-  [75] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 6, 0, 0),
-  [77] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 6, 0, 0),
-  [79] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 5, 0, 0),
-  [81] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 5, 0, 0),
-  [83] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 8, 0, 0),
-  [85] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 8, 0, 0),
-  [87] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 9, 0, 0),
-  [89] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 9, 0, 0),
-  [91] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 7, 0, 0),
-  [93] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 7, 0, 0),
-  [95] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_request_repeat2, 2, 0, 0),
-  [97] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_request_repeat2, 2, 0, 0), SHIFT_REPEAT(222),
-  [100] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_request_repeat2, 2, 0, 0),
-  [102] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_request_repeat2, 2, 0, 0), SHIFT_REPEAT(234),
-  [105] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_request_repeat2, 2, 0, 0), SHIFT_REPEAT(179),
-  [108] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_request_repeat2, 2, 0, 0), SHIFT_REPEAT(178),
-  [111] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_request_repeat2, 2, 0, 0), SHIFT_REPEAT(172),
-  [114] = {.entry = {.count = 1, .reusable = false}}, SHIFT(222),
-  [116] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 10, 0, 0),
-  [118] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 10, 0, 0),
-  [120] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_form_data, 3, 0, 16),
-  [122] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_form_data, 3, 0, 16),
-  [124] = {.entry = {.count = 1, .reusable = true}}, SHIFT(215),
-  [126] = {.entry = {.count = 1, .reusable = false}}, SHIFT(157),
-  [128] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_form_data_repeat2, 2, 0, 22),
-  [130] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_form_data_repeat2, 2, 0, 22),
-  [132] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_form_data_repeat2, 2, 0, 22), SHIFT_REPEAT(215),
-  [135] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_form_data_repeat2, 2, 0, 22), SHIFT_REPEAT(157),
-  [138] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_form_data, 4, 0, 19),
-  [140] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_form_data, 4, 0, 19),
-  [142] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_boolean, 1, 0, 0),
-  [144] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_boolean, 1, 0, 0),
-  [146] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_form_data_repeat2, 4, 0, 24),
-  [148] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_form_data_repeat2, 4, 0, 24),
-  [150] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_host, 1, 0, 0),
-  [152] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_host, 1, 0, 0),
-  [154] = {.entry = {.count = 1, .reusable = true}}, SHIFT(223),
-  [156] = {.entry = {.count = 1, .reusable = true}}, SHIFT(183),
-  [158] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_request_repeat1, 2, 0, 0),
-  [160] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_request_repeat1, 2, 0, 0), SHIFT_REPEAT(210),
-  [163] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_request_repeat1, 2, 0, 0),
-  [165] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_graphql_body, 6, 0, 0),
-  [167] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_graphql_body, 6, 0, 0),
-  [169] = {.entry = {.count = 1, .reusable = false}}, SHIFT(48),
-  [171] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_external_body, 5, 0, 20),
-  [173] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_external_body, 5, 0, 20),
-  [175] = {.entry = {.count = 1, .reusable = false}}, SHIFT(44),
-  [177] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_external_body, 3, 0, 14),
-  [179] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_external_body, 3, 0, 14),
-  [181] = {.entry = {.count = 1, .reusable = false}}, SHIFT(38),
-  [183] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_json_body, 3, 0, 0),
-  [185] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_json_body, 3, 0, 0),
-  [187] = {.entry = {.count = 1, .reusable = false}}, SHIFT(41),
-  [189] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_graphql_body, 5, 0, 0),
-  [191] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_graphql_body, 5, 0, 0),
-  [193] = {.entry = {.count = 1, .reusable = false}}, SHIFT(55),
-  [195] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_xml_body, 4, 0, 0),
-  [197] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_xml_body, 4, 0, 0),
-  [199] = {.entry = {.count = 1, .reusable = false}}, SHIFT(45),
-  [201] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_port, 2, 0, 0),
-  [203] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_port, 2, 0, 0),
-  [205] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_external_body, 4, 0, 14),
-  [207] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_external_body, 4, 0, 14),
-  [209] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_host_url, 2, 0, 0),
-  [211] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_host_url, 2, 0, 0),
-  [213] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_header, 4, 0, 17),
-  [215] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_header, 4, 0, 17),
-  [217] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_json_body, 4, 0, 0),
-  [219] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_json_body, 4, 0, 0),
-  [221] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_host, 2, 0, 0),
-  [223] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_host, 2, 0, 0),
-  [225] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable, 5, 0, 4),
-  [227] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_variable, 5, 0, 4),
-  [229] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_external_body, 6, 0, 20),
-  [231] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_external_body, 6, 0, 20),
-  [233] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_xml_body, 5, 0, 0),
-  [235] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_xml_body, 5, 0, 0),
-  [237] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable, 3, 0, 1),
-  [239] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_variable, 3, 0, 1),
-  [241] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_host_url, 4, 0, 0),
-  [243] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_host_url, 4, 0, 0),
-  [245] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_graphql_body, 7, 0, 0),
-  [247] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_graphql_body, 7, 0, 0),
-  [249] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_header, 3, 0, 15),
-  [251] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_header, 3, 0, 15),
-  [253] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_header, 6, 0, 23),
-  [255] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_header, 6, 0, 23),
-  [257] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_host_url, 1, 0, 0),
-  [259] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_host_url, 1, 0, 0),
-  [261] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_header, 5, 0, 21),
-  [263] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_header, 5, 0, 21),
-  [265] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_header, 4, 0, 18),
-  [267] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_header, 4, 0, 18),
-  [269] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable, 4, 0, 1),
-  [271] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_variable, 4, 0, 1),
-  [273] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable, 4, 0, 4),
-  [275] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_variable, 4, 0, 4),
-  [277] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_host_url, 3, 0, 0),
-  [279] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_host_url, 3, 0, 0),
-  [281] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0),
-  [283] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(59),
-  [286] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(190),
-  [289] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(224),
-  [292] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(150),
-  [295] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(195),
-  [298] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 1, 0, 0),
-  [300] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
-  [302] = {.entry = {.count = 1, .reusable = true}}, SHIFT(220),
-  [304] = {.entry = {.count = 1, .reusable = true}}, SHIFT(68),
-  [306] = {.entry = {.count = 1, .reusable = true}}, SHIFT(127),
-  [308] = {.entry = {.count = 1, .reusable = true}}, SHIFT(197),
-  [310] = {.entry = {.count = 1, .reusable = true}}, SHIFT(120),
-  [312] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_target_url, 1, 0, 0),
-  [314] = {.entry = {.count = 1, .reusable = false}}, SHIFT(106),
-  [316] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_path_repeat1, 1, 0, 0),
-  [318] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_path_repeat1, 1, 0, 0),
-  [320] = {.entry = {.count = 1, .reusable = false}}, SHIFT(135),
-  [322] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__whitespace, 2, 0, 0), SHIFT_REPEAT(65),
-  [325] = {.entry = {.count = 1, .reusable = true}}, SHIFT(87),
-  [327] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
-  [329] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
-  [331] = {.entry = {.count = 1, .reusable = true}}, SHIFT(72),
-  [333] = {.entry = {.count = 1, .reusable = true}}, SHIFT(112),
-  [335] = {.entry = {.count = 1, .reusable = true}}, SHIFT(82),
-  [337] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_query_param, 2, 0, 7),
-  [339] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_query_param, 2, 0, 7),
-  [341] = {.entry = {.count = 1, .reusable = false}}, SHIFT(99),
-  [343] = {.entry = {.count = 1, .reusable = false}}, SHIFT(124),
-  [345] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_path_repeat1, 2, 0, 0), SHIFT_REPEAT(62),
-  [348] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_path_repeat1, 2, 0, 0),
-  [350] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_path_repeat1, 2, 0, 0),
-  [352] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable_declaration, 6, 0, 12),
-  [354] = {.entry = {.count = 1, .reusable = false}}, SHIFT(62),
-  [356] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_path, 1, 0, 0),
-  [358] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_path, 1, 0, 0),
-  [360] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_target_url_repeat1, 2, 0, 0),
-  [362] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_target_url_repeat1, 2, 0, 0),
-  [364] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_target_url_repeat1, 2, 0, 0), SHIFT_REPEAT(217),
-  [367] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_target_url_repeat1, 2, 0, 0), SHIFT_REPEAT(96),
-  [370] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_script_variable, 3, 0, 0),
-  [372] = {.entry = {.count = 1, .reusable = false}}, SHIFT(23),
-  [374] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
-  [376] = {.entry = {.count = 1, .reusable = false}}, SHIFT(26),
-  [378] = {.entry = {.count = 1, .reusable = true}}, SHIFT(202),
-  [380] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_target_url, 3, 0, 0),
-  [382] = {.entry = {.count = 1, .reusable = true}}, SHIFT(217),
-  [384] = {.entry = {.count = 1, .reusable = false}}, SHIFT(96),
-  [386] = {.entry = {.count = 1, .reusable = false}}, SHIFT(27),
-  [388] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
-  [390] = {.entry = {.count = 1, .reusable = true}}, SHIFT(199),
-  [392] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_target_url, 6, 0, 0),
-  [394] = {.entry = {.count = 1, .reusable = true}}, SHIFT(180),
-  [396] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_target_url, 5, 0, 0),
-  [398] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable_declaration, 4, 0, 3),
-  [400] = {.entry = {.count = 1, .reusable = true}}, SHIFT(198),
-  [402] = {.entry = {.count = 1, .reusable = true}}, SHIFT(186),
-  [404] = {.entry = {.count = 1, .reusable = true}}, SHIFT(131),
-  [406] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_target_url, 2, 0, 0),
-  [408] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable_declaration, 5, 0, 9),
-  [410] = {.entry = {.count = 1, .reusable = true}}, SHIFT(228),
-  [412] = {.entry = {.count = 1, .reusable = true}}, SHIFT(122),
-  [414] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_target_url, 3, 0, 0),
-  [416] = {.entry = {.count = 1, .reusable = true}}, SHIFT(181),
-  [418] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_target_url, 7, 0, 0),
-  [420] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_target_url, 2, 0, 0),
-  [422] = {.entry = {.count = 1, .reusable = true}}, SHIFT(177),
-  [424] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_target_url, 4, 0, 0),
-  [426] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_target_url, 1, 0, 0),
-  [428] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_query_param, 1, 0, 2),
-  [430] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_query_param, 1, 0, 2),
-  [432] = {.entry = {.count = 1, .reusable = false}}, SHIFT(101),
-  [434] = {.entry = {.count = 1, .reusable = false}}, SHIFT(119),
-  [436] = {.entry = {.count = 1, .reusable = true}}, SHIFT(117),
-  [438] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_target_url, 4, 0, 0),
-  [440] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_query_param, 3, 0, 7),
-  [442] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_query_param, 3, 0, 7),
-  [444] = {.entry = {.count = 1, .reusable = false}}, SHIFT(115),
-  [446] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_path_repeat1, 2, 0, 0), SHIFT_REPEAT(68),
-  [449] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_query_param, 2, 0, 2),
-  [451] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_query_param, 2, 0, 2),
-  [453] = {.entry = {.count = 1, .reusable = false}}, SHIFT(123),
-  [455] = {.entry = {.count = 1, .reusable = true}}, SHIFT(85),
-  [457] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_path_repeat1, 3, 0, 0),
-  [459] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_path_repeat1, 3, 0, 0),
-  [461] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
-  [463] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_path_repeat1, 2, 0, 0), SHIFT_REPEAT(104),
-  [466] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
-  [468] = {.entry = {.count = 1, .reusable = false}}, SHIFT(114),
-  [470] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_path_repeat1, 2, 0, 0), SHIFT_REPEAT(125),
-  [473] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_script_variable_repeat1, 2, 0, 0),
-  [475] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_script_variable_repeat1, 2, 0, 0), SHIFT_REPEAT(114),
-  [478] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_query_param, 4, 0, 13),
-  [480] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_query_param, 4, 0, 13),
-  [482] = {.entry = {.count = 1, .reusable = true}}, SHIFT(158),
-  [484] = {.entry = {.count = 1, .reusable = true}}, SHIFT(188),
-  [486] = {.entry = {.count = 1, .reusable = true}}, SHIFT(171),
-  [488] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_authority, 2, 0, 0),
-  [490] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_query_param, 2, 0, 8),
-  [492] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_query_param, 2, 0, 8),
-  [494] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__whitespace, 2, 0, 0), SHIFT_REPEAT(171),
-  [497] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_query_param, 3, 0, 11),
-  [499] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_query_param, 3, 0, 11),
-  [501] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_query_param, 3, 0, 10),
-  [503] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_query_param, 3, 0, 10),
-  [505] = {.entry = {.count = 1, .reusable = true}}, SHIFT(231),
-  [507] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_authority, 1, 0, 0),
-  [509] = {.entry = {.count = 1, .reusable = true}}, SHIFT(129),
-  [511] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_target_url, 5, 0, 0),
-  [513] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_form_data_repeat1, 2, 0, 0),
-  [515] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_form_data_repeat1, 2, 0, 0), SHIFT_REPEAT(133),
-  [518] = {.entry = {.count = 1, .reusable = true}}, SHIFT(140),
-  [520] = {.entry = {.count = 1, .reusable = true}}, SHIFT(142),
-  [522] = {.entry = {.count = 1, .reusable = true}}, SHIFT(144),
-  [524] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
-  [526] = {.entry = {.count = 1, .reusable = false}}, SHIFT(156),
-  [528] = {.entry = {.count = 1, .reusable = true}}, SHIFT(147),
-  [530] = {.entry = {.count = 1, .reusable = true}}, SHIFT(108),
-  [532] = {.entry = {.count = 1, .reusable = true}}, SHIFT(109),
-  [534] = {.entry = {.count = 1, .reusable = true}}, SHIFT(107),
-  [536] = {.entry = {.count = 1, .reusable = true}}, SHIFT(98),
-  [538] = {.entry = {.count = 1, .reusable = true}}, SHIFT(84),
-  [540] = {.entry = {.count = 1, .reusable = true}}, SHIFT(95),
-  [542] = {.entry = {.count = 1, .reusable = true}}, SHIFT(83),
-  [544] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
-  [546] = {.entry = {.count = 1, .reusable = false}}, SHIFT(151),
-  [548] = {.entry = {.count = 1, .reusable = true}}, SHIFT(81),
-  [550] = {.entry = {.count = 1, .reusable = false}}, SHIFT(194),
-  [552] = {.entry = {.count = 1, .reusable = false}}, SHIFT(32),
-  [554] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__whitespace, 2, 0, 0), SHIFT_REPEAT(175),
-  [557] = {.entry = {.count = 1, .reusable = true}}, SHIFT(160),
-  [559] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_script_variable_repeat1, 2, 0, 0), SHIFT_REPEAT(151),
-  [562] = {.entry = {.count = 1, .reusable = true}}, SHIFT(176),
-  [564] = {.entry = {.count = 1, .reusable = true}}, SHIFT(175),
-  [566] = {.entry = {.count = 1, .reusable = false}}, SHIFT(33),
-  [568] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__whitespace, 2, 0, 0), SHIFT_REPEAT(194),
-  [571] = {.entry = {.count = 1, .reusable = true}}, SHIFT(69),
-  [573] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_script_variable_repeat1, 2, 0, 0), SHIFT_REPEAT(156),
-  [576] = {.entry = {.count = 1, .reusable = true}}, SHIFT(205),
-  [578] = {.entry = {.count = 1, .reusable = false}}, SHIFT(133),
-  [580] = {.entry = {.count = 1, .reusable = false}}, SHIFT(187),
-  [582] = {.entry = {.count = 1, .reusable = false}}, SHIFT(146),
-  [584] = {.entry = {.count = 1, .reusable = true}}, SHIFT(238),
-  [586] = {.entry = {.count = 1, .reusable = true}}, SHIFT(46),
-  [588] = {.entry = {.count = 1, .reusable = true}}, SHIFT(166),
-  [590] = {.entry = {.count = 1, .reusable = true}}, SHIFT(75),
-  [592] = {.entry = {.count = 1, .reusable = false}}, SHIFT(168),
-  [594] = {.entry = {.count = 1, .reusable = true}}, SHIFT(67),
-  [596] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
-  [598] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
-  [600] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
-  [602] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_script_variable_repeat1, 2, 0, 0), SHIFT_REPEAT(168),
-  [605] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
-  [607] = {.entry = {.count = 1, .reusable = true}}, SHIFT(219),
-  [609] = {.entry = {.count = 1, .reusable = true}}, SHIFT(194),
-  [611] = {.entry = {.count = 1, .reusable = false}}, SHIFT(137),
-  [613] = {.entry = {.count = 1, .reusable = false}}, SHIFT(208),
-  [615] = {.entry = {.count = 1, .reusable = false}}, SHIFT(110),
-  [617] = {.entry = {.count = 1, .reusable = false}}, SHIFT(204),
-  [619] = {.entry = {.count = 1, .reusable = false}}, SHIFT(37),
-  [621] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
-  [623] = {.entry = {.count = 1, .reusable = true}}, SHIFT(88),
-  [625] = {.entry = {.count = 1, .reusable = false}}, SHIFT(167),
-  [627] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
-  [629] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
-  [631] = {.entry = {.count = 1, .reusable = false}}, SHIFT(163),
-  [633] = {.entry = {.count = 1, .reusable = false}}, SHIFT(128),
-  [635] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
-  [637] = {.entry = {.count = 1, .reusable = true}}, SHIFT(105),
-  [639] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pair, 3, 0, 5),
-  [641] = {.entry = {.count = 1, .reusable = true}}, SHIFT(78),
-  [643] = {.entry = {.count = 1, .reusable = true}}, SHIFT(103),
-  [645] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_fragment, 1, 0, 6),
-  [647] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scheme, 1, 0, 0),
-  [649] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_target_url, 6, 0, 0),
-  [651] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_target_url, 7, 0, 0),
-  [653] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_http_version, 2, 0, 0),
-  [655] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [657] = {.entry = {.count = 1, .reusable = false}}, SHIFT(70),
-  [659] = {.entry = {.count = 1, .reusable = true}}, SHIFT(191),
-  [661] = {.entry = {.count = 1, .reusable = true}}, SHIFT(221),
-  [663] = {.entry = {.count = 1, .reusable = true}}, SHIFT(204),
-  [665] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
-  [667] = {.entry = {.count = 1, .reusable = true}}, SHIFT(155),
-  [669] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_target_url, 9, 0, 0),
-  [671] = {.entry = {.count = 1, .reusable = true}}, SHIFT(118),
-  [673] = {.entry = {.count = 1, .reusable = true}}, SHIFT(128),
-  [675] = {.entry = {.count = 1, .reusable = true}}, SHIFT(214),
-  [677] = {.entry = {.count = 1, .reusable = true}}, SHIFT(218),
-  [679] = {.entry = {.count = 1, .reusable = true}}, SHIFT(237),
-  [681] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_target_url, 8, 0, 0),
-  [683] = {.entry = {.count = 1, .reusable = true}}, SHIFT(174),
-  [685] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
-  [687] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
-  [689] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_response, 5, 0, 0),
-  [691] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
+  [41] = {.entry = {.count = 1, .reusable = false}}, SHIFT(48),
+  [43] = {.entry = {.count = 1, .reusable = false}}, SHIFT(168),
+  [45] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym__whitespace, 2),
+  [47] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__whitespace, 2),
+  [49] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__whitespace, 2), SHIFT_REPEAT(7),
+  [52] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__whitespace, 2), SHIFT_REPEAT(8),
+  [55] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym__whitespace, 1),
+  [57] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__whitespace, 1),
+  [59] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 4),
+  [61] = {.entry = {.count = 1, .reusable = false}}, SHIFT(170),
+  [63] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 4),
+  [65] = {.entry = {.count = 1, .reusable = true}}, SHIFT(202),
+  [67] = {.entry = {.count = 1, .reusable = true}}, SHIFT(212),
+  [69] = {.entry = {.count = 1, .reusable = true}}, SHIFT(174),
+  [71] = {.entry = {.count = 1, .reusable = false}}, SHIFT(173),
+  [73] = {.entry = {.count = 1, .reusable = false}}, SHIFT(138),
+  [75] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 6),
+  [77] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 6),
+  [79] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 8),
+  [81] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 8),
+  [83] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 5),
+  [85] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 5),
+  [87] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 9),
+  [89] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 9),
+  [91] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 7),
+  [93] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 7),
+  [95] = {.entry = {.count = 1, .reusable = false}}, SHIFT(192),
+  [97] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_request_repeat2, 2),
+  [99] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_request_repeat2, 2), SHIFT_REPEAT(192),
+  [102] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_request_repeat2, 2),
+  [104] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_request_repeat2, 2), SHIFT_REPEAT(212),
+  [107] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_request_repeat2, 2), SHIFT_REPEAT(174),
+  [110] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_request_repeat2, 2), SHIFT_REPEAT(173),
+  [113] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_request_repeat2, 2), SHIFT_REPEAT(138),
+  [116] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 10),
+  [118] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 10),
+  [120] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_form_data, 4, .production_id = 16),
+  [122] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_form_data, 4, .production_id = 16),
+  [124] = {.entry = {.count = 1, .reusable = true}}, SHIFT(182),
+  [126] = {.entry = {.count = 1, .reusable = false}}, SHIFT(148),
+  [128] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_form_data, 3, .production_id = 13),
+  [130] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_form_data, 3, .production_id = 13),
+  [132] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_form_data_repeat2, 2, .production_id = 19),
+  [134] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_form_data_repeat2, 2, .production_id = 19),
+  [136] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_form_data_repeat2, 2, .production_id = 19), SHIFT_REPEAT(182),
+  [139] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_form_data_repeat2, 2, .production_id = 19), SHIFT_REPEAT(148),
+  [142] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_boolean, 1),
+  [144] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_boolean, 1),
+  [146] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_host, 1),
+  [148] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_host, 1),
+  [150] = {.entry = {.count = 1, .reusable = true}}, SHIFT(191),
+  [152] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_request_repeat1, 2),
+  [154] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_request_repeat1, 2), SHIFT_REPEAT(200),
+  [157] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_request_repeat1, 2),
+  [159] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_form_data_repeat2, 4, .production_id = 21),
+  [161] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_form_data_repeat2, 4, .production_id = 21),
+  [163] = {.entry = {.count = 1, .reusable = true}}, SHIFT(155),
+  [165] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_graphql_body, 5),
+  [167] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_graphql_body, 5),
+  [169] = {.entry = {.count = 1, .reusable = false}}, SHIFT(54),
+  [171] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_xml_body, 4),
+  [173] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_xml_body, 4),
+  [175] = {.entry = {.count = 1, .reusable = false}}, SHIFT(51),
+  [177] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_external_body, 5, .production_id = 17),
+  [179] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_external_body, 5, .production_id = 17),
+  [181] = {.entry = {.count = 1, .reusable = false}}, SHIFT(55),
+  [183] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_external_body, 3, .production_id = 11),
+  [185] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_external_body, 3, .production_id = 11),
+  [187] = {.entry = {.count = 1, .reusable = false}}, SHIFT(46),
+  [189] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_json_body, 3),
+  [191] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_json_body, 3),
+  [193] = {.entry = {.count = 1, .reusable = false}}, SHIFT(43),
+  [195] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_graphql_body, 6),
+  [197] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_graphql_body, 6),
+  [199] = {.entry = {.count = 1, .reusable = false}}, SHIFT(58),
+  [201] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_header, 5, .production_id = 18),
+  [203] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_header, 5, .production_id = 18),
+  [205] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable, 5, .production_id = 3),
+  [207] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_variable, 5, .production_id = 3),
+  [209] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_header, 3, .production_id = 12),
+  [211] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_header, 3, .production_id = 12),
+  [213] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_host_url, 1),
+  [215] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_host_url, 1),
+  [217] = {.entry = {.count = 1, .reusable = true}}, SHIFT(188),
+  [219] = {.entry = {.count = 1, .reusable = true}}, SHIFT(104),
+  [221] = {.entry = {.count = 1, .reusable = true}}, SHIFT(169),
+  [223] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_target_url, 1),
+  [225] = {.entry = {.count = 1, .reusable = true}}, SHIFT(190),
+  [227] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_json_body, 4),
+  [229] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_json_body, 4),
+  [231] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable, 3, .production_id = 1),
+  [233] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_variable, 3, .production_id = 1),
+  [235] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_port, 2),
+  [237] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_port, 2),
+  [239] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_external_body, 4, .production_id = 11),
+  [241] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_external_body, 4, .production_id = 11),
+  [243] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_host_url, 2),
+  [245] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_host_url, 2),
+  [247] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_header, 4, .production_id = 14),
+  [249] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_header, 4, .production_id = 14),
+  [251] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_header, 4, .production_id = 15),
+  [253] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_header, 4, .production_id = 15),
+  [255] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_header, 6, .production_id = 20),
+  [257] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_header, 6, .production_id = 20),
+  [259] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_xml_body, 5),
+  [261] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_xml_body, 5),
+  [263] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_host_url, 3),
+  [265] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_host_url, 3),
+  [267] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_host, 2),
+  [269] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_host, 2),
+  [271] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_external_body, 6, .production_id = 17),
+  [273] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_external_body, 6, .production_id = 17),
+  [275] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_host_url, 4),
+  [277] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_host_url, 4),
+  [279] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable, 4, .production_id = 3),
+  [281] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_variable, 4, .production_id = 3),
+  [283] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_graphql_body, 7),
+  [285] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_graphql_body, 7),
+  [287] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable, 4, .production_id = 1),
+  [289] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_variable, 4, .production_id = 1),
+  [291] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 1),
+  [293] = {.entry = {.count = 1, .reusable = true}}, SHIFT(61),
+  [295] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2),
+  [297] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(61),
+  [300] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(171),
+  [303] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(203),
+  [306] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(129),
+  [309] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(172),
+  [312] = {.entry = {.count = 1, .reusable = true}}, SHIFT(164),
+  [314] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_target_url, 4),
+  [316] = {.entry = {.count = 1, .reusable = true}}, SHIFT(175),
+  [318] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_target_url, 2),
+  [320] = {.entry = {.count = 1, .reusable = true}}, SHIFT(154),
+  [322] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_target_url, 3),
+  [324] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_query_param, 2, .production_id = 6),
+  [326] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_query_param, 2, .production_id = 6),
+  [328] = {.entry = {.count = 1, .reusable = false}}, SHIFT(78),
+  [330] = {.entry = {.count = 1, .reusable = false}}, SHIFT(108),
+  [332] = {.entry = {.count = 1, .reusable = true}}, SHIFT(101),
+  [334] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_path_repeat1, 1),
+  [336] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__whitespace, 2), SHIFT_REPEAT(71),
+  [339] = {.entry = {.count = 1, .reusable = true}}, SHIFT(89),
+  [341] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
+  [343] = {.entry = {.count = 1, .reusable = true}}, SHIFT(71),
+  [345] = {.entry = {.count = 1, .reusable = true}}, SHIFT(83),
+  [347] = {.entry = {.count = 1, .reusable = true}}, SHIFT(179),
+  [349] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_query_param, 3, .production_id = 6),
+  [351] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_query_param, 3, .production_id = 6),
+  [353] = {.entry = {.count = 1, .reusable = false}}, SHIFT(111),
+  [355] = {.entry = {.count = 1, .reusable = true}}, SHIFT(166),
+  [357] = {.entry = {.count = 1, .reusable = true}}, SHIFT(88),
+  [359] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable_declaration, 4, .production_id = 2),
+  [361] = {.entry = {.count = 1, .reusable = false}}, SHIFT(29),
+  [363] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
+  [365] = {.entry = {.count = 1, .reusable = false}}, SHIFT(26),
+  [367] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_path_repeat1, 2), SHIFT_REPEAT(67),
+  [370] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_path_repeat1, 2),
+  [372] = {.entry = {.count = 1, .reusable = true}}, SHIFT(156),
+  [374] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_target_url, 6),
+  [376] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_script_variable, 3),
+  [378] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable_declaration, 6, .production_id = 9),
+  [380] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable_declaration, 5, .production_id = 7),
+  [382] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_target_url_repeat1, 2),
+  [384] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_target_url_repeat1, 2), SHIFT_REPEAT(190),
+  [387] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_path, 1),
+  [389] = {.entry = {.count = 1, .reusable = false}}, SHIFT(24),
+  [391] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
+  [393] = {.entry = {.count = 1, .reusable = true}}, SHIFT(163),
+  [395] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_target_url, 5),
+  [397] = {.entry = {.count = 1, .reusable = true}}, SHIFT(79),
+  [399] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_path_repeat1, 2), SHIFT_REPEAT(103),
+  [402] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
+  [404] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_path_repeat1, 3),
+  [406] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_authority, 1),
+  [408] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_authority, 2),
+  [410] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_query_param, 3, .production_id = 8),
+  [412] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__whitespace, 2), SHIFT_REPEAT(135),
+  [415] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_query_param, 4, .production_id = 10),
+  [417] = {.entry = {.count = 1, .reusable = true}}, SHIFT(121),
+  [419] = {.entry = {.count = 1, .reusable = true}}, SHIFT(153),
+  [421] = {.entry = {.count = 1, .reusable = true}}, SHIFT(135),
+  [423] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_script_variable_repeat1, 2),
+  [425] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_script_variable_repeat1, 2), SHIFT_REPEAT(114),
+  [428] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
+  [430] = {.entry = {.count = 1, .reusable = false}}, SHIFT(114),
+  [432] = {.entry = {.count = 1, .reusable = true}}, SHIFT(195),
+  [434] = {.entry = {.count = 1, .reusable = true}}, SHIFT(119),
+  [436] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_form_data_repeat1, 2),
+  [438] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_form_data_repeat1, 2), SHIFT_REPEAT(118),
+  [441] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
+  [443] = {.entry = {.count = 1, .reusable = true}}, SHIFT(124),
+  [445] = {.entry = {.count = 1, .reusable = false}}, SHIFT(176),
+  [447] = {.entry = {.count = 1, .reusable = false}}, SHIFT(137),
+  [449] = {.entry = {.count = 1, .reusable = true}}, SHIFT(127),
+  [451] = {.entry = {.count = 1, .reusable = true}}, SHIFT(73),
+  [453] = {.entry = {.count = 1, .reusable = true}}, SHIFT(75),
+  [455] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
+  [457] = {.entry = {.count = 1, .reusable = false}}, SHIFT(132),
+  [459] = {.entry = {.count = 1, .reusable = true}}, SHIFT(77),
+  [461] = {.entry = {.count = 1, .reusable = true}}, SHIFT(74),
+  [463] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__whitespace, 2), SHIFT_REPEAT(159),
+  [466] = {.entry = {.count = 1, .reusable = true}}, SHIFT(141),
+  [468] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_script_variable_repeat1, 2), SHIFT_REPEAT(130),
+  [471] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__whitespace, 2), SHIFT_REPEAT(161),
+  [474] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_script_variable_repeat1, 2), SHIFT_REPEAT(132),
+  [477] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_script_variable_repeat1, 2), SHIFT_REPEAT(133),
+  [480] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
+  [482] = {.entry = {.count = 1, .reusable = true}}, SHIFT(72),
+  [484] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
+  [486] = {.entry = {.count = 1, .reusable = false}}, SHIFT(130),
+  [488] = {.entry = {.count = 1, .reusable = true}}, SHIFT(196),
+  [490] = {.entry = {.count = 1, .reusable = true}}, SHIFT(161),
+  [492] = {.entry = {.count = 1, .reusable = false}}, SHIFT(161),
+  [494] = {.entry = {.count = 1, .reusable = false}}, SHIFT(33),
+  [496] = {.entry = {.count = 1, .reusable = true}}, SHIFT(70),
+  [498] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
+  [500] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
+  [502] = {.entry = {.count = 1, .reusable = true}}, SHIFT(157),
+  [504] = {.entry = {.count = 1, .reusable = true}}, SHIFT(159),
+  [506] = {.entry = {.count = 1, .reusable = false}}, SHIFT(34),
+  [508] = {.entry = {.count = 1, .reusable = true}}, SHIFT(87),
+  [510] = {.entry = {.count = 1, .reusable = false}}, SHIFT(133),
+  [512] = {.entry = {.count = 1, .reusable = true}}, SHIFT(210),
+  [514] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
+  [516] = {.entry = {.count = 1, .reusable = true}}, SHIFT(177),
+  [518] = {.entry = {.count = 1, .reusable = false}}, SHIFT(118),
+  [520] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
+  [522] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
+  [524] = {.entry = {.count = 1, .reusable = false}}, SHIFT(125),
+  [526] = {.entry = {.count = 1, .reusable = false}}, SHIFT(184),
+  [528] = {.entry = {.count = 1, .reusable = false}}, SHIFT(185),
+  [530] = {.entry = {.count = 1, .reusable = false}}, SHIFT(45),
+  [532] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
+  [534] = {.entry = {.count = 1, .reusable = false}}, SHIFT(106),
+  [536] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
+  [538] = {.entry = {.count = 1, .reusable = true}}, SHIFT(97),
+  [540] = {.entry = {.count = 1, .reusable = false}}, SHIFT(145),
+  [542] = {.entry = {.count = 1, .reusable = false}}, SHIFT(115),
+  [544] = {.entry = {.count = 1, .reusable = false}}, SHIFT(147),
+  [546] = {.entry = {.count = 1, .reusable = true}}, SHIFT(84),
+  [548] = {.entry = {.count = 1, .reusable = true}}, SHIFT(185),
+  [550] = {.entry = {.count = 1, .reusable = true}}, SHIFT(106),
+  [552] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [554] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_fragment, 1, .production_id = 5),
+  [556] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pair, 3, .production_id = 4),
+  [558] = {.entry = {.count = 1, .reusable = true}}, SHIFT(102),
+  [560] = {.entry = {.count = 1, .reusable = true}}, SHIFT(100),
+  [562] = {.entry = {.count = 1, .reusable = true}}, SHIFT(178),
+  [564] = {.entry = {.count = 1, .reusable = false}}, SHIFT(66),
+  [566] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
+  [568] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_http_version, 2),
+  [570] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_target_url, 8),
+  [572] = {.entry = {.count = 1, .reusable = true}}, SHIFT(211),
+  [574] = {.entry = {.count = 1, .reusable = true}}, SHIFT(165),
+  [576] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_target_url, 7),
+  [578] = {.entry = {.count = 1, .reusable = true}}, SHIFT(189),
+  [580] = {.entry = {.count = 1, .reusable = true}}, SHIFT(193),
+  [582] = {.entry = {.count = 1, .reusable = true}}, SHIFT(136),
+  [584] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scheme, 1),
+  [586] = {.entry = {.count = 1, .reusable = true}}, SHIFT(107),
+  [588] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
+  [590] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
+  [592] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
+  [594] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_response, 5),
+  [596] = {.entry = {.count = 1, .reusable = true}}, SHIFT(152),
 };
 
 #ifdef __cplusplus
@@ -8852,7 +8439,7 @@ extern "C" {
 #define TS_PUBLIC __attribute__((visibility("default")))
 #endif
 
-TS_PUBLIC const TSLanguage *tree_sitter_http(void) {
+TS_PUBLIC const TSLanguage *tree_sitter_http() {
   static const TSLanguage language = {
     .version = LANGUAGE_VERSION,
     .symbol_count = SYMBOL_COUNT,

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -86,11 +86,6 @@ typedef union {
   } entry;
 } TSParseActionEntry;
 
-typedef struct {
-  int32_t start;
-  int32_t end;
-} TSCharacterRange;
-
 struct TSLanguage {
   uint32_t version;
   uint32_t symbol_count;
@@ -130,24 +125,6 @@ struct TSLanguage {
   const TSStateId *primary_state_ids;
 };
 
-static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
-  uint32_t index = 0;
-  uint32_t size = len - index;
-  while (size > 1) {
-    uint32_t half_size = size / 2;
-    uint32_t mid_index = index + half_size;
-    TSCharacterRange *range = &ranges[mid_index];
-    if (lookahead >= range->start && lookahead <= range->end) {
-      return true;
-    } else if (lookahead > range->end) {
-      index = mid_index;
-    }
-    size -= half_size;
-  }
-  TSCharacterRange *range = &ranges[index];
-  return (lookahead >= range->start && lookahead <= range->end);
-}
-
 /*
  *  Lexer Macros
  */
@@ -175,17 +152,6 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
   {                          \
     state = state_value;     \
     goto next_state;         \
-  }
-
-#define ADVANCE_MAP(...)                                              \
-  {                                                                   \
-    static const uint16_t map[] = { __VA_ARGS__ };                    \
-    for (uint32_t i = 0; i < sizeof(map) / sizeof(map[0]); i += 2) {  \
-      if (map[i] == lookahead) {                                      \
-        state = map[i + 1];                                           \
-        goto next_state;                                              \
-      }                                                               \
-    }                                                                 \
   }
 
 #define SKIP(state_value) \
@@ -237,15 +203,14 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
     }                                 \
   }}
 
-#define REDUCE(symbol_name, children, precedence, prod_id) \
-  {{                                                       \
-    .reduce = {                                            \
-      .type = TSParseActionTypeReduce,                     \
-      .symbol = symbol_name,                               \
-      .child_count = children,                             \
-      .dynamic_precedence = precedence,                    \
-      .production_id = prod_id                             \
-    },                                                     \
+#define REDUCE(symbol_val, child_count_val, ...) \
+  {{                                             \
+    .reduce = {                                  \
+      .type = TSParseActionTypeReduce,           \
+      .symbol = symbol_val,                      \
+      .child_count = child_count_val,            \
+      __VA_ARGS__                                \
+    },                                           \
   }}
 
 #define RECOVER()                    \

--- a/test/corpus/variables.txt
+++ b/test/corpus/variables.txt
@@ -108,6 +108,42 @@ Content-Type: application/json
       value: (value))
     (json_body)))
 
+====================================================
+Request with document variable as query param value
+====================================================
+
+@query = "value"
+
+GET https://foo.com/api/users/create?query={{query}}&query2={{ query }}
+Content-Type: application/json
+
+---
+
+(document
+  (variable_declaration
+    name: (identifier)
+    value: (string))
+  (request
+    (method)
+    (target_url
+      (scheme)
+      (host
+        (identifier))
+      (path
+        (identifier)
+        (identifier)
+        (identifier))
+      (query_param
+        key: (key)
+        value: (variable
+          name: (identifier)))
+      (query_param
+        key: (key)
+        value: (variable
+          name: (identifier))))
+    (header
+      name: (name)
+      value: (value))))
 
 ===============================================
 Request with document variable as header value


### PR DESCRIPTION
This PR (related to #33) adds support for variables parsing in query string values. Note that I got to add the characters { and } to the negated set for param, which wouldn't allow something like this: key={"key":"value"}. If you can find a less restrictive solution, let me know!