### PR TITLE
fix singular empty lines captured as raw body

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -11,6 +11,7 @@ module.exports = grammar({
     extras: (_) => [],
     conflicts: ($) => [
         [$.target_url],
+        [$.raw_body],
         [$._raw_body],
         [$._section_content],
     ],
@@ -276,7 +277,14 @@ module.exports = grammar({
                 ),
             )),
 
-        raw_body: ($) => $._raw_body,
+        raw_body: ($) =>
+            seq(
+                choice(
+                    token(prec(1, seq(/.+/, NL))),
+                    seq($._comment_prefix, $._not_comment),
+                ),
+                optional($._raw_body),
+            ),
         _raw_body: ($) =>
             seq(
                 choice(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2035,8 +2035,79 @@
       }
     },
     "raw_body": {
-      "type": "SYMBOL",
-      "name": "_raw_body"
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "TOKEN",
+              "content": {
+                "type": "PREC",
+                "value": 1,
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "PATTERN",
+                      "value": ".+"
+                    },
+                    {
+                      "type": "TOKEN",
+                      "content": {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "\n"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "\r"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "\r\n"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "\u0000"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_comment_prefix"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_not_comment"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_raw_body"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
     },
     "_raw_body": {
       "type": "SEQ",
@@ -2277,6 +2348,9 @@
     ],
     [
       "_raw_body"
+    ],
+    [
+      "raw_body"
     ],
     [
       "_section_content"

--- a/src/parser.c
+++ b/src/parser.c
@@ -13,11 +13,11 @@
 #endif
 
 #define LANGUAGE_VERSION 14
-#define STATE_COUNT 290
+#define STATE_COUNT 293
 #define LARGE_STATE_COUNT 2
-#define SYMBOL_COUNT 78
+#define SYMBOL_COUNT 79
 #define ALIAS_COUNT 0
-#define TOKEN_COUNT 38
+#define TOKEN_COUNT 39
 #define EXTERNAL_TOKEN_COUNT 0
 #define FIELD_COUNT 9
 #define MAX_ALIAS_SEQUENCE_LENGTH 11
@@ -56,51 +56,52 @@ enum ts_symbol_identifiers {
   anon_sym_DASH_DASH = 30,
   aux_sym_multipart_form_data_token1 = 31,
   aux_sym_multipart_form_data_token2 = 32,
-  sym__not_comment = 33,
-  sym_header_entity = 34,
-  sym_identifier = 35,
-  aux_sym_path_token1 = 36,
-  aux_sym__blank_line_token1 = 37,
-  sym_document = 38,
-  sym__comment_prefix = 39,
-  sym_comment = 40,
-  sym_var_comment = 41,
-  sym_request_separator = 42,
-  sym_section = 43,
-  sym__section_content = 44,
-  aux_sym__target_url_line = 45,
-  sym_target_url = 46,
-  sym_response = 47,
-  sym_request = 48,
-  sym_header = 49,
-  sym_variable = 50,
-  sym_pre_request_script = 51,
-  sym_res_handler_script = 52,
-  sym_script = 53,
-  sym_variable_declaration = 54,
-  sym_xml_body = 55,
-  sym_json_body = 56,
-  sym_graphql_body = 57,
-  sym_graphql_data = 58,
-  sym__external_body = 59,
-  sym_external_body = 60,
-  sym_multipart_form_data = 61,
-  sym_raw_body = 62,
-  sym__raw_body = 63,
-  sym_path = 64,
-  sym_value = 65,
-  sym__blank_line = 66,
-  aux_sym_document_repeat1 = 67,
-  aux_sym_target_url_repeat1 = 68,
-  aux_sym_request_repeat1 = 69,
-  aux_sym_request_repeat2 = 70,
-  aux_sym_request_repeat3 = 71,
-  aux_sym_request_repeat4 = 72,
-  aux_sym_script_repeat1 = 73,
-  aux_sym_xml_body_repeat1 = 74,
-  aux_sym_multipart_form_data_repeat1 = 75,
-  aux_sym_path_repeat1 = 76,
-  aux_sym_value_repeat1 = 77,
+  aux_sym_raw_body_token1 = 33,
+  sym__not_comment = 34,
+  sym_header_entity = 35,
+  sym_identifier = 36,
+  aux_sym_path_token1 = 37,
+  aux_sym__blank_line_token1 = 38,
+  sym_document = 39,
+  sym__comment_prefix = 40,
+  sym_comment = 41,
+  sym_var_comment = 42,
+  sym_request_separator = 43,
+  sym_section = 44,
+  sym__section_content = 45,
+  aux_sym__target_url_line = 46,
+  sym_target_url = 47,
+  sym_response = 48,
+  sym_request = 49,
+  sym_header = 50,
+  sym_variable = 51,
+  sym_pre_request_script = 52,
+  sym_res_handler_script = 53,
+  sym_script = 54,
+  sym_variable_declaration = 55,
+  sym_xml_body = 56,
+  sym_json_body = 57,
+  sym_graphql_body = 58,
+  sym_graphql_data = 59,
+  sym__external_body = 60,
+  sym_external_body = 61,
+  sym_multipart_form_data = 62,
+  sym_raw_body = 63,
+  sym__raw_body = 64,
+  sym_path = 65,
+  sym_value = 66,
+  sym__blank_line = 67,
+  aux_sym_document_repeat1 = 68,
+  aux_sym_target_url_repeat1 = 69,
+  aux_sym_request_repeat1 = 70,
+  aux_sym_request_repeat2 = 71,
+  aux_sym_request_repeat3 = 72,
+  aux_sym_request_repeat4 = 73,
+  aux_sym_script_repeat1 = 74,
+  aux_sym_xml_body_repeat1 = 75,
+  aux_sym_multipart_form_data_repeat1 = 76,
+  aux_sym_path_repeat1 = 77,
+  aux_sym_value_repeat1 = 78,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -137,6 +138,7 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_DASH_DASH] = "--",
   [aux_sym_multipart_form_data_token1] = "multipart_form_data_token1",
   [aux_sym_multipart_form_data_token2] = "multipart_form_data_token2",
+  [aux_sym_raw_body_token1] = "raw_body_token1",
   [sym__not_comment] = "_not_comment",
   [sym_header_entity] = "header_entity",
   [sym_identifier] = "identifier",
@@ -218,6 +220,7 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_DASH_DASH] = anon_sym_DASH_DASH,
   [aux_sym_multipart_form_data_token1] = aux_sym_multipart_form_data_token1,
   [aux_sym_multipart_form_data_token2] = aux_sym_multipart_form_data_token2,
+  [aux_sym_raw_body_token1] = aux_sym_raw_body_token1,
   [sym__not_comment] = sym__not_comment,
   [sym_header_entity] = sym_header_entity,
   [sym_identifier] = sym_identifier,
@@ -395,6 +398,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = false,
   },
   [aux_sym_multipart_form_data_token2] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_raw_body_token1] = {
     .visible = false,
     .named = false,
   },
@@ -1029,39 +1036,39 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [121] = 121,
   [122] = 122,
   [123] = 123,
-  [124] = 85,
-  [125] = 84,
-  [126] = 83,
-  [127] = 86,
-  [128] = 128,
-  [129] = 129,
-  [130] = 130,
+  [124] = 124,
+  [125] = 125,
+  [126] = 126,
+  [127] = 68,
+  [128] = 81,
+  [129] = 82,
+  [130] = 86,
   [131] = 131,
   [132] = 132,
   [133] = 133,
   [134] = 134,
   [135] = 135,
   [136] = 136,
-  [137] = 83,
+  [137] = 137,
   [138] = 138,
   [139] = 139,
   [140] = 140,
-  [141] = 141,
-  [142] = 142,
-  [143] = 86,
+  [141] = 68,
+  [142] = 89,
+  [143] = 143,
   [144] = 144,
   [145] = 145,
   [146] = 146,
-  [147] = 147,
-  [148] = 84,
-  [149] = 149,
-  [150] = 88,
+  [147] = 86,
+  [148] = 148,
+  [149] = 82,
+  [150] = 150,
   [151] = 151,
   [152] = 152,
-  [153] = 85,
+  [153] = 153,
   [154] = 154,
   [155] = 155,
-  [156] = 156,
+  [156] = 81,
   [157] = 157,
   [158] = 158,
   [159] = 159,
@@ -1071,75 +1078,75 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [163] = 163,
   [164] = 164,
   [165] = 165,
-  [166] = 163,
-  [167] = 163,
+  [166] = 166,
+  [167] = 167,
   [168] = 168,
   [169] = 169,
   [170] = 170,
-  [171] = 171,
-  [172] = 172,
-  [173] = 170,
+  [171] = 165,
+  [172] = 165,
+  [173] = 173,
   [174] = 174,
-  [175] = 175,
-  [176] = 168,
+  [175] = 170,
+  [176] = 176,
   [177] = 177,
   [178] = 178,
   [179] = 179,
-  [180] = 174,
+  [180] = 180,
   [181] = 181,
   [182] = 174,
   [183] = 183,
-  [184] = 184,
+  [184] = 174,
   [185] = 185,
   [186] = 186,
-  [187] = 187,
+  [187] = 167,
   [188] = 188,
   [189] = 189,
-  [190] = 186,
-  [191] = 185,
-  [192] = 188,
-  [193] = 188,
-  [194] = 186,
-  [195] = 195,
-  [196] = 189,
-  [197] = 185,
-  [198] = 189,
-  [199] = 199,
-  [200] = 200,
+  [190] = 190,
+  [191] = 191,
+  [192] = 192,
+  [193] = 192,
+  [194] = 189,
+  [195] = 190,
+  [196] = 190,
+  [197] = 192,
+  [198] = 191,
+  [199] = 191,
+  [200] = 189,
   [201] = 201,
-  [202] = 200,
+  [202] = 202,
   [203] = 203,
-  [204] = 200,
+  [204] = 203,
   [205] = 205,
-  [206] = 206,
+  [206] = 203,
   [207] = 207,
   [208] = 208,
   [209] = 209,
-  [210] = 209,
+  [210] = 210,
   [211] = 211,
   [212] = 212,
-  [213] = 209,
+  [213] = 211,
   [214] = 214,
   [215] = 215,
   [216] = 216,
-  [217] = 211,
-  [218] = 211,
+  [217] = 217,
+  [218] = 218,
   [219] = 219,
   [220] = 220,
-  [221] = 212,
+  [221] = 221,
   [222] = 222,
-  [223] = 223,
+  [223] = 219,
   [224] = 224,
-  [225] = 225,
-  [226] = 216,
-  [227] = 216,
-  [228] = 228,
-  [229] = 212,
+  [225] = 211,
+  [226] = 226,
+  [227] = 227,
+  [228] = 218,
+  [229] = 219,
   [230] = 230,
   [231] = 231,
-  [232] = 232,
-  [233] = 233,
-  [234] = 234,
+  [232] = 220,
+  [233] = 220,
+  [234] = 218,
   [235] = 235,
   [236] = 236,
   [237] = 237,
@@ -1172,29 +1179,32 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [264] = 264,
   [265] = 265,
   [266] = 266,
-  [267] = 261,
+  [267] = 267,
   [268] = 268,
-  [269] = 234,
-  [270] = 265,
-  [271] = 258,
-  [272] = 272,
+  [269] = 269,
+  [270] = 237,
+  [271] = 266,
+  [272] = 260,
   [273] = 273,
-  [274] = 263,
-  [275] = 261,
+  [274] = 262,
+  [275] = 275,
   [276] = 276,
-  [277] = 234,
-  [278] = 265,
-  [279] = 258,
-  [280] = 280,
-  [281] = 257,
-  [282] = 268,
+  [277] = 277,
+  [278] = 237,
+  [279] = 279,
+  [280] = 260,
+  [281] = 273,
+  [282] = 262,
   [283] = 283,
-  [284] = 284,
-  [285] = 285,
-  [286] = 257,
-  [287] = 268,
+  [284] = 243,
+  [285] = 240,
+  [286] = 273,
+  [287] = 287,
   [288] = 288,
-  [289] = 289,
+  [289] = 243,
+  [290] = 240,
+  [291] = 291,
+  [292] = 292,
 };
 
 static TSCharacterRange aux_sym_WORD_CHAR_token1_character_set_1[] = {
@@ -1257,7 +1267,7 @@ static TSCharacterRange aux_sym_WORD_CHAR_token1_character_set_1[] = {
   {0x10530, 0x10563}, {0x10570, 0x1057a}, {0x1057c, 0x1058a}, {0x1058c, 0x10592}, {0x10594, 0x10595}, {0x10597, 0x105a1}, {0x105a3, 0x105b1}, {0x105b3, 0x105b9},
   {0x105bb, 0x105bc}, {0x10600, 0x10736}, {0x10740, 0x10755}, {0x10760, 0x10767}, {0x10780, 0x10785}, {0x10787, 0x107b0}, {0x107b2, 0x107ba}, {0x10800, 0x10805},
   {0x10808, 0x10808}, {0x1080a, 0x10835}, {0x10837, 0x10838}, {0x1083c, 0x1083c}, {0x1083f, 0x10855}, {0x10858, 0x10876}, {0x10879, 0x1089e}, {0x108a7, 0x108af},
-  {0x108e0, 0x108f2}, {0x108f4, 0x108f5}, {0x108fb, 0x1091b}, {0x10920, 0x1092b},
+  {0x108e0, 0x108f2}, {0x108f4, 0x108f5}, {0x108fb, 0x1091b},
 };
 
 static TSCharacterRange aux_sym_PUNCTUATION_token1_character_set_1[] = {
@@ -1321,7 +1331,7 @@ static TSCharacterRange aux_sym_PUNCTUATION_token1_character_set_1[] = {
   {0x10528, 0x1052f}, {0x10564, 0x1056f}, {0x1057b, 0x1057b}, {0x1058b, 0x1058b}, {0x10593, 0x10593}, {0x10596, 0x10596}, {0x105a2, 0x105a2}, {0x105b2, 0x105b2},
   {0x105ba, 0x105ba}, {0x105bd, 0x105ff}, {0x10737, 0x1073f}, {0x10756, 0x1075f}, {0x10768, 0x1077f}, {0x10786, 0x10786}, {0x107b1, 0x107b1}, {0x107bb, 0x107ff},
   {0x10806, 0x10807}, {0x10809, 0x10809}, {0x10836, 0x10836}, {0x10839, 0x1083b}, {0x1083d, 0x1083e}, {0x10856, 0x10857}, {0x10877, 0x10878}, {0x1089f, 0x108a6},
-  {0x108b0, 0x108df}, {0x108f3, 0x108f3}, {0x108f6, 0x108fa}, {0x1091c, 0x1091f}, {0x1092c, 0x10ffff},
+  {0x108b0, 0x108df}, {0x108f3, 0x108f3}, {0x108f6, 0x108fa}, {0x1091c, 0x10ffff},
 };
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
@@ -1329,32 +1339,32 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(740);
+      if (eof) ADVANCE(789);
       ADVANCE_MAP(
-        0, 869,
-        '\n', 869,
-        '\r', 870,
-        '#', 818,
-        '-', 800,
-        '/', 801,
-        ':', 835,
-        '<', 863,
-        '=', 824,
-        '>', 842,
-        '@', 823,
-        'C', 779,
-        'D', 768,
-        'G', 769,
-        'H', 774,
-        'L', 777,
-        'O', 782,
-        'P', 767,
-        'T', 783,
-        'W', 770,
-        '[', 803,
-        '\\', 805,
-        '_', 804,
-        '{', 799,
+        0, 943,
+        '\n', 943,
+        '\r', 944,
+        '#', 887,
+        '-', 866,
+        '/', 867,
+        ':', 905,
+        '<', 937,
+        '=', 893,
+        '>', 913,
+        '@', 892,
+        'C', 840,
+        'D', 829,
+        'G', 830,
+        'H', 835,
+        'L', 838,
+        'O', 843,
+        'P', 828,
+        'T', 844,
+        'W', 831,
+        '[', 869,
+        '\\', 871,
+        '_', 870,
+        '{', 865,
       );
       if (lookahead == ' ' ||
           lookahead == 0xa0 ||
@@ -1362,372 +1372,372 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           (0x2000 <= lookahead && lookahead <= 0x200a) ||
           lookahead == 0x202f ||
           lookahead == 0x205f ||
-          lookahead == 0x3000) ADVANCE(825);
+          lookahead == 0x3000) ADVANCE(894);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(785);
-      if (set_contains(aux_sym_WORD_CHAR_token1_character_set_1, 476, lookahead)) ADVANCE(741);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(846);
+      if (set_contains(aux_sym_WORD_CHAR_token1_character_set_1, 475, lookahead)) ADVANCE(790);
       if (lookahead != 0 &&
           lookahead != 0x2028 &&
-          lookahead != 0x2029) ADVANCE(786);
+          lookahead != 0x2029) ADVANCE(847);
       END_STATE();
     case 1:
-      if ((!eof && lookahead == 00)) ADVANCE(786);
-      if (lookahead == '\n') ADVANCE(810);
-      if (lookahead == '\r') ADVANCE(811);
-      if (lookahead == '\\') ADVANCE(805);
-      if (lookahead == '{') ADVANCE(802);
+      if ((!eof && lookahead == 00)) ADVANCE(847);
+      if (lookahead == '\n') ADVANCE(877);
+      if (lookahead == '\r') ADVANCE(879);
+      if (lookahead == '\\') ADVANCE(871);
+      if (lookahead == '{') ADVANCE(868);
       if (lookahead == ' ' ||
           lookahead == 0xa0 ||
           lookahead == 0x1680 ||
           (0x2000 <= lookahead && lookahead <= 0x200a) ||
           lookahead == 0x202f ||
           lookahead == 0x205f ||
-          lookahead == 0x3000) ADVANCE(809);
-      if (set_contains(aux_sym_WORD_CHAR_token1_character_set_1, 476, lookahead)) ADVANCE(741);
+          lookahead == 0x3000) ADVANCE(876);
+      if (set_contains(aux_sym_WORD_CHAR_token1_character_set_1, 475, lookahead)) ADVANCE(790);
       if (lookahead != 0 &&
           lookahead != 0x2028 &&
-          lookahead != 0x2029) ADVANCE(786);
+          lookahead != 0x2029) ADVANCE(847);
       END_STATE();
     case 2:
-      if ((!eof && lookahead == 00)) ADVANCE(786);
-      if (lookahead == '\n') ADVANCE(810);
-      if (lookahead == '\r') ADVANCE(811);
-      if (lookahead == '{') ADVANCE(802);
+      if ((!eof && lookahead == 00)) ADVANCE(847);
+      if (lookahead == '\n') ADVANCE(877);
+      if (lookahead == '\r') ADVANCE(879);
+      if (lookahead == '{') ADVANCE(868);
       if (lookahead == ' ' ||
           lookahead == 0xa0 ||
           lookahead == 0x1680 ||
           (0x2000 <= lookahead && lookahead <= 0x200a) ||
           lookahead == 0x202f ||
           lookahead == 0x205f ||
-          lookahead == 0x3000) ADVANCE(825);
-      if (set_contains(aux_sym_WORD_CHAR_token1_character_set_1, 476, lookahead)) ADVANCE(741);
+          lookahead == 0x3000) ADVANCE(894);
+      if (set_contains(aux_sym_WORD_CHAR_token1_character_set_1, 475, lookahead)) ADVANCE(790);
       if (lookahead != 0 &&
           lookahead != 0x2028 &&
-          lookahead != 0x2029) ADVANCE(786);
+          lookahead != 0x2029) ADVANCE(847);
       END_STATE();
     case 3:
-      if ((!eof && lookahead == 00)) ADVANCE(786);
-      if (lookahead == '\n') ADVANCE(810);
-      if (lookahead == '\r') ADVANCE(811);
-      if (lookahead == '{') ADVANCE(802);
+      if ((!eof && lookahead == 00)) ADVANCE(847);
+      if (lookahead == '\n') ADVANCE(877);
+      if (lookahead == '\r') ADVANCE(879);
+      if (lookahead == '{') ADVANCE(868);
       if (lookahead == ' ' ||
           lookahead == 0xa0 ||
           lookahead == 0x1680 ||
           (0x2000 <= lookahead && lookahead <= 0x200a) ||
           lookahead == 0x202f ||
           lookahead == 0x205f ||
-          lookahead == 0x3000) ADVANCE(809);
-      if (set_contains(aux_sym_WORD_CHAR_token1_character_set_1, 476, lookahead)) ADVANCE(741);
+          lookahead == 0x3000) ADVANCE(876);
+      if (set_contains(aux_sym_WORD_CHAR_token1_character_set_1, 475, lookahead)) ADVANCE(790);
       if (lookahead != 0 &&
           lookahead != 0x2028 &&
-          lookahead != 0x2029) ADVANCE(786);
+          lookahead != 0x2029) ADVANCE(847);
       END_STATE();
     case 4:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
-      if (lookahead == '#') ADVANCE(826);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
+      if (lookahead == '#') ADVANCE(895);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 5:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'A') ADVANCE(29);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 6:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'A') ADVANCE(13);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 7:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'A') ADVANCE(12);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 8:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'B') ADVANCE(33);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 9:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'C') ADVANCE(34);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 10:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'C') ADVANCE(21);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 11:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'C') ADVANCE(18);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 12:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'C') ADVANCE(15);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 13:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
-      if (lookahead == 'D') ADVANCE(829);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
+      if (lookahead == 'D') ADVANCE(898);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 14:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'E') ADVANCE(34);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 15:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
-      if (lookahead == 'E') ADVANCE(829);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
+      if (lookahead == 'E') ADVANCE(898);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 16:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'E') ADVANCE(9);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 17:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'E') ADVANCE(37);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 18:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
-      if (lookahead == 'H') ADVANCE(829);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
+      if (lookahead == 'H') ADVANCE(898);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 19:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'H') ADVANCE(30);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 20:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'I') ADVANCE(27);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 21:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'K') ADVANCE(14);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 22:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'L') ADVANCE(17);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 23:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
-      if (lookahead == 'L') ADVANCE(829);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
+      if (lookahead == 'L') ADVANCE(898);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 24:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'N') ADVANCE(25);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 25:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'N') ADVANCE(16);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 26:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'N') ADVANCE(32);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 27:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'O') ADVANCE(26);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 28:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'O') ADVANCE(10);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 29:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'P') ADVANCE(19);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 30:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'Q') ADVANCE(23);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 31:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'S') ADVANCE(34);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 32:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
-      if (lookahead == 'S') ADVANCE(829);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
+      if (lookahead == 'S') ADVANCE(898);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 33:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'S') ADVANCE(28);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 34:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
-      if (lookahead == 'T') ADVANCE(829);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
+      if (lookahead == 'T') ADVANCE(898);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 35:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'T') ADVANCE(20);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 36:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'T') ADVANCE(11);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 37:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'T') ADVANCE(15);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 38:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'a') ADVANCE(45);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 39:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'e') ADVANCE(43);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 40:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'i') ADVANCE(42);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 41:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'n') ADVANCE(47);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 42:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'o') ADVANCE(41);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 43:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'r') ADVANCE(46);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 44:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 't') ADVANCE(38);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 45:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 't') ADVANCE(40);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 46:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'y') ADVANCE(47);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 47:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == ' ' ||
           lookahead == 0xa0 ||
           lookahead == 0x1680 ||
@@ -1738,15 +1748,15 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 48:
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 49:
-      if ((!eof && lookahead == 00)) ADVANCE(868);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(868);
+      if ((!eof && lookahead == 00)) ADVANCE(947);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(947);
       if (lookahead == '{') ADVANCE(51);
       if (lookahead == ' ' ||
           lookahead == 0xa0 ||
@@ -1758,324 +1768,324 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0) ADVANCE(50);
       END_STATE();
     case 50:
-      if ((!eof && lookahead == 00)) ADVANCE(868);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(868);
+      if ((!eof && lookahead == 00)) ADVANCE(947);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(947);
       if (lookahead == '{') ADVANCE(51);
       if (lookahead != 0) ADVANCE(50);
       END_STATE();
     case 51:
-      if ((!eof && lookahead == 00)) ADVANCE(860);
-      if (lookahead == '\n') ADVANCE(858);
-      if (lookahead == '\r') ADVANCE(859);
+      if ((!eof && lookahead == 00)) ADVANCE(932);
+      if (lookahead == '\n') ADVANCE(930);
+      if (lookahead == '\r') ADVANCE(931);
       if (lookahead == '{') ADVANCE(51);
       if (lookahead != 0) ADVANCE(50);
       END_STATE();
     case 52:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
-      if (lookahead == '#') ADVANCE(826);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
+      if (lookahead == '#') ADVANCE(895);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 53:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'A') ADVANCE(77);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 54:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'A') ADVANCE(61);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 55:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'A') ADVANCE(60);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 56:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'B') ADVANCE(80);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 57:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'C') ADVANCE(69);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 58:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'C') ADVANCE(66);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 59:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'C') ADVANCE(82);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 60:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'C') ADVANCE(62);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 61:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
-      if (lookahead == 'D') ADVANCE(830);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
+      if (lookahead == 'D') ADVANCE(899);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 62:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
-      if (lookahead == 'E') ADVANCE(830);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
+      if (lookahead == 'E') ADVANCE(899);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 63:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'E') ADVANCE(82);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 64:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'E') ADVANCE(59);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 65:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'E') ADVANCE(85);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 66:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
-      if (lookahead == 'H') ADVANCE(830);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
+      if (lookahead == 'H') ADVANCE(899);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 67:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'H') ADVANCE(78);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 68:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'I') ADVANCE(75);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 69:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'K') ADVANCE(63);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 70:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
-      if (lookahead == 'L') ADVANCE(830);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
+      if (lookahead == 'L') ADVANCE(899);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 71:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'L') ADVANCE(65);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 72:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'N') ADVANCE(74);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 73:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'N') ADVANCE(79);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 74:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'N') ADVANCE(64);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 75:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'O') ADVANCE(73);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 76:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'O') ADVANCE(57);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 77:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'P') ADVANCE(67);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 78:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'Q') ADVANCE(70);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 79:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
-      if (lookahead == 'S') ADVANCE(830);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
+      if (lookahead == 'S') ADVANCE(899);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 80:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'S') ADVANCE(76);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 81:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'S') ADVANCE(82);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 82:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
-      if (lookahead == 'T') ADVANCE(830);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
+      if (lookahead == 'T') ADVANCE(899);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 83:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'T') ADVANCE(68);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 84:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'T') ADVANCE(58);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 85:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'T') ADVANCE(62);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 86:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'a') ADVANCE(93);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 87:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'e') ADVANCE(91);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 88:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'i') ADVANCE(90);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 89:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'n') ADVANCE(95);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 90:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'o') ADVANCE(89);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 91:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'r') ADVANCE(94);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 92:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 't') ADVANCE(86);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 93:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 't') ADVANCE(88);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 94:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'y') ADVANCE(95);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 95:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == ' ' ||
           lookahead == 0xa0 ||
           lookahead == 0x1680 ||
@@ -2086,16 +2096,16 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 96:
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
     case 97:
-      if ((!eof && lookahead == 00)) ADVANCE(853);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(853);
-      if (lookahead == '{') ADVANCE(98);
+      if ((!eof && lookahead == 00)) ADVANCE(942);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(942);
+      if (lookahead == '{') ADVANCE(151);
       if (lookahead == ' ' ||
           lookahead == 0xa0 ||
           lookahead == 0x1680 ||
@@ -2106,52 +2116,400 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0) ADVANCE(98);
       END_STATE();
     case 98:
-      if ((!eof && lookahead == 00)) ADVANCE(853);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(853);
-      if (lookahead == '{') ADVANCE(98);
+      if ((!eof && lookahead == 00)) ADVANCE(942);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(942);
+      if (lookahead == '{') ADVANCE(151);
       if (lookahead != 0) ADVANCE(98);
       END_STATE();
     case 99:
-      if ((!eof && lookahead == 00)) ADVANCE(797);
-      if (lookahead == '\n') ADVANCE(841);
-      if (lookahead == '\r') ADVANCE(841);
-      if (lookahead == '\\') ADVANCE(805);
-      if (lookahead == '{') ADVANCE(802);
-      if (set_contains(aux_sym_WORD_CHAR_token1_character_set_1, 476, lookahead)) ADVANCE(741);
-      if ((!eof && set_contains(aux_sym_PUNCTUATION_token1_character_set_1, 485, lookahead))) ADVANCE(786);
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == '#') ADVANCE(895);
+      if (lookahead != 0) ADVANCE(143);
       END_STATE();
     case 100:
-      if ((!eof && lookahead == 00)) ADVANCE(813);
-      if (lookahead == '\n') ADVANCE(812);
-      if (lookahead == '\r') ADVANCE(813);
-      if (lookahead == '%') ADVANCE(102);
-      if (lookahead != 0) ADVANCE(103);
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'A') ADVANCE(124);
+      if (lookahead != 0) ADVANCE(143);
       END_STATE();
     case 101:
-      if ((!eof && lookahead == 00)) ADVANCE(813);
-      if (lookahead == '\n') ADVANCE(812);
-      if (lookahead == '\r') ADVANCE(813);
-      if (lookahead == '@') ADVANCE(823);
-      if (lookahead != 0) ADVANCE(103);
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'A') ADVANCE(108);
+      if (lookahead != 0) ADVANCE(143);
       END_STATE();
     case 102:
-      if ((!eof && lookahead == 00)) ADVANCE(813);
-      if (lookahead == '\n') ADVANCE(812);
-      if (lookahead == '\r') ADVANCE(813);
-      if (lookahead == '}') ADVANCE(844);
-      if (lookahead != 0) ADVANCE(103);
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'A') ADVANCE(107);
+      if (lookahead != 0) ADVANCE(143);
       END_STATE();
     case 103:
-      if ((!eof && lookahead == 00)) ADVANCE(813);
-      if (lookahead == '\n') ADVANCE(812);
-      if (lookahead == '\r') ADVANCE(813);
-      if (lookahead != 0) ADVANCE(103);
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'B') ADVANCE(127);
+      if (lookahead != 0) ADVANCE(143);
       END_STATE();
     case 104:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'C') ADVANCE(116);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 105:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'C') ADVANCE(113);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 106:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'C') ADVANCE(129);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 107:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'C') ADVANCE(109);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 108:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'D') ADVANCE(900);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 109:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'E') ADVANCE(900);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 110:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'E') ADVANCE(129);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 111:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'E') ADVANCE(106);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 112:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'E') ADVANCE(132);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 113:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'H') ADVANCE(900);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 114:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'H') ADVANCE(125);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 115:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'I') ADVANCE(122);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 116:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'K') ADVANCE(110);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 117:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'L') ADVANCE(900);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 118:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'L') ADVANCE(112);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 119:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'N') ADVANCE(121);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 120:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'N') ADVANCE(126);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 121:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'N') ADVANCE(111);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 122:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'O') ADVANCE(120);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 123:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'O') ADVANCE(104);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 124:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'P') ADVANCE(114);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 125:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'Q') ADVANCE(117);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 126:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'S') ADVANCE(900);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 127:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'S') ADVANCE(123);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 128:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'S') ADVANCE(129);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 129:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'T') ADVANCE(900);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 130:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'T') ADVANCE(115);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 131:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'T') ADVANCE(105);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 132:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'T') ADVANCE(109);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 133:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'a') ADVANCE(140);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 134:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'e') ADVANCE(138);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 135:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'i') ADVANCE(137);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 136:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'n') ADVANCE(142);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 137:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'o') ADVANCE(136);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 138:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'r') ADVANCE(141);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 139:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 't') ADVANCE(133);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 140:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 't') ADVANCE(135);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 141:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'y') ADVANCE(142);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 142:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == ' ' ||
+          lookahead == 0xa0 ||
+          lookahead == 0x1680 ||
+          (0x2000 <= lookahead && lookahead <= 0x200a) ||
+          lookahead == 0x202f ||
+          lookahead == 0x205f ||
+          lookahead == 0x3000) ADVANCE(144);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 143:
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 144:
+      if ((!eof && lookahead == 00)) ADVANCE(925);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(925);
+      if (lookahead == '{') ADVANCE(145);
+      if (lookahead == ' ' ||
+          lookahead == 0xa0 ||
+          lookahead == 0x1680 ||
+          (0x2000 <= lookahead && lookahead <= 0x200a) ||
+          lookahead == 0x202f ||
+          lookahead == 0x205f ||
+          lookahead == 0x3000) ADVANCE(144);
+      if (lookahead != 0) ADVANCE(145);
+      END_STATE();
+    case 145:
+      if ((!eof && lookahead == 00)) ADVANCE(925);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(925);
+      if (lookahead == '{') ADVANCE(145);
+      if (lookahead != 0) ADVANCE(145);
+      END_STATE();
+    case 146:
+      if ((!eof && lookahead == 00)) ADVANCE(863);
+      if (lookahead == '\n') ADVANCE(912);
       if (lookahead == '\r') ADVANCE(912);
+      if (lookahead == '\\') ADVANCE(871);
+      if (lookahead == '{') ADVANCE(868);
+      if (set_contains(aux_sym_WORD_CHAR_token1_character_set_1, 475, lookahead)) ADVANCE(790);
+      if ((!eof && set_contains(aux_sym_PUNCTUATION_token1_character_set_1, 484, lookahead))) ADVANCE(847);
+      END_STATE();
+    case 147:
+      if ((!eof && lookahead == 00)) ADVANCE(881);
+      if (lookahead == '\n') ADVANCE(880);
+      if (lookahead == '\r') ADVANCE(881);
+      if (lookahead == '%') ADVANCE(149);
+      if (lookahead != 0) ADVANCE(150);
+      END_STATE();
+    case 148:
+      if ((!eof && lookahead == 00)) ADVANCE(881);
+      if (lookahead == '\n') ADVANCE(880);
+      if (lookahead == '\r') ADVANCE(881);
+      if (lookahead == '@') ADVANCE(892);
+      if (lookahead != 0) ADVANCE(150);
+      END_STATE();
+    case 149:
+      if ((!eof && lookahead == 00)) ADVANCE(881);
+      if (lookahead == '\n') ADVANCE(880);
+      if (lookahead == '\r') ADVANCE(881);
+      if (lookahead == '}') ADVANCE(915);
+      if (lookahead != 0) ADVANCE(150);
+      END_STATE();
+    case 150:
+      if ((!eof && lookahead == 00)) ADVANCE(881);
+      if (lookahead == '\n') ADVANCE(880);
+      if (lookahead == '\r') ADVANCE(881);
+      if (lookahead != 0) ADVANCE(150);
+      END_STATE();
+    case 151:
+      if ((!eof && lookahead == 00)) ADVANCE(934);
+      if (lookahead == '\n') ADVANCE(930);
+      if (lookahead == '\r') ADVANCE(933);
+      if (lookahead == '{') ADVANCE(151);
+      if (lookahead != 0) ADVANCE(98);
+      END_STATE();
+    case 152:
+      if (lookahead == '\r') ADVANCE(989);
       if ((!eof && lookahead == 00) ||
-          lookahead == '\n') ADVANCE(911);
+          lookahead == '\n') ADVANCE(988);
       if (lookahead == '$' ||
           lookahead == '-' ||
           lookahead == '.' ||
@@ -2159,55 +2517,55 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(909);
+          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(986);
       END_STATE();
-    case 105:
+    case 153:
       ADVANCE_MAP(
-        '\r', 811,
-        ':', 835,
-        '=', 824,
-        'A', 301,
-        'B', 253,
-        'C', 538,
-        'E', 719,
-        'F', 254,
-        'G', 255,
-        'H', 245,
-        'I', 161,
-        'L', 351,
-        'M', 345,
-        'N', 352,
-        'O', 200,
-        'P', 256,
-        'R', 264,
-        'S', 342,
-        'T', 346,
-        'U', 224,
-        'V', 260,
-        '}', 730,
-        0, 810,
-        '\n', 810,
+        '\r', 879,
+        ':', 905,
+        '=', 893,
+        'A', 349,
+        'B', 301,
+        'C', 586,
+        'E', 767,
+        'F', 302,
+        'G', 303,
+        'H', 293,
+        'I', 209,
+        'L', 399,
+        'M', 393,
+        'N', 400,
+        'O', 248,
+        'P', 304,
+        'R', 312,
+        'S', 390,
+        'T', 394,
+        'U', 272,
+        'V', 308,
+        '}', 778,
+        0, 877,
+        '\n', 877,
       );
-      if (('1' <= lookahead && lookahead <= '5')) ADVANCE(732);
+      if (('1' <= lookahead && lookahead <= '5')) ADVANCE(780);
       if (lookahead == ' ' ||
           lookahead == 0xa0 ||
           lookahead == 0x1680 ||
           (0x2000 <= lookahead && lookahead <= 0x200a) ||
           lookahead == 0x202f ||
           lookahead == 0x205f ||
-          lookahead == 0x3000) ADVANCE(809);
+          lookahead == 0x3000) ADVANCE(876);
       END_STATE();
-    case 106:
-      if (lookahead == '\r') ADVANCE(841);
+    case 154:
+      if (lookahead == '\r') ADVANCE(912);
       if ((!eof && lookahead == 00) ||
-          lookahead == '\n') ADVANCE(841);
+          lookahead == '\n') ADVANCE(912);
       if (lookahead == ' ' ||
-          lookahead == 0xa0) ADVANCE(809);
+          lookahead == 0xa0) ADVANCE(876);
       if (lookahead == 0x1680 ||
           (0x2000 <= lookahead && lookahead <= 0x200a) ||
           lookahead == 0x202f ||
           lookahead == 0x205f ||
-          lookahead == 0x3000) ADVANCE(808);
+          lookahead == 0x3000) ADVANCE(875);
       if (lookahead == '$' ||
           lookahead == '-' ||
           lookahead == '.' ||
@@ -2215,2155 +2573,1970 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(909);
-      END_STATE();
-    case 107:
-      if (lookahead == '\r') ADVANCE(871);
-      if (lookahead == '@') ADVANCE(823);
-      if ((!eof && lookahead == 00) ||
-          lookahead == '\n') ADVANCE(871);
-      if (lookahead != 0) ADVANCE(108);
-      END_STATE();
-    case 108:
-      if (lookahead == '\r') ADVANCE(871);
-      if ((!eof && lookahead == 00) ||
-          lookahead == '\n') ADVANCE(871);
-      if (lookahead != 0 &&
-          lookahead != '@') ADVANCE(108);
-      END_STATE();
-    case 109:
-      if (lookahead == ' ') ADVANCE(249);
-      END_STATE();
-    case 110:
-      if (lookahead == ' ') ADVANCE(193);
-      END_STATE();
-    case 111:
-      if (lookahead == ' ') ADVANCE(168);
-      END_STATE();
-    case 112:
-      if (lookahead == ' ') ADVANCE(188);
-      END_STATE();
-    case 113:
-      if (lookahead == ' ') ADVANCE(251);
-      END_STATE();
-    case 114:
-      if (lookahead == ' ') ADVANCE(227);
-      END_STATE();
-    case 115:
-      if (lookahead == ' ') ADVANCE(196);
-      END_STATE();
-    case 116:
-      if (lookahead == ' ') ADVANCE(190);
-      END_STATE();
-    case 117:
-      if (lookahead == ' ') ADVANCE(207);
-      END_STATE();
-    case 118:
-      if (lookahead == ' ') ADVANCE(191);
-      END_STATE();
-    case 119:
-      if (lookahead == ' ') ADVANCE(180);
-      END_STATE();
-    case 120:
-      if (lookahead == ' ') ADVANCE(250);
-      END_STATE();
-    case 121:
-      if (lookahead == ' ') ADVANCE(228);
-      END_STATE();
-    case 122:
-      if (lookahead == ' ') ADVANCE(192);
-      END_STATE();
-    case 123:
-      if (lookahead == ' ') ADVANCE(206);
-      END_STATE();
-    case 124:
-      if (lookahead == ' ') ADVANCE(221);
-      END_STATE();
-    case 125:
-      if (lookahead == ' ') ADVANCE(221);
-      if (lookahead == 'i') ADVANCE(510);
-      END_STATE();
-    case 126:
-      if (lookahead == ' ') ADVANCE(199);
-      END_STATE();
-    case 127:
-      if (lookahead == ' ') ADVANCE(217);
-      END_STATE();
-    case 128:
-      if (lookahead == ' ') ADVANCE(189);
-      END_STATE();
-    case 129:
-      if (lookahead == ' ') ADVANCE(211);
-      END_STATE();
-    case 130:
-      if (lookahead == ' ') ADVANCE(205);
-      END_STATE();
-    case 131:
-      if (lookahead == ' ') ADVANCE(220);
-      END_STATE();
-    case 132:
-      if (lookahead == ' ') ADVANCE(271);
-      END_STATE();
-    case 133:
-      if (lookahead == ' ') ADVANCE(212);
-      END_STATE();
-    case 134:
-      if (lookahead == ' ') ADVANCE(204);
-      END_STATE();
-    case 135:
-      if (lookahead == ' ') ADVANCE(170);
-      END_STATE();
-    case 136:
-      if (lookahead == ' ') ADVANCE(235);
-      END_STATE();
-    case 137:
-      if (lookahead == ' ') ADVANCE(187);
-      END_STATE();
-    case 138:
-      if (lookahead == ' ') ADVANCE(177);
-      END_STATE();
-    case 139:
-      if (lookahead == ' ') ADVANCE(177);
-      if (lookahead == 'n') ADVANCE(162);
-      if (lookahead == 't') ADVANCE(111);
-      END_STATE();
-    case 140:
-      if (lookahead == ' ') ADVANCE(237);
-      END_STATE();
-    case 141:
-      if (lookahead == ' ') ADVANCE(186);
-      END_STATE();
-    case 142:
-      if (lookahead == ' ') ADVANCE(178);
-      END_STATE();
-    case 143:
-      if (lookahead == ' ') ADVANCE(246);
-      END_STATE();
-    case 144:
-      if (lookahead == ' ') ADVANCE(238);
-      END_STATE();
-    case 145:
-      if (lookahead == ' ') ADVANCE(247);
-      END_STATE();
-    case 146:
-      if (lookahead == ' ') ADVANCE(244);
-      END_STATE();
-    case 147:
-      if (lookahead == ' ') ADVANCE(679);
-      END_STATE();
-    case 148:
-      if (lookahead == ' ') ADVANCE(229);
-      END_STATE();
-    case 149:
-      if (lookahead == ' ') ADVANCE(181);
-      END_STATE();
-    case 150:
-      if (lookahead == ' ') ADVANCE(169);
-      END_STATE();
-    case 151:
-      if (lookahead == ' ') ADVANCE(234);
-      END_STATE();
-    case 152:
-      if (lookahead == ' ') ADVANCE(171);
-      END_STATE();
-    case 153:
-      if (lookahead == ' ') ADVANCE(226);
-      END_STATE();
-    case 154:
-      if (lookahead == ' ') ADVANCE(230);
+          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(986);
       END_STATE();
     case 155:
-      if (lookahead == ' ') ADVANCE(222);
+      if (lookahead == '\r') ADVANCE(948);
+      if (lookahead == '@') ADVANCE(892);
+      if ((!eof && lookahead == 00) ||
+          lookahead == '\n') ADVANCE(948);
+      if (lookahead != 0) ADVANCE(156);
       END_STATE();
     case 156:
-      if (lookahead == ' ') ADVANCE(213);
+      if (lookahead == '\r') ADVANCE(948);
+      if ((!eof && lookahead == 00) ||
+          lookahead == '\n') ADVANCE(948);
+      if (lookahead != 0 &&
+          lookahead != '@') ADVANCE(156);
       END_STATE();
     case 157:
-      if (lookahead == ' ') ADVANCE(248);
+      if (lookahead == ' ') ADVANCE(297);
       END_STATE();
     case 158:
-      if (lookahead == ' ') ADVANCE(225);
+      if (lookahead == ' ') ADVANCE(241);
       END_STATE();
     case 159:
-      if (lookahead == ' ') ADVANCE(214);
+      if (lookahead == ' ') ADVANCE(216);
       END_STATE();
     case 160:
-      if (lookahead == '#') ADVANCE(826);
+      if (lookahead == ' ') ADVANCE(236);
       END_STATE();
     case 161:
-      if (lookahead == '\'') ADVANCE(497);
-      if (lookahead == 'M') ADVANCE(109);
-      if (lookahead == 'n') ADVANCE(632);
+      if (lookahead == ' ') ADVANCE(299);
       END_STATE();
     case 162:
-      if (lookahead == '-') ADVANCE(167);
+      if (lookahead == ' ') ADVANCE(275);
       END_STATE();
     case 163:
-      if (lookahead == '-') ADVANCE(236);
-      if (lookahead == 'p') ADVANCE(492);
+      if (lookahead == ' ') ADVANCE(244);
       END_STATE();
     case 164:
-      if (lookahead == 'A') ADVANCE(218);
+      if (lookahead == ' ') ADVANCE(238);
       END_STATE();
     case 165:
-      if (lookahead == 'A') ADVANCE(179);
+      if (lookahead == ' ') ADVANCE(255);
       END_STATE();
     case 166:
-      if (lookahead == 'A') ADVANCE(176);
+      if (lookahead == ' ') ADVANCE(239);
       END_STATE();
     case 167:
-      if (lookahead == 'A') ADVANCE(706);
+      if (lookahead == ' ') ADVANCE(228);
       END_STATE();
     case 168:
-      if (lookahead == 'A') ADVANCE(318);
-      if (lookahead == 'E') ADVANCE(721);
-      if (lookahead == 'F') ADVANCE(541);
-      if (lookahead == 'I') ADVANCE(499);
-      if (lookahead == 'M') ADVANCE(565);
+      if (lookahead == ' ') ADVANCE(298);
       END_STATE();
     case 169:
-      if (lookahead == 'A') ADVANCE(704);
+      if (lookahead == ' ') ADVANCE(276);
       END_STATE();
     case 170:
-      if (lookahead == 'A') ADVANCE(480);
+      if (lookahead == ' ') ADVANCE(240);
       END_STATE();
     case 171:
-      if (lookahead == 'A') ADVANCE(483);
+      if (lookahead == ' ') ADVANCE(254);
       END_STATE();
     case 172:
-      if (lookahead == 'B') ADVANCE(233);
+      if (lookahead == ' ') ADVANCE(269);
       END_STATE();
     case 173:
-      if (lookahead == 'C') ADVANCE(239);
+      if (lookahead == ' ') ADVANCE(269);
+      if (lookahead == 'i') ADVANCE(558);
       END_STATE();
     case 174:
-      if (lookahead == 'C') ADVANCE(201);
+      if (lookahead == ' ') ADVANCE(247);
       END_STATE();
     case 175:
-      if (lookahead == 'C') ADVANCE(194);
+      if (lookahead == ' ') ADVANCE(265);
       END_STATE();
     case 176:
-      if (lookahead == 'C') ADVANCE(183);
+      if (lookahead == ' ') ADVANCE(237);
       END_STATE();
     case 177:
-      if (lookahead == 'C') ADVANCE(545);
+      if (lookahead == ' ') ADVANCE(259);
       END_STATE();
     case 178:
-      if (lookahead == 'C') ADVANCE(430);
+      if (lookahead == ' ') ADVANCE(253);
       END_STATE();
     case 179:
-      if (lookahead == 'D') ADVANCE(828);
+      if (lookahead == ' ') ADVANCE(268);
       END_STATE();
     case 180:
-      if (lookahead == 'D') ADVANCE(401);
+      if (lookahead == ' ') ADVANCE(319);
       END_STATE();
     case 181:
-      if (lookahead == 'D') ADVANCE(389);
+      if (lookahead == ' ') ADVANCE(260);
       END_STATE();
     case 182:
-      if (lookahead == 'E') ADVANCE(239);
+      if (lookahead == ' ') ADVANCE(252);
       END_STATE();
     case 183:
-      if (lookahead == 'E') ADVANCE(828);
+      if (lookahead == ' ') ADVANCE(218);
       END_STATE();
     case 184:
-      if (lookahead == 'E') ADVANCE(173);
+      if (lookahead == ' ') ADVANCE(283);
       END_STATE();
     case 185:
-      if (lookahead == 'E') ADVANCE(243);
+      if (lookahead == ' ') ADVANCE(235);
       END_STATE();
     case 186:
-      if (lookahead == 'E') ADVANCE(616);
+      if (lookahead == ' ') ADVANCE(225);
       END_STATE();
     case 187:
-      if (lookahead == 'E') ADVANCE(519);
+      if (lookahead == ' ') ADVANCE(225);
+      if (lookahead == 'n') ADVANCE(210);
+      if (lookahead == 't') ADVANCE(159);
       END_STATE();
     case 188:
-      if (lookahead == 'E') ADVANCE(268);
-      if (lookahead == 'M') ADVANCE(270);
+      if (lookahead == ' ') ADVANCE(285);
       END_STATE();
     case 189:
-      if (lookahead == 'F') ADVANCE(451);
+      if (lookahead == ' ') ADVANCE(234);
       END_STATE();
     case 190:
-      if (lookahead == 'F') ADVANCE(291);
+      if (lookahead == ' ') ADVANCE(226);
       END_STATE();
     case 191:
-      if (lookahead == 'F') ADVANCE(291);
-      if (lookahead == 'R') ADVANCE(391);
+      if (lookahead == ' ') ADVANCE(294);
       END_STATE();
     case 192:
-      if (lookahead == 'F') ADVANCE(571);
+      if (lookahead == ' ') ADVANCE(286);
       END_STATE();
     case 193:
-      if (lookahead == 'G') ADVANCE(292);
-      if (lookahead == 'R') ADVANCE(343);
+      if (lookahead == ' ') ADVANCE(295);
       END_STATE();
     case 194:
-      if (lookahead == 'H') ADVANCE(828);
+      if (lookahead == ' ') ADVANCE(292);
       END_STATE();
     case 195:
-      if (lookahead == 'H') ADVANCE(223);
+      if (lookahead == ' ') ADVANCE(727);
       END_STATE();
     case 196:
-      if (lookahead == 'H') ADVANCE(399);
-      if (lookahead == 'T') ADVANCE(457);
+      if (lookahead == ' ') ADVANCE(277);
       END_STATE();
     case 197:
-      if (lookahead == 'I') ADVANCE(215);
+      if (lookahead == ' ') ADVANCE(229);
       END_STATE();
     case 198:
-      if (lookahead == 'I') ADVANCE(143);
+      if (lookahead == ' ') ADVANCE(217);
       END_STATE();
     case 199:
-      if (lookahead == 'I') ADVANCE(509);
+      if (lookahead == ' ') ADVANCE(282);
       END_STATE();
     case 200:
-      if (lookahead == 'K') ADVANCE(834);
+      if (lookahead == ' ') ADVANCE(219);
       END_STATE();
     case 201:
-      if (lookahead == 'K') ADVANCE(182);
+      if (lookahead == ' ') ADVANCE(274);
       END_STATE();
     case 202:
-      if (lookahead == 'L') ADVANCE(185);
+      if (lookahead == ' ') ADVANCE(278);
       END_STATE();
     case 203:
-      if (lookahead == 'L') ADVANCE(828);
+      if (lookahead == ' ') ADVANCE(270);
       END_STATE();
     case 204:
-      if (lookahead == 'L') ADVANCE(364);
+      if (lookahead == ' ') ADVANCE(261);
       END_STATE();
     case 205:
-      if (lookahead == 'L') ADVANCE(274);
+      if (lookahead == ' ') ADVANCE(296);
       END_STATE();
     case 206:
-      if (lookahead == 'L') ADVANCE(554);
+      if (lookahead == ' ') ADVANCE(273);
       END_STATE();
     case 207:
-      if (lookahead == 'M') ADVANCE(400);
+      if (lookahead == ' ') ADVANCE(262);
       END_STATE();
     case 208:
-      if (lookahead == 'N') ADVANCE(209);
+      if (lookahead == '#') ADVANCE(895);
       END_STATE();
     case 209:
-      if (lookahead == 'N') ADVANCE(184);
+      if (lookahead == '\'') ADVANCE(545);
+      if (lookahead == 'M') ADVANCE(157);
+      if (lookahead == 'n') ADVANCE(680);
       END_STATE();
     case 210:
-      if (lookahead == 'N') ADVANCE(232);
+      if (lookahead == '-') ADVANCE(215);
       END_STATE();
     case 211:
-      if (lookahead == 'N') ADVANCE(574);
+      if (lookahead == '-') ADVANCE(284);
+      if (lookahead == 'p') ADVANCE(540);
       END_STATE();
     case 212:
-      if (lookahead == 'N') ADVANCE(361);
+      if (lookahead == 'A') ADVANCE(266);
       END_STATE();
     case 213:
-      if (lookahead == 'N') ADVANCE(575);
+      if (lookahead == 'A') ADVANCE(227);
       END_STATE();
     case 214:
-      if (lookahead == 'N') ADVANCE(576);
+      if (lookahead == 'A') ADVANCE(224);
       END_STATE();
     case 215:
-      if (lookahead == 'O') ADVANCE(210);
+      if (lookahead == 'A') ADVANCE(754);
       END_STATE();
     case 216:
-      if (lookahead == 'O') ADVANCE(174);
+      if (lookahead == 'A') ADVANCE(366);
+      if (lookahead == 'E') ADVANCE(769);
+      if (lookahead == 'F') ADVANCE(589);
+      if (lookahead == 'I') ADVANCE(547);
+      if (lookahead == 'M') ADVANCE(613);
       END_STATE();
     case 217:
-      if (lookahead == 'O') ADVANCE(653);
+      if (lookahead == 'A') ADVANCE(752);
       END_STATE();
     case 218:
-      if (lookahead == 'P') ADVANCE(195);
+      if (lookahead == 'A') ADVANCE(528);
       END_STATE();
     case 219:
-      if (lookahead == 'P') ADVANCE(113);
+      if (lookahead == 'A') ADVANCE(531);
       END_STATE();
     case 220:
-      if (lookahead == 'P') ADVANCE(412);
+      if (lookahead == 'B') ADVANCE(281);
       END_STATE();
     case 221:
-      if (lookahead == 'P') ADVANCE(611);
+      if (lookahead == 'C') ADVANCE(287);
       END_STATE();
     case 222:
-      if (lookahead == 'P') ADVANCE(613);
+      if (lookahead == 'C') ADVANCE(249);
       END_STATE();
     case 223:
-      if (lookahead == 'Q') ADVANCE(203);
+      if (lookahead == 'C') ADVANCE(242);
       END_STATE();
     case 224:
-      if (lookahead == 'R') ADVANCE(198);
-      if (lookahead == 'n') ADVANCE(257);
-      if (lookahead == 'p') ADVANCE(420);
-      if (lookahead == 's') ADVANCE(363);
+      if (lookahead == 'C') ADVANCE(231);
       END_STATE();
     case 225:
-      if (lookahead == 'R') ADVANCE(343);
+      if (lookahead == 'C') ADVANCE(593);
       END_STATE();
     case 226:
-      if (lookahead == 'R') ADVANCE(411);
+      if (lookahead == 'C') ADVANCE(478);
       END_STATE();
     case 227:
-      if (lookahead == 'R') ADVANCE(391);
+      if (lookahead == 'D') ADVANCE(897);
       END_STATE();
     case 228:
-      if (lookahead == 'R') ADVANCE(379);
+      if (lookahead == 'D') ADVANCE(449);
       END_STATE();
     case 229:
-      if (lookahead == 'R') ADVANCE(407);
+      if (lookahead == 'D') ADVANCE(437);
       END_STATE();
     case 230:
-      if (lookahead == 'R') ADVANCE(410);
+      if (lookahead == 'E') ADVANCE(287);
       END_STATE();
     case 231:
-      if (lookahead == 'S') ADVANCE(239);
+      if (lookahead == 'E') ADVANCE(897);
       END_STATE();
     case 232:
-      if (lookahead == 'S') ADVANCE(828);
+      if (lookahead == 'E') ADVANCE(221);
       END_STATE();
     case 233:
-      if (lookahead == 'S') ADVANCE(216);
+      if (lookahead == 'E') ADVANCE(291);
       END_STATE();
     case 234:
-      if (lookahead == 'S') ADVANCE(688);
+      if (lookahead == 'E') ADVANCE(664);
       END_STATE();
     case 235:
-      if (lookahead == 'S') ADVANCE(374);
+      if (lookahead == 'E') ADVANCE(567);
       END_STATE();
     case 236:
-      if (lookahead == 'S') ADVANCE(662);
+      if (lookahead == 'E') ADVANCE(316);
+      if (lookahead == 'M') ADVANCE(318);
       END_STATE();
     case 237:
-      if (lookahead == 'S') ADVANCE(287);
+      if (lookahead == 'F') ADVANCE(499);
       END_STATE();
     case 238:
-      if (lookahead == 'S') ADVANCE(709);
+      if (lookahead == 'F') ADVANCE(339);
       END_STATE();
     case 239:
-      if (lookahead == 'T') ADVANCE(828);
+      if (lookahead == 'F') ADVANCE(339);
+      if (lookahead == 'R') ADVANCE(439);
       END_STATE();
     case 240:
-      if (lookahead == 'T') ADVANCE(197);
+      if (lookahead == 'F') ADVANCE(619);
       END_STATE();
     case 241:
-      if (lookahead == 'T') ADVANCE(175);
+      if (lookahead == 'G') ADVANCE(340);
+      if (lookahead == 'R') ADVANCE(391);
       END_STATE();
     case 242:
-      if (lookahead == 'T') ADVANCE(219);
+      if (lookahead == 'H') ADVANCE(897);
       END_STATE();
     case 243:
-      if (lookahead == 'T') ADVANCE(183);
+      if (lookahead == 'H') ADVANCE(271);
       END_STATE();
     case 244:
-      if (lookahead == 'T') ADVANCE(726);
+      if (lookahead == 'H') ADVANCE(447);
+      if (lookahead == 'T') ADVANCE(505);
       END_STATE();
     case 245:
-      if (lookahead == 'T') ADVANCE(242);
+      if (lookahead == 'I') ADVANCE(263);
       END_STATE();
     case 246:
-      if (lookahead == 'T') ADVANCE(563);
+      if (lookahead == 'I') ADVANCE(191);
       END_STATE();
     case 247:
-      if (lookahead == 'T') ADVANCE(457);
+      if (lookahead == 'I') ADVANCE(557);
       END_STATE();
     case 248:
-      if (lookahead == 'T') ADVANCE(570);
+      if (lookahead == 'K') ADVANCE(904);
       END_STATE();
     case 249:
-      if (lookahead == 'U') ADVANCE(636);
+      if (lookahead == 'K') ADVANCE(230);
       END_STATE();
     case 250:
-      if (lookahead == 'U') ADVANCE(516);
+      if (lookahead == 'L') ADVANCE(233);
       END_STATE();
     case 251:
-      if (lookahead == 'V') ADVANCE(367);
+      if (lookahead == 'L') ADVANCE(897);
       END_STATE();
     case 252:
-      if (lookahead == '\\') ADVANCE(805);
-      if (lookahead == '{') ADVANCE(798);
-      if (set_contains(aux_sym_WORD_CHAR_token1_character_set_1, 476, lookahead)) ADVANCE(741);
-      if ((!eof && set_contains(aux_sym_PUNCTUATION_token1_character_set_1, 485, lookahead))) ADVANCE(786);
+      if (lookahead == 'L') ADVANCE(412);
       END_STATE();
     case 253:
-      if (lookahead == 'a') ADVANCE(321);
+      if (lookahead == 'L') ADVANCE(322);
       END_STATE();
     case 254:
-      if (lookahead == 'a') ADVANCE(437);
-      if (lookahead == 'o') ADVANCE(599);
+      if (lookahead == 'L') ADVANCE(602);
       END_STATE();
     case 255:
-      if (lookahead == 'a') ADVANCE(654);
-      if (lookahead == 'o') ADVANCE(512);
+      if (lookahead == 'M') ADVANCE(448);
       END_STATE();
     case 256:
-      if (lookahead == 'a') ADVANCE(604);
-      if (lookahead == 'e') ADVANCE(602);
-      if (lookahead == 'r') ADVANCE(344);
+      if (lookahead == 'N') ADVANCE(257);
       END_STATE();
     case 257:
-      if (lookahead == 'a') ADVANCE(703);
-      if (lookahead == 'p') ADVANCE(606);
-      if (lookahead == 's') ADVANCE(698);
+      if (lookahead == 'N') ADVANCE(232);
       END_STATE();
     case 258:
-      if (lookahead == 'a') ADVANCE(299);
+      if (lookahead == 'N') ADVANCE(280);
       END_STATE();
     case 259:
-      if (lookahead == 'a') ADVANCE(722);
+      if (lookahead == 'N') ADVANCE(622);
       END_STATE();
     case 260:
-      if (lookahead == 'a') ADVANCE(601);
+      if (lookahead == 'N') ADVANCE(409);
       END_STATE();
     case 261:
-      if (lookahead == 'a') ADVANCE(714);
+      if (lookahead == 'N') ADVANCE(623);
       END_STATE();
     case 262:
-      if (lookahead == 'a') ADVANCE(298);
+      if (lookahead == 'N') ADVANCE(624);
       END_STATE();
     case 263:
-      if (lookahead == 'a') ADVANCE(332);
+      if (lookahead == 'O') ADVANCE(258);
       END_STATE();
     case 264:
-      if (lookahead == 'a') ADVANCE(508);
-      if (lookahead == 'e') ADVANCE(594);
+      if (lookahead == 'O') ADVANCE(222);
       END_STATE();
     case 265:
-      if (lookahead == 'a') ADVANCE(487);
+      if (lookahead == 'O') ADVANCE(701);
       END_STATE();
     case 266:
-      if (lookahead == 'a') ADVANCE(335);
+      if (lookahead == 'P') ADVANCE(243);
       END_STATE();
     case 267:
-      if (lookahead == 'a') ADVANCE(421);
+      if (lookahead == 'P') ADVANCE(161);
       END_STATE();
     case 268:
-      if (lookahead == 'a') ADVANCE(609);
+      if (lookahead == 'P') ADVANCE(460);
       END_STATE();
     case 269:
-      if (lookahead == 'a') ADVANCE(628);
+      if (lookahead == 'P') ADVANCE(659);
       END_STATE();
     case 270:
-      if (lookahead == 'a') ADVANCE(531);
+      if (lookahead == 'P') ADVANCE(661);
       END_STATE();
     case 271:
-      if (lookahead == 'a') ADVANCE(147);
+      if (lookahead == 'Q') ADVANCE(251);
       END_STATE();
     case 272:
-      if (lookahead == 'a') ADVANCE(643);
+      if (lookahead == 'R') ADVANCE(246);
+      if (lookahead == 'n') ADVANCE(305);
+      if (lookahead == 'p') ADVANCE(468);
+      if (lookahead == 's') ADVANCE(411);
       END_STATE();
     case 273:
-      if (lookahead == 'a') ADVANCE(657);
+      if (lookahead == 'R') ADVANCE(391);
       END_STATE();
     case 274:
-      if (lookahead == 'a') ADVANCE(607);
+      if (lookahead == 'R') ADVANCE(459);
       END_STATE();
     case 275:
-      if (lookahead == 'a') ADVANCE(146);
+      if (lookahead == 'R') ADVANCE(439);
       END_STATE();
     case 276:
-      if (lookahead == 'a') ADVANCE(442);
+      if (lookahead == 'R') ADVANCE(427);
       END_STATE();
     case 277:
-      if (lookahead == 'a') ADVANCE(660);
+      if (lookahead == 'R') ADVANCE(455);
       END_STATE();
     case 278:
-      if (lookahead == 'a') ADVANCE(536);
+      if (lookahead == 'R') ADVANCE(458);
       END_STATE();
     case 279:
-      if (lookahead == 'a') ADVANCE(584);
+      if (lookahead == 'S') ADVANCE(287);
       END_STATE();
     case 280:
-      if (lookahead == 'a') ADVANCE(661);
+      if (lookahead == 'S') ADVANCE(897);
       END_STATE();
     case 281:
-      if (lookahead == 'a') ADVANCE(489);
+      if (lookahead == 'S') ADVANCE(264);
       END_STATE();
     case 282:
-      if (lookahead == 'a') ADVANCE(458);
+      if (lookahead == 'S') ADVANCE(736);
       END_STATE();
     case 283:
-      if (lookahead == 'a') ADVANCE(724);
+      if (lookahead == 'S') ADVANCE(422);
       END_STATE();
     case 284:
-      if (lookahead == 'a') ADVANCE(522);
+      if (lookahead == 'S') ADVANCE(710);
       END_STATE();
     case 285:
-      if (lookahead == 'a') ADVANCE(491);
+      if (lookahead == 'S') ADVANCE(335);
       END_STATE();
     case 286:
-      if (lookahead == 'a') ADVANCE(330);
+      if (lookahead == 'S') ADVANCE(757);
       END_STATE();
     case 287:
-      if (lookahead == 'a') ADVANCE(667);
+      if (lookahead == 'T') ADVANCE(897);
       END_STATE();
     case 288:
-      if (lookahead == 'a') ADVANCE(338);
+      if (lookahead == 'T') ADVANCE(245);
       END_STATE();
     case 289:
-      if (lookahead == 'a') ADVANCE(670);
+      if (lookahead == 'T') ADVANCE(223);
       END_STATE();
     case 290:
-      if (lookahead == 'a') ADVANCE(677);
+      if (lookahead == 'T') ADVANCE(267);
       END_STATE();
     case 291:
-      if (lookahead == 'a') ADVANCE(464);
+      if (lookahead == 'T') ADVANCE(231);
       END_STATE();
     case 292:
-      if (lookahead == 'a') ADVANCE(683);
+      if (lookahead == 'T') ADVANCE(774);
       END_STATE();
     case 293:
-      if (lookahead == 'a') ADVANCE(533);
+      if (lookahead == 'T') ADVANCE(290);
       END_STATE();
     case 294:
-      if (lookahead == 'a') ADVANCE(300);
+      if (lookahead == 'T') ADVANCE(611);
       END_STATE();
     case 295:
-      if (lookahead == 'a') ADVANCE(694);
+      if (lookahead == 'T') ADVANCE(505);
       END_STATE();
     case 296:
-      if (lookahead == 'a') ADVANCE(695);
+      if (lookahead == 'T') ADVANCE(618);
       END_STATE();
     case 297:
-      if (lookahead == 'b') ADVANCE(438);
+      if (lookahead == 'U') ADVANCE(684);
       END_STATE();
     case 298:
-      if (lookahead == 'b') ADVANCE(478);
+      if (lookahead == 'U') ADVANCE(564);
       END_STATE();
     case 299:
-      if (lookahead == 'b') ADVANCE(493);
+      if (lookahead == 'V') ADVANCE(415);
       END_STATE();
     case 300:
-      if (lookahead == 'b') ADVANCE(494);
+      if (lookahead == '\\') ADVANCE(871);
+      if (lookahead == '{') ADVANCE(864);
+      if (set_contains(aux_sym_WORD_CHAR_token1_character_set_1, 475, lookahead)) ADVANCE(790);
+      if ((!eof && set_contains(aux_sym_PUNCTUATION_token1_character_set_1, 484, lookahead))) ADVANCE(847);
       END_STATE();
     case 301:
-      if (lookahead == 'c') ADVANCE(304);
-      if (lookahead == 'l') ADVANCE(603);
+      if (lookahead == 'a') ADVANCE(369);
       END_STATE();
     case 302:
-      if (lookahead == 'c') ADVANCE(473);
-      if (lookahead == 'o') ADVANCE(583);
-      END_STATE();
-    case 303:
-      if (lookahead == 'c') ADVANCE(722);
-      END_STATE();
-    case 304:
-      if (lookahead == 'c') ADVANCE(354);
-      END_STATE();
-    case 305:
-      if (lookahead == 'c') ADVANCE(427);
-      END_STATE();
-    case 306:
-      if (lookahead == 'c') ADVANCE(659);
-      END_STATE();
-    case 307:
-      if (lookahead == 'c') ADVANCE(647);
-      END_STATE();
-    case 308:
-      if (lookahead == 'c') ADVANCE(353);
-      if (lookahead == 'x') ADVANCE(723);
-      END_STATE();
-    case 309:
-      if (lookahead == 'c') ADVANCE(472);
-      END_STATE();
-    case 310:
-      if (lookahead == 'c') ADVANCE(390);
-      END_STATE();
-    case 311:
-      if (lookahead == 'c') ADVANCE(547);
-      END_STATE();
-    case 312:
-      if (lookahead == 'c') ADVANCE(366);
-      END_STATE();
-    case 313:
-      if (lookahead == 'c') ADVANCE(660);
-      END_STATE();
-    case 314:
-      if (lookahead == 'c') ADVANCE(360);
-      END_STATE();
-    case 315:
-      if (lookahead == 'c') ADVANCE(546);
-      END_STATE();
-    case 316:
-      if (lookahead == 'c') ADVANCE(394);
-      END_STATE();
-    case 317:
-      if (lookahead == 'c') ADVANCE(690);
-      END_STATE();
-    case 318:
-      if (lookahead == 'c') ADVANCE(314);
-      END_STATE();
-    case 319:
-      if (lookahead == 'c') ADVANCE(295);
-      END_STATE();
-    case 320:
-      if (lookahead == 'd') ADVANCE(834);
-      END_STATE();
-    case 321:
-      if (lookahead == 'd') ADVANCE(110);
-      END_STATE();
-    case 322:
-      if (lookahead == 'd') ADVANCE(453);
-      END_STATE();
-    case 323:
-      if (lookahead == 'd') ADVANCE(328);
-      END_STATE();
-    case 324:
-      if (lookahead == 'd') ADVANCE(350);
-      END_STATE();
-    case 325:
-      if (lookahead == 'd') ADVANCE(454);
-      END_STATE();
-    case 326:
-      if (lookahead == 'd') ADVANCE(645);
-      END_STATE();
-    case 327:
-      if (lookahead == 'd') ADVANCE(131);
-      END_STATE();
-    case 328:
-      if (lookahead == 'd') ADVANCE(371);
-      END_STATE();
-    case 329:
-      if (lookahead == 'd') ADVANCE(117);
-      END_STATE();
-    case 330:
-      if (lookahead == 'd') ADVANCE(377);
-      END_STATE();
-    case 331:
-      if (lookahead == 'd') ADVANCE(382);
-      END_STATE();
-    case 332:
-      if (lookahead == 'd') ADVANCE(725);
-      END_STATE();
-    case 333:
-      if (lookahead == 'd') ADVANCE(470);
-      END_STATE();
-    case 334:
-      if (lookahead == 'd') ADVANCE(149);
-      END_STATE();
-    case 335:
-      if (lookahead == 'd') ADVANCE(378);
-      END_STATE();
-    case 336:
-      if (lookahead == 'd') ADVANCE(456);
-      END_STATE();
-    case 337:
-      if (lookahead == 'd') ADVANCE(463);
-      END_STATE();
-    case 338:
-      if (lookahead == 'd') ADVANCE(157);
-      END_STATE();
-    case 339:
-      if (lookahead == 'd') ADVANCE(156);
-      END_STATE();
-    case 340:
-      if (lookahead == 'd') ADVANCE(158);
-      END_STATE();
-    case 341:
-      if (lookahead == 'e') ADVANCE(834);
-      END_STATE();
-    case 342:
-      if (lookahead == 'e') ADVANCE(357);
-      if (lookahead == 'w') ADVANCE(441);
-      END_STATE();
-    case 343:
-      if (lookahead == 'e') ADVANCE(596);
-      END_STATE();
-    case 344:
-      if (lookahead == 'e') ADVANCE(315);
-      if (lookahead == 'o') ADVANCE(308);
-      END_STATE();
-    case 345:
-      if (lookahead == 'e') ADVANCE(648);
-      if (lookahead == 'i') ADVANCE(633);
-      if (lookahead == 'o') ADVANCE(711);
-      if (lookahead == 'u') ADVANCE(476);
-      END_STATE();
-    case 346:
-      if (lookahead == 'e') ADVANCE(496);
-      if (lookahead == 'o') ADVANCE(542);
-      END_STATE();
-    case 347:
-      if (lookahead == 'e') ADVANCE(716);
-      END_STATE();
-    case 348:
-      if (lookahead == 'e') ADVANCE(277);
-      END_STATE();
-    case 349:
-      if (lookahead == 'e') ADVANCE(306);
-      END_STATE();
-    case 350:
-      if (lookahead == 'e') ADVANCE(320);
-      END_STATE();
-    case 351:
-      if (lookahead == 'e') ADVANCE(506);
-      if (lookahead == 'o') ADVANCE(302);
-      END_STATE();
-    case 352:
-      if (lookahead == 'e') ADVANCE(649);
-      if (lookahead == 'o') ADVANCE(139);
-      END_STATE();
-    case 353:
-      if (lookahead == 'e') ADVANCE(634);
-      END_STATE();
-    case 354:
-      if (lookahead == 'e') ADVANCE(585);
-      END_STATE();
-    case 355:
-      if (lookahead == 'e') ADVANCE(500);
-      END_STATE();
-    case 356:
-      if (lookahead == 'e') ADVANCE(641);
-      END_STATE();
-    case 357:
-      if (lookahead == 'e') ADVANCE(127);
-      if (lookahead == 'r') ADVANCE(710);
-      END_STATE();
-    case 358:
-      if (lookahead == 'e') ADVANCE(608);
-      END_STATE();
-    case 359:
-      if (lookahead == 'e') ADVANCE(317);
-      END_STATE();
-    case 360:
-      if (lookahead == 'e') ADVANCE(589);
-      END_STATE();
-    case 361:
-      if (lookahead == 'e') ADVANCE(423);
-      END_STATE();
-    case 362:
-      if (lookahead == 'e') ADVANCE(664);
-      END_STATE();
-    case 363:
-      if (lookahead == 'e') ADVANCE(124);
-      END_STATE();
-    case 364:
-      if (lookahead == 'e') ADVANCE(425);
-      END_STATE();
-    case 365:
-      if (lookahead == 'e') ADVANCE(526);
-      END_STATE();
-    case 366:
-      if (lookahead == 'e') ADVANCE(631);
-      END_STATE();
-    case 367:
-      if (lookahead == 'e') ADVANCE(605);
-      END_STATE();
-    case 368:
-      if (lookahead == 'e') ADVANCE(279);
-      END_STATE();
-    case 369:
-      if (lookahead == 'e') ADVANCE(479);
-      END_STATE();
-    case 370:
-      if (lookahead == 'e') ADVANCE(598);
-      END_STATE();
-    case 371:
-      if (lookahead == 'e') ADVANCE(504);
-      END_STATE();
-    case 372:
-      if (lookahead == 'e') ADVANCE(515);
-      END_STATE();
-    case 373:
-      if (lookahead == 'e') ADVANCE(129);
-      END_STATE();
-    case 374:
-      if (lookahead == 'e') ADVANCE(621);
-      END_STATE();
-    case 375:
-      if (lookahead == 'e') ADVANCE(525);
-      END_STATE();
-    case 376:
-      if (lookahead == 'e') ADVANCE(567);
-      END_STATE();
-    case 377:
-      if (lookahead == 'e') ADVANCE(617);
-      END_STATE();
-    case 378:
-      if (lookahead == 'e') ADVANCE(114);
-      END_STATE();
-    case 379:
-      if (lookahead == 'e') ADVANCE(272);
-      END_STATE();
-    case 380:
-      if (lookahead == 'e') ADVANCE(530);
-      END_STATE();
-    case 381:
-      if (lookahead == 'e') ADVANCE(517);
-      END_STATE();
-    case 382:
-      if (lookahead == 'e') ADVANCE(513);
-      END_STATE();
-    case 383:
-      if (lookahead == 'e') ADVANCE(142);
-      END_STATE();
-    case 384:
-      if (lookahead == 'e') ADVANCE(122);
-      END_STATE();
-    case 385:
-      if (lookahead == 'e') ADVANCE(137);
-      END_STATE();
-    case 386:
-      if (lookahead == 'e') ADVANCE(126);
-      END_STATE();
-    case 387:
-      if (lookahead == 'e') ADVANCE(263);
-      END_STATE();
-    case 388:
-      if (lookahead == 'e') ADVANCE(327);
-      END_STATE();
-    case 389:
-      if (lookahead == 'e') ADVANCE(591);
-      END_STATE();
-    case 390:
-      if (lookahead == 'e') ADVANCE(120);
-      END_STATE();
-    case 391:
-      if (lookahead == 'e') ADVANCE(595);
-      END_STATE();
-    case 392:
-      if (lookahead == 'e') ADVANCE(718);
-      END_STATE();
-    case 393:
-      if (lookahead == 'e') ADVANCE(307);
-      END_STATE();
-    case 394:
-      if (lookahead == 'e') ADVANCE(635);
-      END_STATE();
-    case 395:
-      if (lookahead == 'e') ADVANCE(637);
-      END_STATE();
-    case 396:
-      if (lookahead == 'e') ADVANCE(618);
-      END_STATE();
-    case 397:
-      if (lookahead == 'e') ADVANCE(334);
-      END_STATE();
-    case 398:
-      if (lookahead == 'e') ADVANCE(638);
-      END_STATE();
-    case 399:
-      if (lookahead == 'e') ADVANCE(286);
-      END_STATE();
-    case 400:
-      if (lookahead == 'e') ADVANCE(336);
-      END_STATE();
-    case 401:
-      if (lookahead == 'e') ADVANCE(689);
-      END_STATE();
-    case 402:
-      if (lookahead == 'e') ADVANCE(340);
-      END_STATE();
-    case 403:
-      if (lookahead == 'e') ADVANCE(329);
-      END_STATE();
-    case 404:
-      if (lookahead == 'e') ADVANCE(313);
-      END_STATE();
-    case 405:
-      if (lookahead == 'e') ADVANCE(523);
-      END_STATE();
-    case 406:
-      if (lookahead == 'e') ADVANCE(532);
-      END_STATE();
-    case 407:
-      if (lookahead == 'e') ADVANCE(592);
-      END_STATE();
-    case 408:
-      if (lookahead == 'e') ADVANCE(534);
-      END_STATE();
-    case 409:
-      if (lookahead == 'e') ADVANCE(535);
-      END_STATE();
-    case 410:
-      if (lookahead == 'e') ADVANCE(597);
-      END_STATE();
-    case 411:
-      if (lookahead == 'e') ADVANCE(337);
-      END_STATE();
-    case 412:
-      if (lookahead == 'e') ADVANCE(629);
-      END_STATE();
-    case 413:
-      if (lookahead == 'f') ADVANCE(415);
-      END_STATE();
-    case 414:
-      if (lookahead == 'f') ADVANCE(481);
-      if (lookahead == 't') ADVANCE(440);
-      END_STATE();
-    case 415:
-      if (lookahead == 'f') ADVANCE(439);
-      END_STATE();
-    case 416:
-      if (lookahead == 'f') ADVANCE(447);
-      END_STATE();
-    case 417:
-      if (lookahead == 'f') ADVANCE(578);
-      END_STATE();
-    case 418:
-      if (lookahead == 'f') ADVANCE(448);
-      END_STATE();
-    case 419:
-      if (lookahead == 'g') ADVANCE(834);
-      END_STATE();
-    case 420:
-      if (lookahead == 'g') ADVANCE(624);
-      END_STATE();
-    case 421:
-      if (lookahead == 'g') ADVANCE(341);
-      END_STATE();
-    case 422:
-      if (lookahead == 'g') ADVANCE(650);
-      END_STATE();
-    case 423:
-      if (lookahead == 'g') ADVANCE(573);
-      END_STATE();
-    case 424:
-      if (lookahead == 'g') ADVANCE(373);
-      END_STATE();
-    case 425:
-      if (lookahead == 'g') ADVANCE(285);
-      END_STATE();
-    case 426:
-      if (lookahead == 'g') ADVANCE(155);
-      END_STATE();
-    case 427:
-      if (lookahead == 'h') ADVANCE(125);
-      END_STATE();
-    case 428:
-      if (lookahead == 'h') ADVANCE(572);
-      END_STATE();
-    case 429:
-      if (lookahead == 'h') ADVANCE(566);
-      END_STATE();
-    case 430:
-      if (lookahead == 'h') ADVANCE(579);
-      END_STATE();
-    case 431:
-      if (lookahead == 'h') ADVANCE(114);
-      END_STATE();
-    case 432:
-      if (lookahead == 'h') ADVANCE(370);
-      END_STATE();
-    case 433:
-      if (lookahead == 'h') ADVANCE(380);
-      END_STATE();
-    case 434:
-      if (lookahead == 'h') ADVANCE(552);
-      END_STATE();
-    case 435:
-      if (lookahead == 'i') ADVANCE(163);
-      END_STATE();
-    case 436:
-      if (lookahead == 'i') ADVANCE(729);
-      END_STATE();
-    case 437:
-      if (lookahead == 'i') ADVANCE(495);
-      END_STATE();
-    case 438:
-      if (lookahead == 'i') ADVANCE(323);
-      END_STATE();
-    case 439:
-      if (lookahead == 'i') ADVANCE(309);
-      END_STATE();
-    case 440:
-      if (lookahead == 'i') ADVANCE(524);
-      END_STATE();
-    case 441:
-      if (lookahead == 'i') ADVANCE(652);
-      END_STATE();
-    case 442:
-      if (lookahead == 'i') ADVANCE(484);
-      END_STATE();
-    case 443:
-      if (lookahead == 'i') ADVANCE(293);
-      END_STATE();
-    case 444:
-      if (lookahead == 'i') ADVANCE(319);
-      END_STATE();
-    case 445:
-      if (lookahead == 'i') ADVANCE(265);
-      END_STATE();
-    case 446:
-      if (lookahead == 'i') ADVANCE(640);
-      END_STATE();
-    case 447:
-      if (lookahead == 'i') ADVANCE(350);
-      END_STATE();
-    case 448:
-      if (lookahead == 'i') ADVANCE(262);
-      END_STATE();
-    case 449:
-      if (lookahead == 'i') ADVANCE(511);
-      END_STATE();
-    case 450:
-      if (lookahead == 'i') ADVANCE(651);
-      END_STATE();
-    case 451:
-      if (lookahead == 'i') ADVANCE(369);
-      END_STATE();
-    case 452:
-      if (lookahead == 'i') ADVANCE(310);
-      END_STATE();
-    case 453:
-      if (lookahead == 'i') ADVANCE(615);
-      END_STATE();
-    case 454:
-      if (lookahead == 'i') ADVANCE(416);
-      END_STATE();
-    case 455:
-      if (lookahead == 'i') ADVANCE(307);
-      END_STATE();
-    case 456:
-      if (lookahead == 'i') ADVANCE(275);
-      END_STATE();
-    case 457:
-      if (lookahead == 'i') ADVANCE(501);
-      END_STATE();
-    case 458:
-      if (lookahead == 'i') ADVANCE(486);
-      END_STATE();
-    case 459:
-      if (lookahead == 'i') ADVANCE(610);
-      END_STATE();
-    case 460:
-      if (lookahead == 'i') ADVANCE(713);
-      END_STATE();
-    case 461:
-      if (lookahead == 'i') ADVANCE(555);
-      END_STATE();
-    case 462:
-      if (lookahead == 'i') ADVANCE(312);
-      END_STATE();
-    case 463:
-      if (lookahead == 'i') ADVANCE(623);
-      END_STATE();
-    case 464:
-      if (lookahead == 'i') ADVANCE(485);
-      END_STATE();
-    case 465:
-      if (lookahead == 'i') ADVANCE(557);
-      END_STATE();
-    case 466:
-      if (lookahead == 'i') ADVANCE(568);
-      END_STATE();
-    case 467:
-      if (lookahead == 'i') ADVANCE(559);
-      END_STATE();
-    case 468:
-      if (lookahead == 'i') ADVANCE(551);
-      END_STATE();
-    case 469:
-      if (lookahead == 'i') ADVANCE(290);
-      END_STATE();
-    case 470:
-      if (lookahead == 'i') ADVANCE(692);
-      END_STATE();
-    case 471:
-      if (lookahead == 'i') ADVANCE(691);
-      END_STATE();
-    case 472:
-      if (lookahead == 'i') ADVANCE(409);
-      END_STATE();
-    case 473:
-      if (lookahead == 'k') ADVANCE(350);
-      END_STATE();
-    case 474:
-      if (lookahead == 'k') ADVANCE(150);
-      END_STATE();
-    case 475:
-      if (lookahead == 'l') ADVANCE(722);
-      END_STATE();
-    case 476:
-      if (lookahead == 'l') ADVANCE(655);
-      END_STATE();
-    case 477:
-      if (lookahead == 'l') ADVANCE(577);
-      if (lookahead == 'm') ADVANCE(365);
-      END_STATE();
-    case 478:
-      if (lookahead == 'l') ADVANCE(341);
-      END_STATE();
-    case 479:
-      if (lookahead == 'l') ADVANCE(326);
-      END_STATE();
-    case 480:
-      if (lookahead == 'l') ADVANCE(642);
-      END_STATE();
-    case 481:
-      if (lookahead == 'l') ADVANCE(455);
-      END_STATE();
-    case 482:
-      if (lookahead == 'l') ADVANCE(631);
-      END_STATE();
-    case 483:
-      if (lookahead == 'l') ADVANCE(488);
-      END_STATE();
-    case 484:
-      if (lookahead == 'l') ADVANCE(258);
-      END_STATE();
-    case 485:
-      if (lookahead == 'l') ADVANCE(350);
-      END_STATE();
-    case 486:
-      if (lookahead == 'l') ADVANCE(262);
-      END_STATE();
-    case 487:
-      if (lookahead == 'l') ADVANCE(138);
-      END_STATE();
-    case 488:
-      if (lookahead == 'l') ADVANCE(540);
-      END_STATE();
-    case 489:
-      if (lookahead == 'l') ADVANCE(136);
-      END_STATE();
-    case 490:
-      if (lookahead == 'l') ADVANCE(355);
-      END_STATE();
-    case 491:
-      if (lookahead == 'l') ADVANCE(121);
-      END_STATE();
-    case 492:
-      if (lookahead == 'l') ADVANCE(383);
-      END_STATE();
-    case 493:
-      if (lookahead == 'l') ADVANCE(384);
-      END_STATE();
-    case 494:
-      if (lookahead == 'l') ADVANCE(385);
-      END_STATE();
-    case 495:
-      if (lookahead == 'l') ADVANCE(397);
-      END_STATE();
-    case 496:
-      if (lookahead == 'm') ADVANCE(587);
-      END_STATE();
-    case 497:
-      if (lookahead == 'm') ADVANCE(132);
-      END_STATE();
-    case 498:
-      if (lookahead == 'm') ADVANCE(278);
-      END_STATE();
-    case 499:
-      if (lookahead == 'm') ADVANCE(586);
-      END_STATE();
-    case 500:
-      if (lookahead == 'm') ADVANCE(405);
-      END_STATE();
-    case 501:
-      if (lookahead == 'm') ADVANCE(376);
-      END_STATE();
-    case 502:
-      if (lookahead == 'm') ADVANCE(284);
-      END_STATE();
-    case 503:
-      if (lookahead == 'm') ADVANCE(296);
-      END_STATE();
-    case 504:
-      if (lookahead == 'n') ADVANCE(834);
-      END_STATE();
-    case 505:
-      if (lookahead == 'n') ADVANCE(414);
-      END_STATE();
-    case 506:
-      if (lookahead == 'n') ADVANCE(422);
-      END_STATE();
-    case 507:
-      if (lookahead == 'n') ADVANCE(320);
-      END_STATE();
-    case 508:
-      if (lookahead == 'n') ADVANCE(424);
-      END_STATE();
-    case 509:
-      if (lookahead == 'n') ADVANCE(417);
-      END_STATE();
-    case 510:
-      if (lookahead == 'n') ADVANCE(426);
-      END_STATE();
-    case 511:
-      if (lookahead == 'n') ADVANCE(419);
-      END_STATE();
-    case 512:
-      if (lookahead == 'n') ADVANCE(341);
-      END_STATE();
-    case 513:
-      if (lookahead == 'n') ADVANCE(303);
-      END_STATE();
-    case 514:
-      if (lookahead == 'n') ADVANCE(631);
-      END_STATE();
-    case 515:
-      if (lookahead == 'n') ADVANCE(647);
-      END_STATE();
-    case 516:
-      if (lookahead == 'n') ADVANCE(261);
-      END_STATE();
-    case 517:
-      if (lookahead == 'n') ADVANCE(656);
-      END_STATE();
-    case 518:
-      if (lookahead == 'n') ADVANCE(114);
-      END_STATE();
-    case 519:
-      if (lookahead == 'n') ADVANCE(687);
-      END_STATE();
-    case 520:
-      if (lookahead == 'n') ADVANCE(116);
-      END_STATE();
-    case 521:
-      if (lookahead == 'n') ADVANCE(118);
-      END_STATE();
-    case 522:
-      if (lookahead == 'n') ADVANCE(381);
-      END_STATE();
-    case 523:
-      if (lookahead == 'n') ADVANCE(660);
-      END_STATE();
-    case 524:
-      if (lookahead == 'n') ADVANCE(699);
-      END_STATE();
-    case 525:
-      if (lookahead == 'n') ADVANCE(324);
-      END_STATE();
-    case 526:
-      if (lookahead == 'n') ADVANCE(665);
-      END_STATE();
-    case 527:
-      if (lookahead == 'n') ADVANCE(281);
-      END_STATE();
-    case 528:
-      if (lookahead == 'n') ADVANCE(673);
-      END_STATE();
-    case 529:
-      if (lookahead == 'n') ADVANCE(333);
-      END_STATE();
-    case 530:
-      if (lookahead == 'n') ADVANCE(666);
-      END_STATE();
-    case 531:
-      if (lookahead == 'n') ADVANCE(728);
-      END_STATE();
-    case 532:
-      if (lookahead == 'n') ADVANCE(331);
-      END_STATE();
-    case 533:
-      if (lookahead == 'n') ADVANCE(671);
-      END_STATE();
-    case 534:
-      if (lookahead == 'n') ADVANCE(686);
-      END_STATE();
-    case 535:
-      if (lookahead == 'n') ADVANCE(676);
-      END_STATE();
-    case 536:
-      if (lookahead == 'n') ADVANCE(408);
-      END_STATE();
-    case 537:
-      if (lookahead == 'n') ADVANCE(159);
-      END_STATE();
-    case 538:
-      if (lookahead == 'o') ADVANCE(505);
-      if (lookahead == 'r') ADVANCE(348);
-      END_STATE();
-    case 539:
-      if (lookahead == 'o') ADVANCE(720);
-      END_STATE();
-    case 540:
-      if (lookahead == 'o') ADVANCE(717);
-      END_STATE();
-    case 541:
-      if (lookahead == 'o') ADVANCE(697);
-      END_STATE();
-    case 542:
-      if (lookahead == 'o') ADVANCE(112);
-      END_STATE();
-    case 543:
-      if (lookahead == 'o') ADVANCE(600);
-      END_STATE();
-    case 544:
-      if (lookahead == 'o') ADVANCE(625);
-      END_STATE();
-    case 545:
-      if (lookahead == 'o') ADVANCE(528);
-      END_STATE();
-    case 546:
-      if (lookahead == 'o') ADVANCE(529);
-      END_STATE();
-    case 547:
-      if (lookahead == 'o') ADVANCE(482);
-      END_STATE();
-    case 548:
-      if (lookahead == 'o') ADVANCE(630);
-      END_STATE();
-    case 549:
+      if (lookahead == 'a') ADVANCE(485);
       if (lookahead == 'o') ADVANCE(647);
       END_STATE();
+    case 303:
+      if (lookahead == 'a') ADVANCE(702);
+      if (lookahead == 'o') ADVANCE(560);
+      END_STATE();
+    case 304:
+      if (lookahead == 'a') ADVANCE(652);
+      if (lookahead == 'e') ADVANCE(650);
+      if (lookahead == 'r') ADVANCE(392);
+      END_STATE();
+    case 305:
+      if (lookahead == 'a') ADVANCE(751);
+      if (lookahead == 'p') ADVANCE(654);
+      if (lookahead == 's') ADVANCE(746);
+      END_STATE();
+    case 306:
+      if (lookahead == 'a') ADVANCE(347);
+      END_STATE();
+    case 307:
+      if (lookahead == 'a') ADVANCE(770);
+      END_STATE();
+    case 308:
+      if (lookahead == 'a') ADVANCE(649);
+      END_STATE();
+    case 309:
+      if (lookahead == 'a') ADVANCE(762);
+      END_STATE();
+    case 310:
+      if (lookahead == 'a') ADVANCE(346);
+      END_STATE();
+    case 311:
+      if (lookahead == 'a') ADVANCE(380);
+      END_STATE();
+    case 312:
+      if (lookahead == 'a') ADVANCE(556);
+      if (lookahead == 'e') ADVANCE(642);
+      END_STATE();
+    case 313:
+      if (lookahead == 'a') ADVANCE(535);
+      END_STATE();
+    case 314:
+      if (lookahead == 'a') ADVANCE(383);
+      END_STATE();
+    case 315:
+      if (lookahead == 'a') ADVANCE(469);
+      END_STATE();
+    case 316:
+      if (lookahead == 'a') ADVANCE(657);
+      END_STATE();
+    case 317:
+      if (lookahead == 'a') ADVANCE(676);
+      END_STATE();
+    case 318:
+      if (lookahead == 'a') ADVANCE(579);
+      END_STATE();
+    case 319:
+      if (lookahead == 'a') ADVANCE(195);
+      END_STATE();
+    case 320:
+      if (lookahead == 'a') ADVANCE(691);
+      END_STATE();
+    case 321:
+      if (lookahead == 'a') ADVANCE(705);
+      END_STATE();
+    case 322:
+      if (lookahead == 'a') ADVANCE(655);
+      END_STATE();
+    case 323:
+      if (lookahead == 'a') ADVANCE(194);
+      END_STATE();
+    case 324:
+      if (lookahead == 'a') ADVANCE(490);
+      END_STATE();
+    case 325:
+      if (lookahead == 'a') ADVANCE(708);
+      END_STATE();
+    case 326:
+      if (lookahead == 'a') ADVANCE(584);
+      END_STATE();
+    case 327:
+      if (lookahead == 'a') ADVANCE(632);
+      END_STATE();
+    case 328:
+      if (lookahead == 'a') ADVANCE(709);
+      END_STATE();
+    case 329:
+      if (lookahead == 'a') ADVANCE(537);
+      END_STATE();
+    case 330:
+      if (lookahead == 'a') ADVANCE(506);
+      END_STATE();
+    case 331:
+      if (lookahead == 'a') ADVANCE(772);
+      END_STATE();
+    case 332:
+      if (lookahead == 'a') ADVANCE(570);
+      END_STATE();
+    case 333:
+      if (lookahead == 'a') ADVANCE(539);
+      END_STATE();
+    case 334:
+      if (lookahead == 'a') ADVANCE(378);
+      END_STATE();
+    case 335:
+      if (lookahead == 'a') ADVANCE(715);
+      END_STATE();
+    case 336:
+      if (lookahead == 'a') ADVANCE(386);
+      END_STATE();
+    case 337:
+      if (lookahead == 'a') ADVANCE(718);
+      END_STATE();
+    case 338:
+      if (lookahead == 'a') ADVANCE(725);
+      END_STATE();
+    case 339:
+      if (lookahead == 'a') ADVANCE(512);
+      END_STATE();
+    case 340:
+      if (lookahead == 'a') ADVANCE(731);
+      END_STATE();
+    case 341:
+      if (lookahead == 'a') ADVANCE(581);
+      END_STATE();
+    case 342:
+      if (lookahead == 'a') ADVANCE(348);
+      END_STATE();
+    case 343:
+      if (lookahead == 'a') ADVANCE(742);
+      END_STATE();
+    case 344:
+      if (lookahead == 'a') ADVANCE(743);
+      END_STATE();
+    case 345:
+      if (lookahead == 'b') ADVANCE(486);
+      END_STATE();
+    case 346:
+      if (lookahead == 'b') ADVANCE(526);
+      END_STATE();
+    case 347:
+      if (lookahead == 'b') ADVANCE(541);
+      END_STATE();
+    case 348:
+      if (lookahead == 'b') ADVANCE(542);
+      END_STATE();
+    case 349:
+      if (lookahead == 'c') ADVANCE(352);
+      if (lookahead == 'l') ADVANCE(651);
+      END_STATE();
+    case 350:
+      if (lookahead == 'c') ADVANCE(521);
+      if (lookahead == 'o') ADVANCE(631);
+      END_STATE();
+    case 351:
+      if (lookahead == 'c') ADVANCE(770);
+      END_STATE();
+    case 352:
+      if (lookahead == 'c') ADVANCE(402);
+      END_STATE();
+    case 353:
+      if (lookahead == 'c') ADVANCE(475);
+      END_STATE();
+    case 354:
+      if (lookahead == 'c') ADVANCE(707);
+      END_STATE();
+    case 355:
+      if (lookahead == 'c') ADVANCE(695);
+      END_STATE();
+    case 356:
+      if (lookahead == 'c') ADVANCE(401);
+      if (lookahead == 'x') ADVANCE(771);
+      END_STATE();
+    case 357:
+      if (lookahead == 'c') ADVANCE(520);
+      END_STATE();
+    case 358:
+      if (lookahead == 'c') ADVANCE(438);
+      END_STATE();
+    case 359:
+      if (lookahead == 'c') ADVANCE(595);
+      END_STATE();
+    case 360:
+      if (lookahead == 'c') ADVANCE(414);
+      END_STATE();
+    case 361:
+      if (lookahead == 'c') ADVANCE(708);
+      END_STATE();
+    case 362:
+      if (lookahead == 'c') ADVANCE(408);
+      END_STATE();
+    case 363:
+      if (lookahead == 'c') ADVANCE(594);
+      END_STATE();
+    case 364:
+      if (lookahead == 'c') ADVANCE(442);
+      END_STATE();
+    case 365:
+      if (lookahead == 'c') ADVANCE(738);
+      END_STATE();
+    case 366:
+      if (lookahead == 'c') ADVANCE(362);
+      END_STATE();
+    case 367:
+      if (lookahead == 'c') ADVANCE(343);
+      END_STATE();
+    case 368:
+      if (lookahead == 'd') ADVANCE(904);
+      END_STATE();
+    case 369:
+      if (lookahead == 'd') ADVANCE(158);
+      END_STATE();
+    case 370:
+      if (lookahead == 'd') ADVANCE(501);
+      END_STATE();
+    case 371:
+      if (lookahead == 'd') ADVANCE(376);
+      END_STATE();
+    case 372:
+      if (lookahead == 'd') ADVANCE(398);
+      END_STATE();
+    case 373:
+      if (lookahead == 'd') ADVANCE(502);
+      END_STATE();
+    case 374:
+      if (lookahead == 'd') ADVANCE(693);
+      END_STATE();
+    case 375:
+      if (lookahead == 'd') ADVANCE(179);
+      END_STATE();
+    case 376:
+      if (lookahead == 'd') ADVANCE(419);
+      END_STATE();
+    case 377:
+      if (lookahead == 'd') ADVANCE(165);
+      END_STATE();
+    case 378:
+      if (lookahead == 'd') ADVANCE(425);
+      END_STATE();
+    case 379:
+      if (lookahead == 'd') ADVANCE(430);
+      END_STATE();
+    case 380:
+      if (lookahead == 'd') ADVANCE(773);
+      END_STATE();
+    case 381:
+      if (lookahead == 'd') ADVANCE(518);
+      END_STATE();
+    case 382:
+      if (lookahead == 'd') ADVANCE(197);
+      END_STATE();
+    case 383:
+      if (lookahead == 'd') ADVANCE(426);
+      END_STATE();
+    case 384:
+      if (lookahead == 'd') ADVANCE(504);
+      END_STATE();
+    case 385:
+      if (lookahead == 'd') ADVANCE(511);
+      END_STATE();
+    case 386:
+      if (lookahead == 'd') ADVANCE(205);
+      END_STATE();
+    case 387:
+      if (lookahead == 'd') ADVANCE(204);
+      END_STATE();
+    case 388:
+      if (lookahead == 'd') ADVANCE(206);
+      END_STATE();
+    case 389:
+      if (lookahead == 'e') ADVANCE(904);
+      END_STATE();
+    case 390:
+      if (lookahead == 'e') ADVANCE(405);
+      if (lookahead == 'w') ADVANCE(489);
+      END_STATE();
+    case 391:
+      if (lookahead == 'e') ADVANCE(644);
+      END_STATE();
+    case 392:
+      if (lookahead == 'e') ADVANCE(363);
+      if (lookahead == 'o') ADVANCE(356);
+      END_STATE();
+    case 393:
+      if (lookahead == 'e') ADVANCE(696);
+      if (lookahead == 'i') ADVANCE(681);
+      if (lookahead == 'o') ADVANCE(759);
+      if (lookahead == 'u') ADVANCE(524);
+      END_STATE();
+    case 394:
+      if (lookahead == 'e') ADVANCE(544);
+      if (lookahead == 'o') ADVANCE(590);
+      END_STATE();
+    case 395:
+      if (lookahead == 'e') ADVANCE(764);
+      END_STATE();
+    case 396:
+      if (lookahead == 'e') ADVANCE(325);
+      END_STATE();
+    case 397:
+      if (lookahead == 'e') ADVANCE(354);
+      END_STATE();
+    case 398:
+      if (lookahead == 'e') ADVANCE(368);
+      END_STATE();
+    case 399:
+      if (lookahead == 'e') ADVANCE(554);
+      if (lookahead == 'o') ADVANCE(350);
+      END_STATE();
+    case 400:
+      if (lookahead == 'e') ADVANCE(697);
+      if (lookahead == 'o') ADVANCE(187);
+      END_STATE();
+    case 401:
+      if (lookahead == 'e') ADVANCE(682);
+      END_STATE();
+    case 402:
+      if (lookahead == 'e') ADVANCE(633);
+      END_STATE();
+    case 403:
+      if (lookahead == 'e') ADVANCE(548);
+      END_STATE();
+    case 404:
+      if (lookahead == 'e') ADVANCE(689);
+      END_STATE();
+    case 405:
+      if (lookahead == 'e') ADVANCE(175);
+      if (lookahead == 'r') ADVANCE(758);
+      END_STATE();
+    case 406:
+      if (lookahead == 'e') ADVANCE(656);
+      END_STATE();
+    case 407:
+      if (lookahead == 'e') ADVANCE(365);
+      END_STATE();
+    case 408:
+      if (lookahead == 'e') ADVANCE(637);
+      END_STATE();
+    case 409:
+      if (lookahead == 'e') ADVANCE(471);
+      END_STATE();
+    case 410:
+      if (lookahead == 'e') ADVANCE(712);
+      END_STATE();
+    case 411:
+      if (lookahead == 'e') ADVANCE(172);
+      END_STATE();
+    case 412:
+      if (lookahead == 'e') ADVANCE(473);
+      END_STATE();
+    case 413:
+      if (lookahead == 'e') ADVANCE(574);
+      END_STATE();
+    case 414:
+      if (lookahead == 'e') ADVANCE(679);
+      END_STATE();
+    case 415:
+      if (lookahead == 'e') ADVANCE(653);
+      END_STATE();
+    case 416:
+      if (lookahead == 'e') ADVANCE(327);
+      END_STATE();
+    case 417:
+      if (lookahead == 'e') ADVANCE(527);
+      END_STATE();
+    case 418:
+      if (lookahead == 'e') ADVANCE(646);
+      END_STATE();
+    case 419:
+      if (lookahead == 'e') ADVANCE(552);
+      END_STATE();
+    case 420:
+      if (lookahead == 'e') ADVANCE(563);
+      END_STATE();
+    case 421:
+      if (lookahead == 'e') ADVANCE(177);
+      END_STATE();
+    case 422:
+      if (lookahead == 'e') ADVANCE(669);
+      END_STATE();
+    case 423:
+      if (lookahead == 'e') ADVANCE(573);
+      END_STATE();
+    case 424:
+      if (lookahead == 'e') ADVANCE(615);
+      END_STATE();
+    case 425:
+      if (lookahead == 'e') ADVANCE(665);
+      END_STATE();
+    case 426:
+      if (lookahead == 'e') ADVANCE(162);
+      END_STATE();
+    case 427:
+      if (lookahead == 'e') ADVANCE(320);
+      END_STATE();
+    case 428:
+      if (lookahead == 'e') ADVANCE(578);
+      END_STATE();
+    case 429:
+      if (lookahead == 'e') ADVANCE(565);
+      END_STATE();
+    case 430:
+      if (lookahead == 'e') ADVANCE(561);
+      END_STATE();
+    case 431:
+      if (lookahead == 'e') ADVANCE(190);
+      END_STATE();
+    case 432:
+      if (lookahead == 'e') ADVANCE(170);
+      END_STATE();
+    case 433:
+      if (lookahead == 'e') ADVANCE(185);
+      END_STATE();
+    case 434:
+      if (lookahead == 'e') ADVANCE(174);
+      END_STATE();
+    case 435:
+      if (lookahead == 'e') ADVANCE(311);
+      END_STATE();
+    case 436:
+      if (lookahead == 'e') ADVANCE(375);
+      END_STATE();
+    case 437:
+      if (lookahead == 'e') ADVANCE(639);
+      END_STATE();
+    case 438:
+      if (lookahead == 'e') ADVANCE(168);
+      END_STATE();
+    case 439:
+      if (lookahead == 'e') ADVANCE(643);
+      END_STATE();
+    case 440:
+      if (lookahead == 'e') ADVANCE(766);
+      END_STATE();
+    case 441:
+      if (lookahead == 'e') ADVANCE(355);
+      END_STATE();
+    case 442:
+      if (lookahead == 'e') ADVANCE(683);
+      END_STATE();
+    case 443:
+      if (lookahead == 'e') ADVANCE(685);
+      END_STATE();
+    case 444:
+      if (lookahead == 'e') ADVANCE(666);
+      END_STATE();
+    case 445:
+      if (lookahead == 'e') ADVANCE(382);
+      END_STATE();
+    case 446:
+      if (lookahead == 'e') ADVANCE(686);
+      END_STATE();
+    case 447:
+      if (lookahead == 'e') ADVANCE(334);
+      END_STATE();
+    case 448:
+      if (lookahead == 'e') ADVANCE(384);
+      END_STATE();
+    case 449:
+      if (lookahead == 'e') ADVANCE(737);
+      END_STATE();
+    case 450:
+      if (lookahead == 'e') ADVANCE(388);
+      END_STATE();
+    case 451:
+      if (lookahead == 'e') ADVANCE(377);
+      END_STATE();
+    case 452:
+      if (lookahead == 'e') ADVANCE(361);
+      END_STATE();
+    case 453:
+      if (lookahead == 'e') ADVANCE(571);
+      END_STATE();
+    case 454:
+      if (lookahead == 'e') ADVANCE(580);
+      END_STATE();
+    case 455:
+      if (lookahead == 'e') ADVANCE(640);
+      END_STATE();
+    case 456:
+      if (lookahead == 'e') ADVANCE(582);
+      END_STATE();
+    case 457:
+      if (lookahead == 'e') ADVANCE(583);
+      END_STATE();
+    case 458:
+      if (lookahead == 'e') ADVANCE(645);
+      END_STATE();
+    case 459:
+      if (lookahead == 'e') ADVANCE(385);
+      END_STATE();
+    case 460:
+      if (lookahead == 'e') ADVANCE(677);
+      END_STATE();
+    case 461:
+      if (lookahead == 'f') ADVANCE(463);
+      END_STATE();
+    case 462:
+      if (lookahead == 'f') ADVANCE(529);
+      if (lookahead == 't') ADVANCE(488);
+      END_STATE();
+    case 463:
+      if (lookahead == 'f') ADVANCE(487);
+      END_STATE();
+    case 464:
+      if (lookahead == 'f') ADVANCE(495);
+      END_STATE();
+    case 465:
+      if (lookahead == 'f') ADVANCE(626);
+      END_STATE();
+    case 466:
+      if (lookahead == 'f') ADVANCE(496);
+      END_STATE();
+    case 467:
+      if (lookahead == 'g') ADVANCE(904);
+      END_STATE();
+    case 468:
+      if (lookahead == 'g') ADVANCE(672);
+      END_STATE();
+    case 469:
+      if (lookahead == 'g') ADVANCE(389);
+      END_STATE();
+    case 470:
+      if (lookahead == 'g') ADVANCE(698);
+      END_STATE();
+    case 471:
+      if (lookahead == 'g') ADVANCE(621);
+      END_STATE();
+    case 472:
+      if (lookahead == 'g') ADVANCE(421);
+      END_STATE();
+    case 473:
+      if (lookahead == 'g') ADVANCE(333);
+      END_STATE();
+    case 474:
+      if (lookahead == 'g') ADVANCE(203);
+      END_STATE();
+    case 475:
+      if (lookahead == 'h') ADVANCE(173);
+      END_STATE();
+    case 476:
+      if (lookahead == 'h') ADVANCE(620);
+      END_STATE();
+    case 477:
+      if (lookahead == 'h') ADVANCE(614);
+      END_STATE();
+    case 478:
+      if (lookahead == 'h') ADVANCE(627);
+      END_STATE();
+    case 479:
+      if (lookahead == 'h') ADVANCE(162);
+      END_STATE();
+    case 480:
+      if (lookahead == 'h') ADVANCE(418);
+      END_STATE();
+    case 481:
+      if (lookahead == 'h') ADVANCE(428);
+      END_STATE();
+    case 482:
+      if (lookahead == 'h') ADVANCE(600);
+      END_STATE();
+    case 483:
+      if (lookahead == 'i') ADVANCE(211);
+      END_STATE();
+    case 484:
+      if (lookahead == 'i') ADVANCE(777);
+      END_STATE();
+    case 485:
+      if (lookahead == 'i') ADVANCE(543);
+      END_STATE();
+    case 486:
+      if (lookahead == 'i') ADVANCE(371);
+      END_STATE();
+    case 487:
+      if (lookahead == 'i') ADVANCE(357);
+      END_STATE();
+    case 488:
+      if (lookahead == 'i') ADVANCE(572);
+      END_STATE();
+    case 489:
+      if (lookahead == 'i') ADVANCE(700);
+      END_STATE();
+    case 490:
+      if (lookahead == 'i') ADVANCE(532);
+      END_STATE();
+    case 491:
+      if (lookahead == 'i') ADVANCE(341);
+      END_STATE();
+    case 492:
+      if (lookahead == 'i') ADVANCE(367);
+      END_STATE();
+    case 493:
+      if (lookahead == 'i') ADVANCE(313);
+      END_STATE();
+    case 494:
+      if (lookahead == 'i') ADVANCE(688);
+      END_STATE();
+    case 495:
+      if (lookahead == 'i') ADVANCE(398);
+      END_STATE();
+    case 496:
+      if (lookahead == 'i') ADVANCE(310);
+      END_STATE();
+    case 497:
+      if (lookahead == 'i') ADVANCE(559);
+      END_STATE();
+    case 498:
+      if (lookahead == 'i') ADVANCE(699);
+      END_STATE();
+    case 499:
+      if (lookahead == 'i') ADVANCE(417);
+      END_STATE();
+    case 500:
+      if (lookahead == 'i') ADVANCE(358);
+      END_STATE();
+    case 501:
+      if (lookahead == 'i') ADVANCE(663);
+      END_STATE();
+    case 502:
+      if (lookahead == 'i') ADVANCE(464);
+      END_STATE();
+    case 503:
+      if (lookahead == 'i') ADVANCE(355);
+      END_STATE();
+    case 504:
+      if (lookahead == 'i') ADVANCE(323);
+      END_STATE();
+    case 505:
+      if (lookahead == 'i') ADVANCE(549);
+      END_STATE();
+    case 506:
+      if (lookahead == 'i') ADVANCE(534);
+      END_STATE();
+    case 507:
+      if (lookahead == 'i') ADVANCE(658);
+      END_STATE();
+    case 508:
+      if (lookahead == 'i') ADVANCE(761);
+      END_STATE();
+    case 509:
+      if (lookahead == 'i') ADVANCE(603);
+      END_STATE();
+    case 510:
+      if (lookahead == 'i') ADVANCE(360);
+      END_STATE();
+    case 511:
+      if (lookahead == 'i') ADVANCE(671);
+      END_STATE();
+    case 512:
+      if (lookahead == 'i') ADVANCE(533);
+      END_STATE();
+    case 513:
+      if (lookahead == 'i') ADVANCE(605);
+      END_STATE();
+    case 514:
+      if (lookahead == 'i') ADVANCE(616);
+      END_STATE();
+    case 515:
+      if (lookahead == 'i') ADVANCE(607);
+      END_STATE();
+    case 516:
+      if (lookahead == 'i') ADVANCE(599);
+      END_STATE();
+    case 517:
+      if (lookahead == 'i') ADVANCE(338);
+      END_STATE();
+    case 518:
+      if (lookahead == 'i') ADVANCE(740);
+      END_STATE();
+    case 519:
+      if (lookahead == 'i') ADVANCE(739);
+      END_STATE();
+    case 520:
+      if (lookahead == 'i') ADVANCE(457);
+      END_STATE();
+    case 521:
+      if (lookahead == 'k') ADVANCE(398);
+      END_STATE();
+    case 522:
+      if (lookahead == 'k') ADVANCE(198);
+      END_STATE();
+    case 523:
+      if (lookahead == 'l') ADVANCE(770);
+      END_STATE();
+    case 524:
+      if (lookahead == 'l') ADVANCE(703);
+      END_STATE();
+    case 525:
+      if (lookahead == 'l') ADVANCE(625);
+      if (lookahead == 'm') ADVANCE(413);
+      END_STATE();
+    case 526:
+      if (lookahead == 'l') ADVANCE(389);
+      END_STATE();
+    case 527:
+      if (lookahead == 'l') ADVANCE(374);
+      END_STATE();
+    case 528:
+      if (lookahead == 'l') ADVANCE(690);
+      END_STATE();
+    case 529:
+      if (lookahead == 'l') ADVANCE(503);
+      END_STATE();
+    case 530:
+      if (lookahead == 'l') ADVANCE(679);
+      END_STATE();
+    case 531:
+      if (lookahead == 'l') ADVANCE(536);
+      END_STATE();
+    case 532:
+      if (lookahead == 'l') ADVANCE(306);
+      END_STATE();
+    case 533:
+      if (lookahead == 'l') ADVANCE(398);
+      END_STATE();
+    case 534:
+      if (lookahead == 'l') ADVANCE(310);
+      END_STATE();
+    case 535:
+      if (lookahead == 'l') ADVANCE(186);
+      END_STATE();
+    case 536:
+      if (lookahead == 'l') ADVANCE(588);
+      END_STATE();
+    case 537:
+      if (lookahead == 'l') ADVANCE(184);
+      END_STATE();
+    case 538:
+      if (lookahead == 'l') ADVANCE(403);
+      END_STATE();
+    case 539:
+      if (lookahead == 'l') ADVANCE(169);
+      END_STATE();
+    case 540:
+      if (lookahead == 'l') ADVANCE(431);
+      END_STATE();
+    case 541:
+      if (lookahead == 'l') ADVANCE(432);
+      END_STATE();
+    case 542:
+      if (lookahead == 'l') ADVANCE(433);
+      END_STATE();
+    case 543:
+      if (lookahead == 'l') ADVANCE(445);
+      END_STATE();
+    case 544:
+      if (lookahead == 'm') ADVANCE(635);
+      END_STATE();
+    case 545:
+      if (lookahead == 'm') ADVANCE(180);
+      END_STATE();
+    case 546:
+      if (lookahead == 'm') ADVANCE(326);
+      END_STATE();
+    case 547:
+      if (lookahead == 'm') ADVANCE(634);
+      END_STATE();
+    case 548:
+      if (lookahead == 'm') ADVANCE(453);
+      END_STATE();
+    case 549:
+      if (lookahead == 'm') ADVANCE(424);
+      END_STATE();
     case 550:
-      if (lookahead == 'o') ADVANCE(598);
+      if (lookahead == 'm') ADVANCE(332);
       END_STATE();
     case 551:
-      if (lookahead == 'o') ADVANCE(504);
+      if (lookahead == 'm') ADVANCE(344);
       END_STATE();
     case 552:
-      if (lookahead == 'o') ADVANCE(626);
+      if (lookahead == 'n') ADVANCE(904);
       END_STATE();
     case 553:
-      if (lookahead == 'o') ADVANCE(669);
+      if (lookahead == 'n') ADVANCE(462);
       END_STATE();
     case 554:
-      if (lookahead == 'o') ADVANCE(511);
+      if (lookahead == 'n') ADVANCE(470);
       END_STATE();
     case 555:
-      if (lookahead == 'o') ADVANCE(520);
+      if (lookahead == 'n') ADVANCE(368);
       END_STATE();
     case 556:
-      if (lookahead == 'o') ADVANCE(614);
+      if (lookahead == 'n') ADVANCE(472);
       END_STATE();
     case 557:
-      if (lookahead == 'o') ADVANCE(537);
+      if (lookahead == 'n') ADVANCE(465);
       END_STATE();
     case 558:
-      if (lookahead == 'o') ADVANCE(123);
+      if (lookahead == 'n') ADVANCE(474);
       END_STATE();
     case 559:
-      if (lookahead == 'o') ADVANCE(518);
+      if (lookahead == 'n') ADVANCE(467);
       END_STATE();
     case 560:
-      if (lookahead == 'o') ADVANCE(514);
+      if (lookahead == 'n') ADVANCE(389);
       END_STATE();
     case 561:
-      if (lookahead == 'o') ADVANCE(130);
+      if (lookahead == 'n') ADVANCE(351);
       END_STATE();
     case 562:
-      if (lookahead == 'o') ADVANCE(133);
+      if (lookahead == 'n') ADVANCE(679);
       END_STATE();
     case 563:
-      if (lookahead == 'o') ADVANCE(558);
+      if (lookahead == 'n') ADVANCE(695);
       END_STATE();
     case 564:
-      if (lookahead == 'o') ADVANCE(311);
+      if (lookahead == 'n') ADVANCE(309);
       END_STATE();
     case 565:
-      if (lookahead == 'o') ADVANCE(325);
+      if (lookahead == 'n') ADVANCE(704);
       END_STATE();
     case 566:
-      if (lookahead == 'o') ADVANCE(612);
+      if (lookahead == 'n') ADVANCE(162);
       END_STATE();
     case 567:
-      if (lookahead == 'o') ADVANCE(701);
+      if (lookahead == 'n') ADVANCE(735);
       END_STATE();
     case 568:
-      if (lookahead == 'o') ADVANCE(521);
+      if (lookahead == 'n') ADVANCE(164);
       END_STATE();
     case 569:
-      if (lookahead == 'o') ADVANCE(316);
+      if (lookahead == 'n') ADVANCE(166);
       END_STATE();
     case 570:
-      if (lookahead == 'o') ADVANCE(561);
+      if (lookahead == 'n') ADVANCE(429);
       END_STATE();
     case 571:
-      if (lookahead == 'o') ADVANCE(619);
+      if (lookahead == 'n') ADVANCE(708);
       END_STATE();
     case 572:
-      if (lookahead == 'o') ADVANCE(339);
+      if (lookahead == 'n') ADVANCE(747);
       END_STATE();
     case 573:
-      if (lookahead == 'o') ADVANCE(672);
+      if (lookahead == 'n') ADVANCE(372);
       END_STATE();
     case 574:
-      if (lookahead == 'o') ADVANCE(675);
+      if (lookahead == 'n') ADVANCE(713);
       END_STATE();
     case 575:
-      if (lookahead == 'o') ADVANCE(684);
+      if (lookahead == 'n') ADVANCE(329);
       END_STATE();
     case 576:
-      if (lookahead == 'o') ADVANCE(678);
+      if (lookahead == 'n') ADVANCE(721);
       END_STATE();
     case 577:
-      if (lookahead == 'o') ADVANCE(288);
+      if (lookahead == 'n') ADVANCE(381);
       END_STATE();
     case 578:
-      if (lookahead == 'o') ADVANCE(622);
+      if (lookahead == 'n') ADVANCE(714);
       END_STATE();
     case 579:
-      if (lookahead == 'o') ADVANCE(462);
+      if (lookahead == 'n') ADVANCE(776);
       END_STATE();
     case 580:
-      if (lookahead == 'o') ADVANCE(620);
+      if (lookahead == 'n') ADVANCE(379);
       END_STATE();
     case 581:
-      if (lookahead == 'p') ADVANCE(349);
+      if (lookahead == 'n') ADVANCE(719);
       END_STATE();
     case 582:
-      if (lookahead == 'p') ADVANCE(341);
+      if (lookahead == 'n') ADVANCE(734);
       END_STATE();
     case 583:
-      if (lookahead == 'p') ADVANCE(119);
+      if (lookahead == 'n') ADVANCE(724);
       END_STATE();
     case 584:
-      if (lookahead == 'p') ADVANCE(549);
+      if (lookahead == 'n') ADVANCE(456);
       END_STATE();
     case 585:
-      if (lookahead == 'p') ADVANCE(660);
+      if (lookahead == 'n') ADVANCE(207);
       END_STATE();
     case 586:
-      if (lookahead == 'p') ADVANCE(490);
+      if (lookahead == 'o') ADVANCE(553);
+      if (lookahead == 'r') ADVANCE(396);
       END_STATE();
     case 587:
-      if (lookahead == 'p') ADVANCE(544);
+      if (lookahead == 'o') ADVANCE(768);
       END_STATE();
     case 588:
-      if (lookahead == 'p') ADVANCE(548);
+      if (lookahead == 'o') ADVANCE(765);
       END_STATE();
     case 589:
-      if (lookahead == 'p') ADVANCE(663);
+      if (lookahead == 'o') ADVANCE(745);
       END_STATE();
     case 590:
-      if (lookahead == 'p') ADVANCE(588);
+      if (lookahead == 'o') ADVANCE(160);
       END_STATE();
     case 591:
-      if (lookahead == 'p') ADVANCE(406);
+      if (lookahead == 'o') ADVANCE(648);
       END_STATE();
     case 592:
-      if (lookahead == 'p') ADVANCE(580);
+      if (lookahead == 'o') ADVANCE(673);
       END_STATE();
     case 593:
-      if (lookahead == 'p') ADVANCE(592);
+      if (lookahead == 'o') ADVANCE(576);
       END_STATE();
     case 594:
-      if (lookahead == 'q') ADVANCE(702);
-      if (lookahead == 's') ADVANCE(362);
+      if (lookahead == 'o') ADVANCE(577);
       END_STATE();
     case 595:
-      if (lookahead == 'q') ADVANCE(708);
+      if (lookahead == 'o') ADVANCE(530);
       END_STATE();
     case 596:
-      if (lookahead == 'q') ADVANCE(705);
+      if (lookahead == 'o') ADVANCE(678);
       END_STATE();
     case 597:
-      if (lookahead == 'q') ADVANCE(707);
+      if (lookahead == 'o') ADVANCE(695);
       END_STATE();
     case 598:
-      if (lookahead == 'r') ADVANCE(834);
+      if (lookahead == 'o') ADVANCE(646);
       END_STATE();
     case 599:
-      if (lookahead == 'r') ADVANCE(297);
-      if (lookahead == 'u') ADVANCE(507);
+      if (lookahead == 'o') ADVANCE(552);
       END_STATE();
     case 600:
-      if (lookahead == 'r') ADVANCE(474);
+      if (lookahead == 'o') ADVANCE(674);
       END_STATE();
     case 601:
-      if (lookahead == 'r') ADVANCE(443);
+      if (lookahead == 'o') ADVANCE(717);
       END_STATE();
     case 602:
-      if (lookahead == 'r') ADVANCE(498);
+      if (lookahead == 'o') ADVANCE(559);
       END_STATE();
     case 603:
-      if (lookahead == 'r') ADVANCE(387);
+      if (lookahead == 'o') ADVANCE(568);
       END_STATE();
     case 604:
-      if (lookahead == 'r') ADVANCE(681);
-      if (lookahead == 'y') ADVANCE(477);
+      if (lookahead == 'o') ADVANCE(662);
       END_STATE();
     case 605:
-      if (lookahead == 'r') ADVANCE(644);
+      if (lookahead == 'o') ADVANCE(585);
       END_STATE();
     case 606:
-      if (lookahead == 'r') ADVANCE(569);
+      if (lookahead == 'o') ADVANCE(171);
       END_STATE();
     case 607:
-      if (lookahead == 'r') ADVANCE(421);
+      if (lookahead == 'o') ADVANCE(566);
       END_STATE();
     case 608:
-      if (lookahead == 'r') ADVANCE(527);
+      if (lookahead == 'o') ADVANCE(562);
       END_STATE();
     case 609:
-      if (lookahead == 'r') ADVANCE(475);
+      if (lookahead == 'o') ADVANCE(178);
       END_STATE();
     case 610:
-      if (lookahead == 'r') ADVANCE(350);
+      if (lookahead == 'o') ADVANCE(181);
       END_STATE();
     case 611:
-      if (lookahead == 'r') ADVANCE(539);
+      if (lookahead == 'o') ADVANCE(606);
       END_STATE();
     case 612:
-      if (lookahead == 'r') ADVANCE(436);
+      if (lookahead == 'o') ADVANCE(359);
       END_STATE();
     case 613:
-      if (lookahead == 'r') ADVANCE(553);
+      if (lookahead == 'o') ADVANCE(373);
       END_STATE();
     case 614:
-      if (lookahead == 'r') ADVANCE(267);
+      if (lookahead == 'o') ADVANCE(660);
       END_STATE();
     case 615:
-      if (lookahead == 'r') ADVANCE(359);
+      if (lookahead == 'o') ADVANCE(749);
       END_STATE();
     case 616:
-      if (lookahead == 'r') ADVANCE(627);
+      if (lookahead == 'o') ADVANCE(569);
       END_STATE();
     case 617:
-      if (lookahead == 'r') ADVANCE(128);
+      if (lookahead == 'o') ADVANCE(364);
       END_STATE();
     case 618:
-      if (lookahead == 'r') ADVANCE(141);
+      if (lookahead == 'o') ADVANCE(609);
       END_STATE();
     case 619:
-      if (lookahead == 'r') ADVANCE(134);
+      if (lookahead == 'o') ADVANCE(667);
       END_STATE();
     case 620:
-      if (lookahead == 'r') ADVANCE(660);
+      if (lookahead == 'o') ADVANCE(387);
       END_STATE();
     case 621:
-      if (lookahead == 'r') ADVANCE(712);
+      if (lookahead == 'o') ADVANCE(720);
       END_STATE();
     case 622:
-      if (lookahead == 'r') ADVANCE(503);
+      if (lookahead == 'o') ADVANCE(723);
       END_STATE();
     case 623:
-      if (lookahead == 'r') ADVANCE(393);
+      if (lookahead == 'o') ADVANCE(732);
       END_STATE();
     case 624:
-      if (lookahead == 'r') ADVANCE(266);
+      if (lookahead == 'o') ADVANCE(726);
       END_STATE();
     case 625:
-      if (lookahead == 'r') ADVANCE(269);
+      if (lookahead == 'o') ADVANCE(336);
       END_STATE();
     case 626:
-      if (lookahead == 'r') ADVANCE(471);
+      if (lookahead == 'o') ADVANCE(670);
       END_STATE();
     case 627:
-      if (lookahead == 'r') ADVANCE(550);
+      if (lookahead == 'o') ADVANCE(510);
       END_STATE();
     case 628:
-      if (lookahead == 'r') ADVANCE(727);
+      if (lookahead == 'o') ADVANCE(668);
       END_STATE();
     case 629:
-      if (lookahead == 'r') ADVANCE(502);
+      if (lookahead == 'p') ADVANCE(397);
       END_STATE();
     case 630:
-      if (lookahead == 'r') ADVANCE(693);
+      if (lookahead == 'p') ADVANCE(389);
       END_STATE();
     case 631:
-      if (lookahead == 's') ADVANCE(834);
+      if (lookahead == 'p') ADVANCE(167);
       END_STATE();
     case 632:
-      if (lookahead == 's') ADVANCE(696);
-      if (lookahead == 't') ADVANCE(358);
+      if (lookahead == 'p') ADVANCE(597);
       END_STATE();
     case 633:
-      if (lookahead == 's') ADVANCE(322);
+      if (lookahead == 'p') ADVANCE(708);
       END_STATE();
     case 634:
-      if (lookahead == 's') ADVANCE(639);
+      if (lookahead == 'p') ADVANCE(538);
       END_STATE();
     case 635:
-      if (lookahead == 's') ADVANCE(646);
+      if (lookahead == 'p') ADVANCE(592);
       END_STATE();
     case 636:
-      if (lookahead == 's') ADVANCE(350);
+      if (lookahead == 'p') ADVANCE(596);
       END_STATE();
     case 637:
-      if (lookahead == 's') ADVANCE(647);
+      if (lookahead == 'p') ADVANCE(711);
       END_STATE();
     case 638:
-      if (lookahead == 's') ADVANCE(658);
+      if (lookahead == 'p') ADVANCE(636);
       END_STATE();
     case 639:
-      if (lookahead == 's') ADVANCE(449);
+      if (lookahead == 'p') ADVANCE(454);
       END_STATE();
     case 640:
-      if (lookahead == 's') ADVANCE(418);
+      if (lookahead == 'p') ADVANCE(628);
       END_STATE();
     case 641:
-      if (lookahead == 's') ADVANCE(668);
+      if (lookahead == 'p') ADVANCE(640);
       END_STATE();
     case 642:
-      if (lookahead == 's') ADVANCE(562);
+      if (lookahead == 'q') ADVANCE(750);
+      if (lookahead == 's') ADVANCE(410);
       END_STATE();
     case 643:
-      if (lookahead == 's') ADVANCE(560);
+      if (lookahead == 'q') ADVANCE(756);
       END_STATE();
     case 644:
-      if (lookahead == 's') ADVANCE(465);
+      if (lookahead == 'q') ADVANCE(753);
       END_STATE();
     case 645:
-      if (lookahead == 's') ADVANCE(157);
+      if (lookahead == 'q') ADVANCE(755);
       END_STATE();
     case 646:
-      if (lookahead == 's') ADVANCE(294);
+      if (lookahead == 'r') ADVANCE(904);
       END_STATE();
     case 647:
-      if (lookahead == 't') ADVANCE(834);
+      if (lookahead == 'r') ADVANCE(345);
+      if (lookahead == 'u') ADVANCE(555);
       END_STATE();
     case 648:
-      if (lookahead == 't') ADVANCE(428);
+      if (lookahead == 'r') ADVANCE(522);
       END_STATE();
     case 649:
-      if (lookahead == 't') ADVANCE(715);
+      if (lookahead == 'r') ADVANCE(491);
       END_STATE();
     case 650:
-      if (lookahead == 't') ADVANCE(431);
+      if (lookahead == 'r') ADVANCE(546);
       END_STATE();
     case 651:
-      if (lookahead == 't') ADVANCE(722);
+      if (lookahead == 'r') ADVANCE(435);
       END_STATE();
     case 652:
-      if (lookahead == 't') ADVANCE(305);
+      if (lookahead == 'r') ADVANCE(729);
+      if (lookahead == 'y') ADVANCE(525);
       END_STATE();
     case 653:
-      if (lookahead == 't') ADVANCE(432);
+      if (lookahead == 'r') ADVANCE(692);
       END_STATE();
     case 654:
-      if (lookahead == 't') ADVANCE(347);
+      if (lookahead == 'r') ADVANCE(617);
       END_STATE();
     case 655:
-      if (lookahead == 't') ADVANCE(435);
+      if (lookahead == 'r') ADVANCE(469);
       END_STATE();
     case 656:
-      if (lookahead == 't') ADVANCE(475);
+      if (lookahead == 'r') ADVANCE(575);
       END_STATE();
     case 657:
-      if (lookahead == 't') ADVANCE(700);
+      if (lookahead == 'r') ADVANCE(523);
       END_STATE();
     case 658:
-      if (lookahead == 't') ADVANCE(631);
+      if (lookahead == 'r') ADVANCE(398);
       END_STATE();
     case 659:
-      if (lookahead == 't') ADVANCE(280);
+      if (lookahead == 'r') ADVANCE(587);
       END_STATE();
     case 660:
-      if (lookahead == 't') ADVANCE(350);
+      if (lookahead == 'r') ADVANCE(484);
       END_STATE();
     case 661:
-      if (lookahead == 't') ADVANCE(461);
+      if (lookahead == 'r') ADVANCE(601);
       END_STATE();
     case 662:
-      if (lookahead == 't') ADVANCE(273);
+      if (lookahead == 'r') ADVANCE(315);
       END_STATE();
     case 663:
-      if (lookahead == 't') ADVANCE(262);
+      if (lookahead == 'r') ADVANCE(407);
       END_STATE();
     case 664:
-      if (lookahead == 't') ADVANCE(138);
+      if (lookahead == 'r') ADVANCE(675);
       END_STATE();
     case 665:
-      if (lookahead == 't') ADVANCE(114);
+      if (lookahead == 'r') ADVANCE(176);
       END_STATE();
     case 666:
-      if (lookahead == 't') ADVANCE(444);
+      if (lookahead == 'r') ADVANCE(189);
       END_STATE();
     case 667:
-      if (lookahead == 't') ADVANCE(446);
+      if (lookahead == 'r') ADVANCE(182);
       END_STATE();
     case 668:
-      if (lookahead == 't') ADVANCE(115);
+      if (lookahead == 'r') ADVANCE(708);
       END_STATE();
     case 669:
-      if (lookahead == 't') ADVANCE(564);
+      if (lookahead == 'r') ADVANCE(760);
       END_STATE();
     case 670:
-      if (lookahead == 't') ADVANCE(460);
+      if (lookahead == 'r') ADVANCE(551);
       END_STATE();
     case 671:
-      if (lookahead == 't') ADVANCE(135);
+      if (lookahead == 'r') ADVANCE(441);
       END_STATE();
     case 672:
-      if (lookahead == 't') ADVANCE(469);
+      if (lookahead == 'r') ADVANCE(314);
       END_STATE();
     case 673:
-      if (lookahead == 't') ADVANCE(372);
+      if (lookahead == 'r') ADVANCE(317);
       END_STATE();
     case 674:
-      if (lookahead == 't') ADVANCE(375);
+      if (lookahead == 'r') ADVANCE(519);
       END_STATE();
     case 675:
-      if (lookahead == 't') ADVANCE(140);
+      if (lookahead == 'r') ADVANCE(598);
       END_STATE();
     case 676:
-      if (lookahead == 't') ADVANCE(151);
+      if (lookahead == 'r') ADVANCE(775);
       END_STATE();
     case 677:
-      if (lookahead == 't') ADVANCE(366);
+      if (lookahead == 'r') ADVANCE(550);
       END_STATE();
     case 678:
-      if (lookahead == 't') ADVANCE(144);
+      if (lookahead == 'r') ADVANCE(741);
       END_STATE();
     case 679:
-      if (lookahead == 't') ADVANCE(368);
+      if (lookahead == 's') ADVANCE(904);
       END_STATE();
     case 680:
-      if (lookahead == 't') ADVANCE(429);
+      if (lookahead == 's') ADVANCE(744);
+      if (lookahead == 't') ADVANCE(406);
       END_STATE();
     case 681:
-      if (lookahead == 't') ADVANCE(445);
+      if (lookahead == 's') ADVANCE(370);
       END_STATE();
     case 682:
-      if (lookahead == 't') ADVANCE(433);
+      if (lookahead == 's') ADVANCE(687);
       END_STATE();
     case 683:
-      if (lookahead == 't') ADVANCE(392);
+      if (lookahead == 's') ADVANCE(694);
       END_STATE();
     case 684:
-      if (lookahead == 't') ADVANCE(152);
+      if (lookahead == 's') ADVANCE(398);
       END_STATE();
     case 685:
-      if (lookahead == 't') ADVANCE(434);
+      if (lookahead == 's') ADVANCE(695);
       END_STATE();
     case 686:
-      if (lookahead == 't') ADVANCE(153);
+      if (lookahead == 's') ADVANCE(706);
       END_STATE();
     case 687:
-      if (lookahead == 't') ADVANCE(450);
+      if (lookahead == 's') ADVANCE(497);
       END_STATE();
     case 688:
-      if (lookahead == 't') ADVANCE(556);
+      if (lookahead == 's') ADVANCE(466);
       END_STATE();
     case 689:
-      if (lookahead == 't') ADVANCE(404);
+      if (lookahead == 's') ADVANCE(716);
       END_STATE();
     case 690:
-      if (lookahead == 't') ADVANCE(402);
+      if (lookahead == 's') ADVANCE(610);
       END_STATE();
     case 691:
-      if (lookahead == 't') ADVANCE(289);
+      if (lookahead == 's') ADVANCE(608);
       END_STATE();
     case 692:
-      if (lookahead == 't') ADVANCE(466);
+      if (lookahead == 's') ADVANCE(513);
       END_STATE();
     case 693:
-      if (lookahead == 't') ADVANCE(403);
+      if (lookahead == 's') ADVANCE(205);
       END_STATE();
     case 694:
-      if (lookahead == 't') ADVANCE(467);
+      if (lookahead == 's') ADVANCE(342);
       END_STATE();
     case 695:
-      if (lookahead == 't') ADVANCE(468);
+      if (lookahead == 't') ADVANCE(904);
       END_STATE();
     case 696:
-      if (lookahead == 'u') ADVANCE(413);
+      if (lookahead == 't') ADVANCE(476);
       END_STATE();
     case 697:
-      if (lookahead == 'u') ADVANCE(507);
+      if (lookahead == 't') ADVANCE(763);
       END_STATE();
     case 698:
-      if (lookahead == 'u') ADVANCE(590);
+      if (lookahead == 't') ADVANCE(479);
       END_STATE();
     case 699:
-      if (lookahead == 'u') ADVANCE(341);
+      if (lookahead == 't') ADVANCE(770);
       END_STATE();
     case 700:
-      if (lookahead == 'u') ADVANCE(631);
+      if (lookahead == 't') ADVANCE(353);
       END_STATE();
     case 701:
-      if (lookahead == 'u') ADVANCE(647);
+      if (lookahead == 't') ADVANCE(480);
       END_STATE();
     case 702:
-      if (lookahead == 'u') ADVANCE(356);
+      if (lookahead == 't') ADVANCE(395);
       END_STATE();
     case 703:
-      if (lookahead == 'u') ADVANCE(680);
-      if (lookahead == 'v') ADVANCE(276);
+      if (lookahead == 't') ADVANCE(483);
       END_STATE();
     case 704:
-      if (lookahead == 'u') ADVANCE(682);
+      if (lookahead == 't') ADVANCE(523);
       END_STATE();
     case 705:
-      if (lookahead == 'u') ADVANCE(395);
+      if (lookahead == 't') ADVANCE(748);
       END_STATE();
     case 706:
-      if (lookahead == 'u') ADVANCE(685);
+      if (lookahead == 't') ADVANCE(679);
       END_STATE();
     case 707:
-      if (lookahead == 'u') ADVANCE(398);
+      if (lookahead == 't') ADVANCE(328);
       END_STATE();
     case 708:
-      if (lookahead == 'u') ADVANCE(459);
+      if (lookahead == 't') ADVANCE(398);
       END_STATE();
     case 709:
-      if (lookahead == 'u') ADVANCE(593);
+      if (lookahead == 't') ADVANCE(509);
       END_STATE();
     case 710:
-      if (lookahead == 'v') ADVANCE(452);
+      if (lookahead == 't') ADVANCE(321);
       END_STATE();
     case 711:
-      if (lookahead == 'v') ADVANCE(388);
+      if (lookahead == 't') ADVANCE(310);
       END_STATE();
     case 712:
-      if (lookahead == 'v') ADVANCE(396);
+      if (lookahead == 't') ADVANCE(186);
       END_STATE();
     case 713:
-      if (lookahead == 'v') ADVANCE(386);
+      if (lookahead == 't') ADVANCE(162);
       END_STATE();
     case 714:
-      if (lookahead == 'v') ADVANCE(282);
+      if (lookahead == 't') ADVANCE(492);
       END_STATE();
     case 715:
-      if (lookahead == 'w') ADVANCE(543);
+      if (lookahead == 't') ADVANCE(494);
       END_STATE();
     case 716:
-      if (lookahead == 'w') ADVANCE(283);
+      if (lookahead == 't') ADVANCE(163);
       END_STATE();
     case 717:
-      if (lookahead == 'w') ADVANCE(350);
+      if (lookahead == 't') ADVANCE(612);
       END_STATE();
     case 718:
-      if (lookahead == 'w') ADVANCE(259);
+      if (lookahead == 't') ADVANCE(508);
       END_STATE();
     case 719:
-      if (lookahead == 'x') ADVANCE(581);
+      if (lookahead == 't') ADVANCE(183);
       END_STATE();
     case 720:
-      if (lookahead == 'x') ADVANCE(722);
+      if (lookahead == 't') ADVANCE(517);
       END_STATE();
     case 721:
-      if (lookahead == 'x') ADVANCE(674);
+      if (lookahead == 't') ADVANCE(420);
       END_STATE();
     case 722:
-      if (lookahead == 'y') ADVANCE(834);
+      if (lookahead == 't') ADVANCE(423);
       END_STATE();
     case 723:
-      if (lookahead == 'y') ADVANCE(150);
+      if (lookahead == 't') ADVANCE(188);
       END_STATE();
     case 724:
-      if (lookahead == 'y') ADVANCE(145);
+      if (lookahead == 't') ADVANCE(199);
       END_STATE();
     case 725:
-      if (lookahead == 'y') ADVANCE(148);
+      if (lookahead == 't') ADVANCE(414);
       END_STATE();
     case 726:
-      if (lookahead == 'y') ADVANCE(582);
+      if (lookahead == 't') ADVANCE(192);
       END_STATE();
     case 727:
-      if (lookahead == 'y') ADVANCE(153);
+      if (lookahead == 't') ADVANCE(416);
       END_STATE();
     case 728:
-      if (lookahead == 'y') ADVANCE(154);
+      if (lookahead == 't') ADVANCE(477);
       END_STATE();
     case 729:
-      if (lookahead == 'z') ADVANCE(350);
+      if (lookahead == 't') ADVANCE(493);
       END_STATE();
     case 730:
-      if (lookahead == '}') ADVANCE(839);
+      if (lookahead == 't') ADVANCE(481);
       END_STATE();
     case 731:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(833);
+      if (lookahead == 't') ADVANCE(440);
       END_STATE();
     case 732:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(731);
+      if (lookahead == 't') ADVANCE(200);
       END_STATE();
     case 733:
-      if (lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9')) ADVANCE(832);
+      if (lookahead == 't') ADVANCE(482);
       END_STATE();
     case 734:
-      if (eof) ADVANCE(740);
-      ADVANCE_MAP(
-        0, 869,
-        '\n', 869,
-        '\r', 870,
-        '#', 816,
-        '-', 789,
-        '/', 790,
-        '<', 861,
-        '>', 842,
-        '@', 846,
-        'C', 748,
-        'D', 743,
-        'G', 744,
-        'H', 746,
-        'L', 747,
-        'O', 749,
-        'P', 742,
-        'T', 750,
-        'W', 745,
-        '[', 788,
-        'm', 751,
-        'q', 752,
-        '{', 787,
-        0x2028, 48,
-        0x2029, 48,
-      );
-      if (lookahead == ' ' ||
-          lookahead == 0xa0 ||
-          lookahead == 0x1680 ||
-          (0x2000 <= lookahead && lookahead <= 0x200a) ||
-          lookahead == 0x202f ||
-          lookahead == 0x205f ||
-          lookahead == 0x3000) ADVANCE(806);
-      if (set_contains(aux_sym_WORD_CHAR_token1_character_set_1, 476, lookahead)) ADVANCE(753);
-      if (lookahead != 0) ADVANCE(791);
+      if (lookahead == 't') ADVANCE(201);
       END_STATE();
     case 735:
-      if (eof) ADVANCE(740);
-      ADVANCE_MAP(
-        0, 786,
-        '\n', 911,
-        '\r', 912,
-        '#', 818,
-        '/', 801,
-        '<', 840,
-        '@', 845,
-        'C', 779,
-        'D', 768,
-        'G', 769,
-        'H', 774,
-        'L', 777,
-        'O', 782,
-        'P', 767,
-        'T', 783,
-        'W', 770,
-        '{', 802,
-        '-', 804,
-        '_', 804,
-      );
-      if (lookahead == ' ' ||
-          lookahead == 0xa0 ||
-          lookahead == 0x1680 ||
-          (0x2000 <= lookahead && lookahead <= 0x200a) ||
-          lookahead == 0x202f ||
-          lookahead == 0x205f ||
-          lookahead == 0x3000) ADVANCE(809);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(785);
-      if (set_contains(aux_sym_WORD_CHAR_token1_character_set_1, 476, lookahead)) ADVANCE(741);
-      if (lookahead != 0 &&
-          lookahead != 0x2028 &&
-          lookahead != 0x2029) ADVANCE(786);
+      if (lookahead == 't') ADVANCE(498);
       END_STATE();
     case 736:
-      if (eof) ADVANCE(740);
-      ADVANCE_MAP(
-        0, 786,
-        '\n', 911,
-        '\r', 912,
-        '#', 818,
-        '/', 801,
-        '<', 840,
-        '@', 845,
-        'C', 779,
-        'D', 768,
-        'G', 769,
-        'H', 775,
-        'L', 777,
-        'O', 782,
-        'P', 767,
-        'T', 783,
-        'W', 770,
-        '{', 802,
-        '-', 804,
-        '_', 804,
-      );
-      if (lookahead == ' ' ||
-          lookahead == 0xa0 ||
-          lookahead == 0x1680 ||
-          (0x2000 <= lookahead && lookahead <= 0x200a) ||
-          lookahead == 0x202f ||
-          lookahead == 0x205f ||
-          lookahead == 0x3000) ADVANCE(809);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(785);
-      if (set_contains(aux_sym_WORD_CHAR_token1_character_set_1, 476, lookahead)) ADVANCE(741);
-      if (lookahead != 0 &&
-          lookahead != 0x2028 &&
-          lookahead != 0x2029) ADVANCE(786);
+      if (lookahead == 't') ADVANCE(604);
       END_STATE();
     case 737:
-      if (eof) ADVANCE(740);
-      ADVANCE_MAP(
-        0, 786,
-        '\n', 911,
-        '\r', 912,
-        '#', 818,
-        '/', 801,
-        '<', 840,
-        '@', 845,
-        'C', 780,
-        'D', 771,
-        'G', 772,
-        'H', 776,
-        'L', 778,
-        'O', 781,
-        'P', 766,
-        'T', 784,
-        'W', 773,
-        '{', 802,
-      );
-      if (lookahead == ' ' ||
-          lookahead == 0xa0 ||
-          lookahead == 0x1680 ||
-          (0x2000 <= lookahead && lookahead <= 0x200a) ||
-          lookahead == 0x202f ||
-          lookahead == 0x205f ||
-          lookahead == 0x3000) ADVANCE(809);
-      if (set_contains(aux_sym_WORD_CHAR_token1_character_set_1, 476, lookahead)) ADVANCE(741);
-      if (lookahead != 0 &&
-          lookahead != 0x2028 &&
-          lookahead != 0x2029) ADVANCE(786);
+      if (lookahead == 't') ADVANCE(452);
       END_STATE();
     case 738:
-      if (eof) ADVANCE(740);
-      ADVANCE_MAP(
-        0, 867,
-        '\n', 866,
-        '\r', 867,
-        '#', 816,
-        '-', 789,
-        '/', 790,
-        '<', 861,
-        '>', 842,
-        '@', 846,
-        'C', 748,
-        'D', 743,
-        'G', 744,
-        'H', 746,
-        'L', 747,
-        'O', 749,
-        'P', 742,
-        'T', 750,
-        'W', 745,
-        '[', 788,
-        'm', 751,
-        'q', 752,
-        '{', 787,
-        0x2028, 48,
-        0x2029, 48,
-      );
-      if (lookahead == ' ' ||
-          lookahead == 0xa0 ||
-          lookahead == 0x1680 ||
-          (0x2000 <= lookahead && lookahead <= 0x200a) ||
-          lookahead == 0x202f ||
-          lookahead == 0x205f ||
-          lookahead == 0x3000) ADVANCE(806);
-      if (set_contains(aux_sym_WORD_CHAR_token1_character_set_1, 476, lookahead)) ADVANCE(753);
-      if (lookahead != 0) ADVANCE(791);
+      if (lookahead == 't') ADVANCE(450);
       END_STATE();
     case 739:
-      if (eof) ADVANCE(740);
+      if (lookahead == 't') ADVANCE(337);
+      END_STATE();
+    case 740:
+      if (lookahead == 't') ADVANCE(514);
+      END_STATE();
+    case 741:
+      if (lookahead == 't') ADVANCE(451);
+      END_STATE();
+    case 742:
+      if (lookahead == 't') ADVANCE(515);
+      END_STATE();
+    case 743:
+      if (lookahead == 't') ADVANCE(516);
+      END_STATE();
+    case 744:
+      if (lookahead == 'u') ADVANCE(461);
+      END_STATE();
+    case 745:
+      if (lookahead == 'u') ADVANCE(555);
+      END_STATE();
+    case 746:
+      if (lookahead == 'u') ADVANCE(638);
+      END_STATE();
+    case 747:
+      if (lookahead == 'u') ADVANCE(389);
+      END_STATE();
+    case 748:
+      if (lookahead == 'u') ADVANCE(679);
+      END_STATE();
+    case 749:
+      if (lookahead == 'u') ADVANCE(695);
+      END_STATE();
+    case 750:
+      if (lookahead == 'u') ADVANCE(404);
+      END_STATE();
+    case 751:
+      if (lookahead == 'u') ADVANCE(728);
+      if (lookahead == 'v') ADVANCE(324);
+      END_STATE();
+    case 752:
+      if (lookahead == 'u') ADVANCE(730);
+      END_STATE();
+    case 753:
+      if (lookahead == 'u') ADVANCE(443);
+      END_STATE();
+    case 754:
+      if (lookahead == 'u') ADVANCE(733);
+      END_STATE();
+    case 755:
+      if (lookahead == 'u') ADVANCE(446);
+      END_STATE();
+    case 756:
+      if (lookahead == 'u') ADVANCE(507);
+      END_STATE();
+    case 757:
+      if (lookahead == 'u') ADVANCE(641);
+      END_STATE();
+    case 758:
+      if (lookahead == 'v') ADVANCE(500);
+      END_STATE();
+    case 759:
+      if (lookahead == 'v') ADVANCE(436);
+      END_STATE();
+    case 760:
+      if (lookahead == 'v') ADVANCE(444);
+      END_STATE();
+    case 761:
+      if (lookahead == 'v') ADVANCE(434);
+      END_STATE();
+    case 762:
+      if (lookahead == 'v') ADVANCE(330);
+      END_STATE();
+    case 763:
+      if (lookahead == 'w') ADVANCE(591);
+      END_STATE();
+    case 764:
+      if (lookahead == 'w') ADVANCE(331);
+      END_STATE();
+    case 765:
+      if (lookahead == 'w') ADVANCE(398);
+      END_STATE();
+    case 766:
+      if (lookahead == 'w') ADVANCE(307);
+      END_STATE();
+    case 767:
+      if (lookahead == 'x') ADVANCE(629);
+      END_STATE();
+    case 768:
+      if (lookahead == 'x') ADVANCE(770);
+      END_STATE();
+    case 769:
+      if (lookahead == 'x') ADVANCE(722);
+      END_STATE();
+    case 770:
+      if (lookahead == 'y') ADVANCE(904);
+      END_STATE();
+    case 771:
+      if (lookahead == 'y') ADVANCE(198);
+      END_STATE();
+    case 772:
+      if (lookahead == 'y') ADVANCE(193);
+      END_STATE();
+    case 773:
+      if (lookahead == 'y') ADVANCE(196);
+      END_STATE();
+    case 774:
+      if (lookahead == 'y') ADVANCE(630);
+      END_STATE();
+    case 775:
+      if (lookahead == 'y') ADVANCE(201);
+      END_STATE();
+    case 776:
+      if (lookahead == 'y') ADVANCE(202);
+      END_STATE();
+    case 777:
+      if (lookahead == 'z') ADVANCE(398);
+      END_STATE();
+    case 778:
+      if (lookahead == '}') ADVANCE(910);
+      END_STATE();
+    case 779:
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(903);
+      END_STATE();
+    case 780:
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(779);
+      END_STATE();
+    case 781:
+      if (lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9')) ADVANCE(902);
+      END_STATE();
+    case 782:
+      if (eof) ADVANCE(789);
       ADVANCE_MAP(
-        0, 851,
-        '\n', 850,
-        '\r', 851,
-        '#', 814,
-        '-', 792,
-        '/', 793,
-        '<', 862,
-        '>', 842,
-        '@', 847,
-        'C', 760,
-        'D', 756,
-        'G', 757,
-        'H', 758,
-        'L', 759,
-        'O', 761,
-        'P', 754,
-        'T', 762,
-        'W', 755,
-        '[', 796,
-        'm', 764,
-        'q', 763,
-        '{', 795,
+        0, 943,
+        '\n', 943,
+        '\r', 944,
+        '#', 885,
+        '-', 855,
+        '/', 856,
+        '<', 935,
+        '>', 913,
+        '@', 918,
+        'C', 809,
+        'D', 805,
+        'G', 806,
+        'H', 807,
+        'L', 808,
+        'O', 810,
+        'P', 803,
+        'T', 811,
+        'W', 804,
+        '[', 854,
+        'm', 813,
+        'q', 812,
+        '{', 853,
         0x2028, 96,
         0x2029, 96,
       );
@@ -4373,530 +4546,907 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           (0x2000 <= lookahead && lookahead <= 0x200a) ||
           lookahead == 0x202f ||
           lookahead == 0x205f ||
-          lookahead == 0x3000) ADVANCE(807);
-      if (set_contains(aux_sym_WORD_CHAR_token1_character_set_1, 476, lookahead)) ADVANCE(765);
-      if (lookahead != 0) ADVANCE(794);
+          lookahead == 0x3000) ADVANCE(873);
+      if (set_contains(aux_sym_WORD_CHAR_token1_character_set_1, 475, lookahead)) ADVANCE(814);
+      if (lookahead != 0) ADVANCE(857);
       END_STATE();
-    case 740:
+    case 783:
+      if (eof) ADVANCE(789);
+      ADVANCE_MAP(
+        0, 847,
+        '\n', 988,
+        '\r', 989,
+        '#', 887,
+        '/', 867,
+        '<', 911,
+        '@', 916,
+        'C', 840,
+        'D', 829,
+        'G', 830,
+        'H', 835,
+        'L', 838,
+        'O', 843,
+        'P', 828,
+        'T', 844,
+        'W', 831,
+        '{', 868,
+        '-', 870,
+        '_', 870,
+      );
+      if (lookahead == ' ' ||
+          lookahead == 0xa0 ||
+          lookahead == 0x1680 ||
+          (0x2000 <= lookahead && lookahead <= 0x200a) ||
+          lookahead == 0x202f ||
+          lookahead == 0x205f ||
+          lookahead == 0x3000) ADVANCE(876);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(846);
+      if (set_contains(aux_sym_WORD_CHAR_token1_character_set_1, 475, lookahead)) ADVANCE(790);
+      if (lookahead != 0 &&
+          lookahead != 0x2028 &&
+          lookahead != 0x2029) ADVANCE(847);
+      END_STATE();
+    case 784:
+      if (eof) ADVANCE(789);
+      ADVANCE_MAP(
+        0, 847,
+        '\n', 988,
+        '\r', 989,
+        '#', 887,
+        '/', 867,
+        '<', 911,
+        '@', 916,
+        'C', 840,
+        'D', 829,
+        'G', 830,
+        'H', 836,
+        'L', 838,
+        'O', 843,
+        'P', 828,
+        'T', 844,
+        'W', 831,
+        '{', 868,
+        '-', 870,
+        '_', 870,
+      );
+      if (lookahead == ' ' ||
+          lookahead == 0xa0 ||
+          lookahead == 0x1680 ||
+          (0x2000 <= lookahead && lookahead <= 0x200a) ||
+          lookahead == 0x202f ||
+          lookahead == 0x205f ||
+          lookahead == 0x3000) ADVANCE(876);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(846);
+      if (set_contains(aux_sym_WORD_CHAR_token1_character_set_1, 475, lookahead)) ADVANCE(790);
+      if (lookahead != 0 &&
+          lookahead != 0x2028 &&
+          lookahead != 0x2029) ADVANCE(847);
+      END_STATE();
+    case 785:
+      if (eof) ADVANCE(789);
+      ADVANCE_MAP(
+        0, 847,
+        '\n', 988,
+        '\r', 989,
+        '#', 887,
+        '/', 867,
+        '<', 911,
+        '@', 916,
+        'C', 841,
+        'D', 832,
+        'G', 833,
+        'H', 837,
+        'L', 839,
+        'O', 842,
+        'P', 827,
+        'T', 845,
+        'W', 834,
+        '{', 868,
+      );
+      if (lookahead == ' ' ||
+          lookahead == 0xa0 ||
+          lookahead == 0x1680 ||
+          (0x2000 <= lookahead && lookahead <= 0x200a) ||
+          lookahead == 0x202f ||
+          lookahead == 0x205f ||
+          lookahead == 0x3000) ADVANCE(876);
+      if (set_contains(aux_sym_WORD_CHAR_token1_character_set_1, 475, lookahead)) ADVANCE(790);
+      if (lookahead != 0 &&
+          lookahead != 0x2028 &&
+          lookahead != 0x2029) ADVANCE(847);
+      END_STATE();
+    case 786:
+      if (eof) ADVANCE(789);
+      ADVANCE_MAP(
+        0, 852,
+        '\n', 877,
+        '\r', 878,
+        '#', 884,
+        '-', 850,
+        '/', 851,
+        '<', 935,
+        '>', 913,
+        '@', 917,
+        'C', 797,
+        'D', 792,
+        'G', 793,
+        'H', 795,
+        'L', 796,
+        'O', 798,
+        'P', 791,
+        'T', 799,
+        'W', 794,
+        '[', 849,
+        'm', 800,
+        'q', 801,
+        '{', 848,
+        0x2028, 48,
+        0x2029, 48,
+      );
+      if (lookahead == ' ' ||
+          lookahead == 0xa0 ||
+          lookahead == 0x1680 ||
+          (0x2000 <= lookahead && lookahead <= 0x200a) ||
+          lookahead == 0x202f ||
+          lookahead == 0x205f ||
+          lookahead == 0x3000) ADVANCE(872);
+      if (set_contains(aux_sym_WORD_CHAR_token1_character_set_1, 475, lookahead)) ADVANCE(802);
+      if (lookahead != 0) ADVANCE(852);
+      END_STATE();
+    case 787:
+      if (eof) ADVANCE(789);
+      ADVANCE_MAP(
+        0, 941,
+        '\n', 940,
+        '\r', 941,
+        '#', 885,
+        '-', 855,
+        '/', 856,
+        '<', 935,
+        '>', 913,
+        '@', 918,
+        'C', 809,
+        'D', 805,
+        'G', 806,
+        'H', 807,
+        'L', 808,
+        'O', 810,
+        'P', 803,
+        'T', 811,
+        'W', 804,
+        '[', 854,
+        'm', 813,
+        'q', 812,
+        '{', 853,
+        0x2028, 96,
+        0x2029, 96,
+      );
+      if (lookahead == ' ' ||
+          lookahead == 0xa0 ||
+          lookahead == 0x1680 ||
+          (0x2000 <= lookahead && lookahead <= 0x200a) ||
+          lookahead == 0x202f ||
+          lookahead == 0x205f ||
+          lookahead == 0x3000) ADVANCE(873);
+      if (set_contains(aux_sym_WORD_CHAR_token1_character_set_1, 475, lookahead)) ADVANCE(814);
+      if (lookahead != 0) ADVANCE(857);
+      END_STATE();
+    case 788:
+      if (eof) ADVANCE(789);
+      ADVANCE_MAP(
+        0, 923,
+        '\n', 922,
+        '\r', 923,
+        '#', 882,
+        '-', 858,
+        '/', 859,
+        '<', 936,
+        '>', 913,
+        '@', 919,
+        'C', 821,
+        'D', 817,
+        'G', 819,
+        'H', 818,
+        'L', 820,
+        'O', 822,
+        'P', 815,
+        'T', 823,
+        'W', 816,
+        '[', 862,
+        'm', 825,
+        'q', 824,
+        '{', 861,
+        0x2028, 143,
+        0x2029, 143,
+      );
+      if (lookahead == ' ' ||
+          lookahead == 0xa0 ||
+          lookahead == 0x1680 ||
+          (0x2000 <= lookahead && lookahead <= 0x200a) ||
+          lookahead == 0x202f ||
+          lookahead == 0x205f ||
+          lookahead == 0x3000) ADVANCE(874);
+      if (set_contains(aux_sym_WORD_CHAR_token1_character_set_1, 475, lookahead)) ADVANCE(826);
+      if (lookahead != 0) ADVANCE(860);
+      END_STATE();
+    case 789:
       ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
-    case 741:
+    case 790:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
       END_STATE();
-    case 742:
+    case 791:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'A') ADVANCE(36);
       if (lookahead == 'O') ADVANCE(31);
       if (lookahead == 'U') ADVANCE(34);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
-    case 743:
+    case 792:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'E') ADVANCE(22);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
-    case 744:
+    case 793:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'E') ADVANCE(34);
       if (lookahead == 'R') ADVANCE(5);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
-    case 745:
+    case 794:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'E') ADVANCE(8);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
-    case 746:
+    case 795:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'E') ADVANCE(6);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
-    case 747:
+    case 796:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'I') ADVANCE(31);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
-    case 748:
+    case 797:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'O') ADVANCE(24);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
-    case 749:
+    case 798:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'P') ADVANCE(35);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
-    case 750:
+    case 799:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'R') ADVANCE(7);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
-    case 751:
+    case 800:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'u') ADVANCE(44);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
-    case 752:
+    case 801:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == 'u') ADVANCE(39);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
-    case 753:
+    case 802:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
-    case 754:
+    case 803:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'A') ADVANCE(84);
       if (lookahead == 'O') ADVANCE(81);
       if (lookahead == 'U') ADVANCE(82);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
-    case 755:
+    case 804:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'E') ADVANCE(56);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
-    case 756:
+    case 805:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'E') ADVANCE(71);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
-    case 757:
+    case 806:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'E') ADVANCE(82);
       if (lookahead == 'R') ADVANCE(53);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
-    case 758:
+    case 807:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'E') ADVANCE(54);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
-    case 759:
+    case 808:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'I') ADVANCE(81);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
-    case 760:
+    case 809:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'O') ADVANCE(72);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
-    case 761:
+    case 810:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'P') ADVANCE(83);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
-    case 762:
+    case 811:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'R') ADVANCE(55);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
-    case 763:
+    case 812:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'u') ADVANCE(87);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
-    case 764:
+    case 813:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == 'u') ADVANCE(92);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
-    case 765:
+    case 814:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
-    case 766:
+    case 815:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if (lookahead == 'A') ADVANCE(241);
-      if (lookahead == 'O') ADVANCE(231);
-      if (lookahead == 'U') ADVANCE(239);
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'A') ADVANCE(131);
+      if (lookahead == 'O') ADVANCE(128);
+      if (lookahead == 'U') ADVANCE(129);
+      if (lookahead != 0) ADVANCE(143);
       END_STATE();
-    case 767:
+    case 816:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if (lookahead == 'A') ADVANCE(905);
-      if (lookahead == 'O') ADVANCE(900);
-      if (lookahead == 'U') ADVANCE(903);
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'E') ADVANCE(103);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 817:
+      ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'E') ADVANCE(118);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 818:
+      ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'E') ADVANCE(101);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 819:
+      ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'E') ADVANCE(129);
+      if (lookahead == 'R') ADVANCE(100);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 820:
+      ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'I') ADVANCE(128);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 821:
+      ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'O') ADVANCE(119);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 822:
+      ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'P') ADVANCE(130);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 823:
+      ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'R') ADVANCE(102);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 824:
+      ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'u') ADVANCE(134);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 825:
+      ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == 'u') ADVANCE(139);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 826:
+      ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 827:
+      ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
+      if (lookahead == 'A') ADVANCE(289);
+      if (lookahead == 'O') ADVANCE(279);
+      if (lookahead == 'U') ADVANCE(287);
+      END_STATE();
+    case 828:
+      ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
+      if (lookahead == 'A') ADVANCE(982);
+      if (lookahead == 'O') ADVANCE(977);
+      if (lookahead == 'U') ADVANCE(980);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 768:
+    case 829:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if (lookahead == 'E') ADVANCE(890);
+      if (lookahead == 'E') ADVANCE(967);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 769:
+    case 830:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if (lookahead == 'E') ADVANCE(903);
-      if (lookahead == 'R') ADVANCE(873);
+      if (lookahead == 'E') ADVANCE(980);
+      if (lookahead == 'R') ADVANCE(950);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 770:
+    case 831:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if (lookahead == 'E') ADVANCE(876);
+      if (lookahead == 'E') ADVANCE(953);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 771:
+    case 832:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if (lookahead == 'E') ADVANCE(202);
+      if (lookahead == 'E') ADVANCE(250);
       END_STATE();
-    case 772:
+    case 833:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if (lookahead == 'E') ADVANCE(239);
-      if (lookahead == 'R') ADVANCE(164);
+      if (lookahead == 'E') ADVANCE(287);
+      if (lookahead == 'R') ADVANCE(212);
       END_STATE();
-    case 773:
+    case 834:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if (lookahead == 'E') ADVANCE(172);
+      if (lookahead == 'E') ADVANCE(220);
       END_STATE();
-    case 774:
+    case 835:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if (lookahead == 'E') ADVANCE(874);
-      if (lookahead == 'T') ADVANCE(906);
+      if (lookahead == 'E') ADVANCE(951);
+      if (lookahead == 'T') ADVANCE(983);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 775:
+    case 836:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if (lookahead == 'E') ADVANCE(874);
+      if (lookahead == 'E') ADVANCE(951);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 776:
+    case 837:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if (lookahead == 'E') ADVANCE(165);
+      if (lookahead == 'E') ADVANCE(213);
       END_STATE();
-    case 777:
+    case 838:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if (lookahead == 'I') ADVANCE(900);
+      if (lookahead == 'I') ADVANCE(977);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 778:
+    case 839:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if (lookahead == 'I') ADVANCE(231);
+      if (lookahead == 'I') ADVANCE(279);
       END_STATE();
-    case 779:
+    case 840:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if (lookahead == 'O') ADVANCE(892);
+      if (lookahead == 'O') ADVANCE(969);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 780:
+    case 841:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if (lookahead == 'O') ADVANCE(208);
+      if (lookahead == 'O') ADVANCE(256);
       END_STATE();
-    case 781:
+    case 842:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if (lookahead == 'P') ADVANCE(240);
+      if (lookahead == 'P') ADVANCE(288);
       END_STATE();
-    case 782:
+    case 843:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if (lookahead == 'P') ADVANCE(904);
+      if (lookahead == 'P') ADVANCE(981);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 783:
+    case 844:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if (lookahead == 'R') ADVANCE(875);
+      if (lookahead == 'R') ADVANCE(952);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 784:
+    case 845:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
-      if (lookahead == 'R') ADVANCE(166);
+      if (lookahead == 'R') ADVANCE(214);
       END_STATE();
-    case 785:
+    case 846:
       ACCEPT_TOKEN(aux_sym_WORD_CHAR_token1);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 786:
+    case 847:
       ACCEPT_TOKEN(aux_sym_PUNCTUATION_token1);
       END_STATE();
-    case 787:
+    case 848:
       ACCEPT_TOKEN(aux_sym_PUNCTUATION_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(857);
-      if (lookahead == '\r') ADVANCE(856);
-      if (lookahead == '{') ADVANCE(837);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(929);
+      if (lookahead == '\r') ADVANCE(928);
+      if (lookahead == '{') ADVANCE(907);
       if (('\t' <= lookahead && lookahead <= '\f') ||
-          lookahead == ' ') ADVANCE(856);
+          lookahead == ' ') ADVANCE(928);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
-    case 788:
+    case 849:
       ACCEPT_TOKEN(aux_sym_PUNCTUATION_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(857);
-      if (lookahead == '\r') ADVANCE(856);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(929);
+      if (lookahead == '\r') ADVANCE(928);
       if (('\t' <= lookahead && lookahead <= '\f') ||
-          lookahead == ' ') ADVANCE(856);
+          lookahead == ' ') ADVANCE(928);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
-    case 789:
+    case 850:
       ACCEPT_TOKEN(aux_sym_PUNCTUATION_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
-      if (lookahead == '-') ADVANCE(864);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
+      if (lookahead == '-') ADVANCE(938);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
-    case 790:
+    case 851:
       ACCEPT_TOKEN(aux_sym_PUNCTUATION_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
-      if (lookahead == '/') ADVANCE(821);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
+      if (lookahead == '/') ADVANCE(890);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
-    case 791:
+    case 852:
       ACCEPT_TOKEN(aux_sym_PUNCTUATION_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
-    case 792:
+    case 853:
       ACCEPT_TOKEN(aux_sym_PUNCTUATION_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
-      if (lookahead == '-') ADVANCE(865);
-      if (lookahead != 0) ADVANCE(96);
-      END_STATE();
-    case 793:
-      ACCEPT_TOKEN(aux_sym_PUNCTUATION_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
-      if (lookahead == '/') ADVANCE(820);
-      if (lookahead != 0) ADVANCE(96);
-      END_STATE();
-    case 794:
-      ACCEPT_TOKEN(aux_sym_PUNCTUATION_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
-      if (lookahead != 0) ADVANCE(96);
-      END_STATE();
-    case 795:
-      ACCEPT_TOKEN(aux_sym_PUNCTUATION_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(854);
-      if (lookahead == '\r') ADVANCE(852);
-      if (lookahead == '{') ADVANCE(838);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(929);
+      if (lookahead == '\r') ADVANCE(928);
+      if (lookahead == '{') ADVANCE(908);
       if (('\t' <= lookahead && lookahead <= '\f') ||
-          lookahead == ' ') ADVANCE(855);
+          lookahead == ' ') ADVANCE(928);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
-    case 796:
+    case 854:
       ACCEPT_TOKEN(aux_sym_PUNCTUATION_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(854);
-      if (lookahead == '\r') ADVANCE(852);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(929);
+      if (lookahead == '\r') ADVANCE(928);
       if (('\t' <= lookahead && lookahead <= '\f') ||
-          lookahead == ' ') ADVANCE(855);
+          lookahead == ' ') ADVANCE(928);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
-    case 797:
+    case 855:
       ACCEPT_TOKEN(aux_sym_PUNCTUATION_token1);
-      if (lookahead == '\r') ADVANCE(841);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
+      if (lookahead == '-') ADVANCE(938);
+      if (lookahead != 0) ADVANCE(96);
+      END_STATE();
+    case 856:
+      ACCEPT_TOKEN(aux_sym_PUNCTUATION_token1);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
+      if (lookahead == '/') ADVANCE(890);
+      if (lookahead != 0) ADVANCE(96);
+      END_STATE();
+    case 857:
+      ACCEPT_TOKEN(aux_sym_PUNCTUATION_token1);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
+      if (lookahead != 0) ADVANCE(96);
+      END_STATE();
+    case 858:
+      ACCEPT_TOKEN(aux_sym_PUNCTUATION_token1);
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == '-') ADVANCE(939);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 859:
+      ACCEPT_TOKEN(aux_sym_PUNCTUATION_token1);
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == '/') ADVANCE(889);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 860:
+      ACCEPT_TOKEN(aux_sym_PUNCTUATION_token1);
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 861:
+      ACCEPT_TOKEN(aux_sym_PUNCTUATION_token1);
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(926);
+      if (lookahead == '\r') ADVANCE(924);
+      if (lookahead == '{') ADVANCE(909);
+      if (('\t' <= lookahead && lookahead <= '\f') ||
+          lookahead == ' ') ADVANCE(927);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 862:
+      ACCEPT_TOKEN(aux_sym_PUNCTUATION_token1);
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(926);
+      if (lookahead == '\r') ADVANCE(924);
+      if (('\t' <= lookahead && lookahead <= '\f') ||
+          lookahead == ' ') ADVANCE(927);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 863:
+      ACCEPT_TOKEN(aux_sym_PUNCTUATION_token1);
+      if (lookahead == '\r') ADVANCE(912);
       if ((!eof && lookahead == 00) ||
-          lookahead == '\n') ADVANCE(841);
+          lookahead == '\n') ADVANCE(912);
       END_STATE();
-    case 798:
+    case 864:
       ACCEPT_TOKEN(aux_sym_PUNCTUATION_token1);
-      if (lookahead == '%') ADVANCE(843);
-      if (lookahead == '{') ADVANCE(836);
+      if (lookahead == '%') ADVANCE(914);
+      if (lookahead == '{') ADVANCE(906);
       END_STATE();
-    case 799:
+    case 865:
       ACCEPT_TOKEN(aux_sym_PUNCTUATION_token1);
-      if (lookahead == '%') ADVANCE(843);
-      if (lookahead == '{') ADVANCE(836);
+      if (lookahead == '%') ADVANCE(914);
+      if (lookahead == '{') ADVANCE(906);
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(857);
+          lookahead == ' ') ADVANCE(929);
       END_STATE();
-    case 800:
+    case 866:
       ACCEPT_TOKEN(aux_sym_PUNCTUATION_token1);
-      if (lookahead == '-') ADVANCE(864);
+      if (lookahead == '-') ADVANCE(938);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 801:
+    case 867:
       ACCEPT_TOKEN(aux_sym_PUNCTUATION_token1);
-      if (lookahead == '/') ADVANCE(822);
+      if (lookahead == '/') ADVANCE(891);
       END_STATE();
-    case 802:
+    case 868:
       ACCEPT_TOKEN(aux_sym_PUNCTUATION_token1);
-      if (lookahead == '{') ADVANCE(836);
+      if (lookahead == '{') ADVANCE(906);
       END_STATE();
-    case 803:
+    case 869:
       ACCEPT_TOKEN(aux_sym_PUNCTUATION_token1);
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(857);
+          lookahead == ' ') ADVANCE(929);
       END_STATE();
-    case 804:
+    case 870:
       ACCEPT_TOKEN(aux_sym_PUNCTUATION_token1);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 805:
+    case 871:
       ACCEPT_TOKEN(aux_sym_PUNCTUATION_token1);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(910);
+          lookahead != '\r') ADVANCE(987);
       END_STATE();
-    case 806:
+    case 872:
       ACCEPT_TOKEN(aux_sym_WS_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead == ' ' ||
           lookahead == 0xa0 ||
           lookahead == 0x1680 ||
           (0x2000 <= lookahead && lookahead <= 0x200a) ||
           lookahead == 0x202f ||
           lookahead == 0x205f ||
-          lookahead == 0x3000) ADVANCE(806);
+          lookahead == 0x3000) ADVANCE(872);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
-    case 807:
+    case 873:
       ACCEPT_TOKEN(aux_sym_WS_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead == ' ' ||
           lookahead == 0xa0 ||
           lookahead == 0x1680 ||
           (0x2000 <= lookahead && lookahead <= 0x200a) ||
           lookahead == 0x202f ||
           lookahead == 0x205f ||
-          lookahead == 0x3000) ADVANCE(807);
+          lookahead == 0x3000) ADVANCE(873);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
-    case 808:
+    case 874:
+      ACCEPT_TOKEN(aux_sym_WS_token1);
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead == ' ' ||
+          lookahead == 0xa0 ||
+          lookahead == 0x1680 ||
+          (0x2000 <= lookahead && lookahead <= 0x200a) ||
+          lookahead == 0x202f ||
+          lookahead == 0x205f ||
+          lookahead == 0x3000) ADVANCE(874);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 875:
       ACCEPT_TOKEN(aux_sym_WS_token1);
       if (lookahead == ' ' ||
-          lookahead == 0xa0) ADVANCE(809);
+          lookahead == 0xa0) ADVANCE(876);
       if (lookahead == 0x1680 ||
           (0x2000 <= lookahead && lookahead <= 0x200a) ||
           lookahead == 0x202f ||
           lookahead == 0x205f ||
-          lookahead == 0x3000) ADVANCE(808);
+          lookahead == 0x3000) ADVANCE(875);
       if (lookahead == '$' ||
           lookahead == '-' ||
           lookahead == '.' ||
@@ -4904,9 +5454,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(909);
+          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(986);
       END_STATE();
-    case 809:
+    case 876:
       ACCEPT_TOKEN(aux_sym_WS_token1);
       if (lookahead == ' ' ||
           lookahead == 0xa0 ||
@@ -4914,98 +5464,113 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           (0x2000 <= lookahead && lookahead <= 0x200a) ||
           lookahead == 0x202f ||
           lookahead == 0x205f ||
-          lookahead == 0x3000) ADVANCE(809);
+          lookahead == 0x3000) ADVANCE(876);
       END_STATE();
-    case 810:
+    case 877:
       ACCEPT_TOKEN(aux_sym_NL_token1);
       END_STATE();
-    case 811:
+    case 878:
       ACCEPT_TOKEN(aux_sym_NL_token1);
-      if (lookahead == '\n') ADVANCE(810);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
+      if (lookahead != 0) ADVANCE(48);
       END_STATE();
-    case 812:
+    case 879:
+      ACCEPT_TOKEN(aux_sym_NL_token1);
+      if (lookahead == '\n') ADVANCE(877);
+      END_STATE();
+    case 880:
       ACCEPT_TOKEN(aux_sym_LINE_TAIL_token1);
       END_STATE();
-    case 813:
+    case 881:
       ACCEPT_TOKEN(aux_sym_LINE_TAIL_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(813);
-      if (lookahead == '\n') ADVANCE(812);
-      if (lookahead == '\r') ADVANCE(813);
-      if (lookahead != 0) ADVANCE(103);
+      if ((!eof && lookahead == 00)) ADVANCE(881);
+      if (lookahead == '\n') ADVANCE(880);
+      if (lookahead == '\r') ADVANCE(881);
+      if (lookahead != 0) ADVANCE(150);
       END_STATE();
-    case 814:
+    case 882:
       ACCEPT_TOKEN(aux_sym__comment_prefix_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(819);
-      if (lookahead == '\r') ADVANCE(815);
-      if (lookahead == '#') ADVANCE(52);
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(888);
+      if (lookahead == '\r') ADVANCE(883);
+      if (lookahead == '#') ADVANCE(99);
       if (('\t' <= lookahead && lookahead <= '\f') ||
-          lookahead == ' ') ADVANCE(815);
-      if (lookahead != 0) ADVANCE(96);
+          lookahead == ' ') ADVANCE(883);
+      if (lookahead != 0) ADVANCE(143);
       END_STATE();
-    case 815:
+    case 883:
       ACCEPT_TOKEN(aux_sym__comment_prefix_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(819);
-      if (lookahead == '\r') ADVANCE(815);
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(888);
+      if (lookahead == '\r') ADVANCE(883);
       if (('\t' <= lookahead && lookahead <= '\f') ||
-          lookahead == ' ') ADVANCE(815);
-      if (lookahead != 0) ADVANCE(96);
+          lookahead == ' ') ADVANCE(883);
+      if (lookahead != 0) ADVANCE(143);
       END_STATE();
-    case 816:
+    case 884:
       ACCEPT_TOKEN(aux_sym__comment_prefix_token1);
-      if (lookahead == '\n') ADVANCE(819);
-      if (lookahead == '\r') ADVANCE(817);
+      if (lookahead == '\n') ADVANCE(888);
+      if (lookahead == '\r') ADVANCE(886);
       if (lookahead == '#') ADVANCE(4);
       if (('\t' <= lookahead && lookahead <= '\f') ||
-          lookahead == ' ') ADVANCE(817);
+          lookahead == ' ') ADVANCE(886);
       END_STATE();
-    case 817:
+    case 885:
       ACCEPT_TOKEN(aux_sym__comment_prefix_token1);
-      if (lookahead == '\n') ADVANCE(819);
-      if (lookahead == '\r') ADVANCE(817);
+      if (lookahead == '\n') ADVANCE(888);
+      if (lookahead == '\r') ADVANCE(886);
+      if (lookahead == '#') ADVANCE(52);
       if (('\t' <= lookahead && lookahead <= '\f') ||
-          lookahead == ' ') ADVANCE(817);
+          lookahead == ' ') ADVANCE(886);
       END_STATE();
-    case 818:
+    case 886:
       ACCEPT_TOKEN(aux_sym__comment_prefix_token1);
-      if (lookahead == '#') ADVANCE(160);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(819);
+      if (lookahead == '\n') ADVANCE(888);
+      if (lookahead == '\r') ADVANCE(886);
+      if (('\t' <= lookahead && lookahead <= '\f') ||
+          lookahead == ' ') ADVANCE(886);
       END_STATE();
-    case 819:
+    case 887:
+      ACCEPT_TOKEN(aux_sym__comment_prefix_token1);
+      if (lookahead == '#') ADVANCE(208);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(888);
+      END_STATE();
+    case 888:
       ACCEPT_TOKEN(aux_sym__comment_prefix_token1);
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(819);
+          lookahead == ' ') ADVANCE(888);
       END_STATE();
-    case 820:
+    case 889:
       ACCEPT_TOKEN(aux_sym__comment_prefix_token2);
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(822);
-      if (lookahead == '\r') ADVANCE(820);
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(891);
+      if (lookahead == '\r') ADVANCE(889);
       if (('\t' <= lookahead && lookahead <= '\f') ||
-          lookahead == ' ') ADVANCE(820);
-      if (lookahead != 0) ADVANCE(96);
+          lookahead == ' ') ADVANCE(889);
+      if (lookahead != 0) ADVANCE(143);
       END_STATE();
-    case 821:
+    case 890:
       ACCEPT_TOKEN(aux_sym__comment_prefix_token2);
-      if (lookahead == '\n') ADVANCE(822);
-      if (lookahead == '\r') ADVANCE(821);
+      if (lookahead == '\n') ADVANCE(891);
+      if (lookahead == '\r') ADVANCE(890);
       if (('\t' <= lookahead && lookahead <= '\f') ||
-          lookahead == ' ') ADVANCE(821);
+          lookahead == ' ') ADVANCE(890);
       END_STATE();
-    case 822:
+    case 891:
       ACCEPT_TOKEN(aux_sym__comment_prefix_token2);
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(822);
+          lookahead == ' ') ADVANCE(891);
       END_STATE();
-    case 823:
+    case 892:
       ACCEPT_TOKEN(anon_sym_AT);
       END_STATE();
-    case 824:
+    case 893:
       ACCEPT_TOKEN(anon_sym_EQ);
       END_STATE();
-    case 825:
+    case 894:
       ACCEPT_TOKEN(aux_sym_comment_token1);
       if (lookahead == ' ' ||
           lookahead == 0xa0 ||
@@ -5013,20 +5578,20 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           (0x2000 <= lookahead && lookahead <= 0x200a) ||
           lookahead == 0x202f ||
           lookahead == 0x205f ||
-          lookahead == 0x3000) ADVANCE(825);
+          lookahead == 0x3000) ADVANCE(894);
       END_STATE();
-    case 826:
+    case 895:
       ACCEPT_TOKEN(aux_sym_request_separator_token1);
-      if (lookahead == '#') ADVANCE(826);
+      if (lookahead == '#') ADVANCE(895);
       if (lookahead == ' ' ||
           lookahead == 0xa0 ||
           lookahead == 0x1680 ||
           (0x2000 <= lookahead && lookahead <= 0x200a) ||
           lookahead == 0x202f ||
           lookahead == 0x205f ||
-          lookahead == 0x3000) ADVANCE(827);
+          lookahead == 0x3000) ADVANCE(896);
       END_STATE();
-    case 827:
+    case 896:
       ACCEPT_TOKEN(aux_sym_request_separator_token1);
       if (lookahead == ' ' ||
           lookahead == 0xa0 ||
@@ -5034,585 +5599,640 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           (0x2000 <= lookahead && lookahead <= 0x200a) ||
           lookahead == 0x202f ||
           lookahead == 0x205f ||
-          lookahead == 0x3000) ADVANCE(827);
+          lookahead == 0x3000) ADVANCE(896);
       END_STATE();
-    case 828:
+    case 897:
       ACCEPT_TOKEN(sym_method);
       END_STATE();
-    case 829:
+    case 898:
       ACCEPT_TOKEN(sym_method);
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
-    case 830:
+    case 899:
       ACCEPT_TOKEN(sym_method);
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
-    case 831:
+    case 900:
+      ACCEPT_TOKEN(sym_method);
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 901:
       ACCEPT_TOKEN(sym_method);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 832:
+    case 902:
       ACCEPT_TOKEN(sym_http_version);
       if (lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9')) ADVANCE(832);
+          ('0' <= lookahead && lookahead <= '9')) ADVANCE(902);
       END_STATE();
-    case 833:
+    case 903:
       ACCEPT_TOKEN(sym_status_code);
       END_STATE();
-    case 834:
+    case 904:
       ACCEPT_TOKEN(sym_status_text);
       END_STATE();
-    case 835:
+    case 905:
       ACCEPT_TOKEN(anon_sym_COLON);
       END_STATE();
-    case 836:
+    case 906:
       ACCEPT_TOKEN(anon_sym_LBRACE_LBRACE);
       END_STATE();
-    case 837:
+    case 907:
       ACCEPT_TOKEN(anon_sym_LBRACE_LBRACE);
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
-    case 838:
+    case 908:
       ACCEPT_TOKEN(anon_sym_LBRACE_LBRACE);
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
-    case 839:
+    case 909:
+      ACCEPT_TOKEN(anon_sym_LBRACE_LBRACE);
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 910:
       ACCEPT_TOKEN(anon_sym_RBRACE_RBRACE);
       END_STATE();
-    case 840:
+    case 911:
       ACCEPT_TOKEN(anon_sym_LT);
       END_STATE();
-    case 841:
+    case 912:
       ACCEPT_TOKEN(aux_sym_pre_request_script_token1);
-      if (lookahead == '\r') ADVANCE(841);
+      if (lookahead == '\r') ADVANCE(912);
       if ((!eof && lookahead == 00) ||
-          lookahead == '\n') ADVANCE(841);
+          lookahead == '\n') ADVANCE(912);
       END_STATE();
-    case 842:
+    case 913:
       ACCEPT_TOKEN(anon_sym_GT);
       END_STATE();
-    case 843:
+    case 914:
       ACCEPT_TOKEN(anon_sym_LBRACE_PERCENT);
       END_STATE();
-    case 844:
+    case 915:
       ACCEPT_TOKEN(anon_sym_PERCENT_RBRACE);
       END_STATE();
-    case 845:
+    case 916:
       ACCEPT_TOKEN(anon_sym_AT2);
       END_STATE();
-    case 846:
+    case 917:
       ACCEPT_TOKEN(anon_sym_AT2);
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
-    case 847:
+    case 918:
       ACCEPT_TOKEN(anon_sym_AT2);
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
-    case 848:
+    case 919:
+      ACCEPT_TOKEN(anon_sym_AT2);
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 920:
       ACCEPT_TOKEN(aux_sym_xml_body_token1);
       END_STATE();
-    case 849:
+    case 921:
       ACCEPT_TOKEN(aux_sym_xml_body_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
-      if (lookahead != 0) ADVANCE(96);
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead != 0) ADVANCE(143);
       END_STATE();
-    case 850:
+    case 922:
       ACCEPT_TOKEN(aux_sym_xml_body_token2);
       END_STATE();
-    case 851:
+    case 923:
       ACCEPT_TOKEN(aux_sym_xml_body_token2);
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
-      if (lookahead != 0) ADVANCE(96);
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead != 0) ADVANCE(143);
       END_STATE();
-    case 852:
+    case 924:
       ACCEPT_TOKEN(aux_sym_xml_body_token2);
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(854);
-      if (lookahead == '\r') ADVANCE(852);
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(926);
+      if (lookahead == '\r') ADVANCE(924);
       if (('\t' <= lookahead && lookahead <= '\f') ||
-          lookahead == ' ') ADVANCE(855);
-      if (lookahead != 0) ADVANCE(96);
+          lookahead == ' ') ADVANCE(927);
+      if (lookahead != 0) ADVANCE(143);
       END_STATE();
-    case 853:
+    case 925:
       ACCEPT_TOKEN(aux_sym_xml_body_token2);
-      if ((!eof && lookahead == 00)) ADVANCE(853);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(853);
-      if (lookahead == '{') ADVANCE(98);
-      if (lookahead != 0) ADVANCE(98);
+      if ((!eof && lookahead == 00)) ADVANCE(925);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(925);
+      if (lookahead == '{') ADVANCE(145);
+      if (lookahead != 0) ADVANCE(145);
       END_STATE();
-    case 854:
+    case 926:
       ACCEPT_TOKEN(aux_sym_xml_body_token2);
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(857);
+          lookahead == ' ') ADVANCE(929);
       END_STATE();
-    case 855:
+    case 927:
       ACCEPT_TOKEN(aux_sym_json_body_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(854);
-      if (lookahead == '\r') ADVANCE(852);
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(926);
+      if (lookahead == '\r') ADVANCE(924);
       if (('\t' <= lookahead && lookahead <= '\f') ||
-          lookahead == ' ') ADVANCE(855);
-      if (lookahead != 0) ADVANCE(96);
+          lookahead == ' ') ADVANCE(927);
+      if (lookahead != 0) ADVANCE(143);
       END_STATE();
-    case 856:
+    case 928:
       ACCEPT_TOKEN(aux_sym_json_body_token1);
-      if (lookahead == '\n') ADVANCE(857);
-      if (lookahead == '\r') ADVANCE(856);
+      if (lookahead == '\n') ADVANCE(929);
+      if (lookahead == '\r') ADVANCE(928);
       if (('\t' <= lookahead && lookahead <= '\f') ||
-          lookahead == ' ') ADVANCE(856);
+          lookahead == ' ') ADVANCE(928);
       END_STATE();
-    case 857:
+    case 929:
       ACCEPT_TOKEN(aux_sym_json_body_token1);
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(857);
+          lookahead == ' ') ADVANCE(929);
       END_STATE();
-    case 858:
+    case 930:
       ACCEPT_TOKEN(aux_sym_graphql_data_token1);
       END_STATE();
-    case 859:
+    case 931:
       ACCEPT_TOKEN(aux_sym_graphql_data_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(868);
-      if (lookahead == '\n') ADVANCE(858);
-      if (lookahead == '\r') ADVANCE(868);
+      if ((!eof && lookahead == 00)) ADVANCE(947);
+      if (lookahead == '\n') ADVANCE(930);
+      if (lookahead == '\r') ADVANCE(947);
       if (lookahead == '{') ADVANCE(51);
       if (lookahead != 0) ADVANCE(50);
       END_STATE();
-    case 860:
+    case 932:
       ACCEPT_TOKEN(aux_sym_graphql_data_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(868);
-      if (lookahead == '\r') ADVANCE(868);
+      if ((!eof && lookahead == 00)) ADVANCE(947);
+      if (lookahead == '\r') ADVANCE(947);
       if (lookahead == '{') ADVANCE(51);
       if (lookahead != 0 &&
           lookahead != '\n') ADVANCE(50);
       END_STATE();
-    case 861:
+    case 933:
+      ACCEPT_TOKEN(aux_sym_graphql_data_token1);
+      if ((!eof && lookahead == 00)) ADVANCE(942);
+      if (lookahead == '\n') ADVANCE(930);
+      if (lookahead == '\r') ADVANCE(942);
+      if (lookahead == '{') ADVANCE(151);
+      if (lookahead != 0) ADVANCE(98);
+      END_STATE();
+    case 934:
+      ACCEPT_TOKEN(aux_sym_graphql_data_token1);
+      if ((!eof && lookahead == 00)) ADVANCE(942);
+      if (lookahead == '\r') ADVANCE(942);
+      if (lookahead == '{') ADVANCE(151);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(98);
+      END_STATE();
+    case 935:
       ACCEPT_TOKEN(anon_sym_LT2);
-      if ((!eof && lookahead == 00)) ADVANCE(848);
+      if ((!eof && lookahead == 00)) ADVANCE(920);
       if (lookahead != 0 &&
           (lookahead < '\t' || '\r' < lookahead) &&
           lookahead != ' ' &&
-          lookahead != '@') ADVANCE(848);
+          lookahead != '@') ADVANCE(920);
       END_STATE();
-    case 862:
+    case 936:
       ACCEPT_TOKEN(anon_sym_LT2);
-      if ((!eof && lookahead == 00)) ADVANCE(849);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(921);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
       if (('\t' <= lookahead && lookahead <= '\f') ||
           lookahead == ' ' ||
-          lookahead == '@') ADVANCE(96);
-      if (lookahead != 0) ADVANCE(849);
+          lookahead == '@') ADVANCE(143);
+      if (lookahead != 0) ADVANCE(921);
       END_STATE();
-    case 863:
+    case 937:
       ACCEPT_TOKEN(anon_sym_LT2);
       if (lookahead != 0 &&
           (lookahead < '\t' || '\r' < lookahead) &&
           lookahead != ' ' &&
-          lookahead != '@') ADVANCE(848);
+          lookahead != '@') ADVANCE(920);
       END_STATE();
-    case 864:
+    case 938:
       ACCEPT_TOKEN(anon_sym_DASH_DASH);
       END_STATE();
-    case 865:
+    case 939:
       ACCEPT_TOKEN(anon_sym_DASH_DASH);
-      if ((!eof && lookahead == 00)) ADVANCE(851);
-      if (lookahead == '\n') ADVANCE(850);
-      if (lookahead == '\r') ADVANCE(851);
+      if ((!eof && lookahead == 00)) ADVANCE(923);
+      if (lookahead == '\n') ADVANCE(922);
+      if (lookahead == '\r') ADVANCE(923);
+      if (lookahead != 0) ADVANCE(143);
+      END_STATE();
+    case 940:
+      ACCEPT_TOKEN(aux_sym_multipart_form_data_token1);
+      END_STATE();
+    case 941:
+      ACCEPT_TOKEN(aux_sym_multipart_form_data_token1);
+      if ((!eof && lookahead == 00)) ADVANCE(941);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(941);
       if (lookahead != 0) ADVANCE(96);
       END_STATE();
-    case 866:
+    case 942:
       ACCEPT_TOKEN(aux_sym_multipart_form_data_token1);
+      if ((!eof && lookahead == 00)) ADVANCE(942);
+      if (lookahead == '\n') ADVANCE(940);
+      if (lookahead == '\r') ADVANCE(942);
+      if (lookahead == '{') ADVANCE(151);
+      if (lookahead != 0) ADVANCE(98);
       END_STATE();
-    case 867:
-      ACCEPT_TOKEN(aux_sym_multipart_form_data_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(867);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(867);
+    case 943:
+      ACCEPT_TOKEN(aux_sym_multipart_form_data_token2);
+      END_STATE();
+    case 944:
+      ACCEPT_TOKEN(aux_sym_multipart_form_data_token2);
+      if (lookahead == '\n') ADVANCE(943);
+      END_STATE();
+    case 945:
+      ACCEPT_TOKEN(aux_sym_raw_body_token1);
+      END_STATE();
+    case 946:
+      ACCEPT_TOKEN(aux_sym_raw_body_token1);
+      if ((!eof && lookahead == 00)) ADVANCE(946);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(946);
       if (lookahead != 0) ADVANCE(48);
       END_STATE();
-    case 868:
-      ACCEPT_TOKEN(aux_sym_multipart_form_data_token1);
-      if ((!eof && lookahead == 00)) ADVANCE(868);
-      if (lookahead == '\n') ADVANCE(866);
-      if (lookahead == '\r') ADVANCE(868);
+    case 947:
+      ACCEPT_TOKEN(aux_sym_raw_body_token1);
+      if ((!eof && lookahead == 00)) ADVANCE(947);
+      if (lookahead == '\n') ADVANCE(945);
+      if (lookahead == '\r') ADVANCE(947);
       if (lookahead == '{') ADVANCE(51);
       if (lookahead != 0) ADVANCE(50);
       END_STATE();
-    case 869:
-      ACCEPT_TOKEN(aux_sym_multipart_form_data_token2);
-      END_STATE();
-    case 870:
-      ACCEPT_TOKEN(aux_sym_multipart_form_data_token2);
-      if (lookahead == '\n') ADVANCE(869);
-      END_STATE();
-    case 871:
+    case 948:
       ACCEPT_TOKEN(sym__not_comment);
-      if (lookahead == '\r') ADVANCE(871);
+      if (lookahead == '\r') ADVANCE(948);
       if ((!eof && lookahead == 00) ||
-          lookahead == '\n') ADVANCE(871);
+          lookahead == '\n') ADVANCE(948);
       if (lookahead != 0 &&
-          lookahead != '@') ADVANCE(108);
+          lookahead != '@') ADVANCE(156);
       END_STATE();
-    case 872:
+    case 949:
       ACCEPT_TOKEN(sym_header_entity);
-      if (lookahead == '/') ADVANCE(733);
+      if (lookahead == '/') ADVANCE(781);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 873:
+    case 950:
       ACCEPT_TOKEN(sym_header_entity);
-      if (lookahead == 'A') ADVANCE(897);
+      if (lookahead == 'A') ADVANCE(974);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 874:
+    case 951:
       ACCEPT_TOKEN(sym_header_entity);
-      if (lookahead == 'A') ADVANCE(881);
+      if (lookahead == 'A') ADVANCE(958);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 875:
+    case 952:
       ACCEPT_TOKEN(sym_header_entity);
-      if (lookahead == 'A') ADVANCE(880);
+      if (lookahead == 'A') ADVANCE(957);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('B' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 876:
+    case 953:
       ACCEPT_TOKEN(sym_header_entity);
-      if (lookahead == 'B') ADVANCE(902);
+      if (lookahead == 'B') ADVANCE(979);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 877:
+    case 954:
       ACCEPT_TOKEN(sym_header_entity);
-      if (lookahead == 'C') ADVANCE(903);
+      if (lookahead == 'C') ADVANCE(980);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 878:
+    case 955:
       ACCEPT_TOKEN(sym_header_entity);
-      if (lookahead == 'C') ADVANCE(889);
+      if (lookahead == 'C') ADVANCE(966);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 879:
+    case 956:
       ACCEPT_TOKEN(sym_header_entity);
-      if (lookahead == 'C') ADVANCE(886);
+      if (lookahead == 'C') ADVANCE(963);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 880:
+    case 957:
       ACCEPT_TOKEN(sym_header_entity);
-      if (lookahead == 'C') ADVANCE(883);
+      if (lookahead == 'C') ADVANCE(960);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 881:
+    case 958:
       ACCEPT_TOKEN(sym_header_entity);
-      if (lookahead == 'D') ADVANCE(831);
+      if (lookahead == 'D') ADVANCE(901);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 882:
+    case 959:
       ACCEPT_TOKEN(sym_header_entity);
-      if (lookahead == 'E') ADVANCE(903);
+      if (lookahead == 'E') ADVANCE(980);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 883:
+    case 960:
       ACCEPT_TOKEN(sym_header_entity);
-      if (lookahead == 'E') ADVANCE(831);
+      if (lookahead == 'E') ADVANCE(901);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 884:
+    case 961:
       ACCEPT_TOKEN(sym_header_entity);
-      if (lookahead == 'E') ADVANCE(877);
+      if (lookahead == 'E') ADVANCE(954);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 885:
+    case 962:
       ACCEPT_TOKEN(sym_header_entity);
-      if (lookahead == 'E') ADVANCE(907);
+      if (lookahead == 'E') ADVANCE(984);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 886:
+    case 963:
       ACCEPT_TOKEN(sym_header_entity);
-      if (lookahead == 'H') ADVANCE(831);
+      if (lookahead == 'H') ADVANCE(901);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 887:
+    case 964:
       ACCEPT_TOKEN(sym_header_entity);
-      if (lookahead == 'H') ADVANCE(899);
+      if (lookahead == 'H') ADVANCE(976);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 888:
+    case 965:
       ACCEPT_TOKEN(sym_header_entity);
-      if (lookahead == 'I') ADVANCE(895);
+      if (lookahead == 'I') ADVANCE(972);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 889:
+    case 966:
       ACCEPT_TOKEN(sym_header_entity);
-      if (lookahead == 'K') ADVANCE(882);
+      if (lookahead == 'K') ADVANCE(959);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 890:
+    case 967:
       ACCEPT_TOKEN(sym_header_entity);
-      if (lookahead == 'L') ADVANCE(885);
+      if (lookahead == 'L') ADVANCE(962);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 891:
+    case 968:
       ACCEPT_TOKEN(sym_header_entity);
-      if (lookahead == 'L') ADVANCE(831);
+      if (lookahead == 'L') ADVANCE(901);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 892:
+    case 969:
       ACCEPT_TOKEN(sym_header_entity);
-      if (lookahead == 'N') ADVANCE(893);
+      if (lookahead == 'N') ADVANCE(970);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 893:
+    case 970:
       ACCEPT_TOKEN(sym_header_entity);
-      if (lookahead == 'N') ADVANCE(884);
+      if (lookahead == 'N') ADVANCE(961);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 894:
+    case 971:
       ACCEPT_TOKEN(sym_header_entity);
-      if (lookahead == 'N') ADVANCE(901);
+      if (lookahead == 'N') ADVANCE(978);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 895:
+    case 972:
       ACCEPT_TOKEN(sym_header_entity);
-      if (lookahead == 'O') ADVANCE(894);
+      if (lookahead == 'O') ADVANCE(971);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 896:
+    case 973:
       ACCEPT_TOKEN(sym_header_entity);
-      if (lookahead == 'O') ADVANCE(878);
+      if (lookahead == 'O') ADVANCE(955);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 897:
+    case 974:
       ACCEPT_TOKEN(sym_header_entity);
-      if (lookahead == 'P') ADVANCE(887);
+      if (lookahead == 'P') ADVANCE(964);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 898:
+    case 975:
       ACCEPT_TOKEN(sym_header_entity);
-      if (lookahead == 'P') ADVANCE(872);
+      if (lookahead == 'P') ADVANCE(949);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 899:
+    case 976:
       ACCEPT_TOKEN(sym_header_entity);
-      if (lookahead == 'Q') ADVANCE(891);
+      if (lookahead == 'Q') ADVANCE(968);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 900:
+    case 977:
       ACCEPT_TOKEN(sym_header_entity);
-      if (lookahead == 'S') ADVANCE(903);
+      if (lookahead == 'S') ADVANCE(980);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 901:
+    case 978:
       ACCEPT_TOKEN(sym_header_entity);
-      if (lookahead == 'S') ADVANCE(831);
+      if (lookahead == 'S') ADVANCE(901);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 902:
+    case 979:
       ACCEPT_TOKEN(sym_header_entity);
-      if (lookahead == 'S') ADVANCE(896);
+      if (lookahead == 'S') ADVANCE(973);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 903:
+    case 980:
       ACCEPT_TOKEN(sym_header_entity);
-      if (lookahead == 'T') ADVANCE(831);
+      if (lookahead == 'T') ADVANCE(901);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 904:
+    case 981:
       ACCEPT_TOKEN(sym_header_entity);
-      if (lookahead == 'T') ADVANCE(888);
+      if (lookahead == 'T') ADVANCE(965);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 905:
+    case 982:
       ACCEPT_TOKEN(sym_header_entity);
-      if (lookahead == 'T') ADVANCE(879);
+      if (lookahead == 'T') ADVANCE(956);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 906:
+    case 983:
       ACCEPT_TOKEN(sym_header_entity);
-      if (lookahead == 'T') ADVANCE(898);
+      if (lookahead == 'T') ADVANCE(975);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 907:
+    case 984:
       ACCEPT_TOKEN(sym_header_entity);
-      if (lookahead == 'T') ADVANCE(883);
+      if (lookahead == 'T') ADVANCE(960);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 908:
+    case 985:
       ACCEPT_TOKEN(sym_header_entity);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(908);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(985);
       END_STATE();
-    case 909:
+    case 986:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == '$' ||
           lookahead == '-' ||
@@ -5621,17 +6241,17 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(909);
+          (0xa1 <= lookahead && lookahead <= 0xffff)) ADVANCE(986);
       END_STATE();
-    case 910:
+    case 987:
       ACCEPT_TOKEN(aux_sym_path_token1);
       END_STATE();
-    case 911:
+    case 988:
       ACCEPT_TOKEN(aux_sym__blank_line_token1);
       END_STATE();
-    case 912:
+    case 989:
       ACCEPT_TOKEN(aux_sym__blank_line_token1);
-      if (lookahead == '\n') ADVANCE(911);
+      if (lookahead == '\n') ADVANCE(988);
       END_STATE();
     default:
       return false;
@@ -5640,295 +6260,298 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 737},
-  [2] = {.lex_state = 738},
-  [3] = {.lex_state = 738},
-  [4] = {.lex_state = 738},
-  [5] = {.lex_state = 738},
-  [6] = {.lex_state = 738},
-  [7] = {.lex_state = 738},
-  [8] = {.lex_state = 738},
-  [9] = {.lex_state = 738},
-  [10] = {.lex_state = 738},
-  [11] = {.lex_state = 738},
-  [12] = {.lex_state = 738},
-  [13] = {.lex_state = 738},
-  [14] = {.lex_state = 738},
-  [15] = {.lex_state = 738},
-  [16] = {.lex_state = 738},
-  [17] = {.lex_state = 738},
-  [18] = {.lex_state = 738},
-  [19] = {.lex_state = 738},
-  [20] = {.lex_state = 738},
-  [21] = {.lex_state = 738},
-  [22] = {.lex_state = 738},
-  [23] = {.lex_state = 738},
-  [24] = {.lex_state = 738},
-  [25] = {.lex_state = 738},
-  [26] = {.lex_state = 738},
-  [27] = {.lex_state = 738},
-  [28] = {.lex_state = 738},
-  [29] = {.lex_state = 738},
-  [30] = {.lex_state = 738},
-  [31] = {.lex_state = 738},
-  [32] = {.lex_state = 738},
-  [33] = {.lex_state = 738},
-  [34] = {.lex_state = 738},
-  [35] = {.lex_state = 738},
-  [36] = {.lex_state = 738},
-  [37] = {.lex_state = 738},
-  [38] = {.lex_state = 738},
-  [39] = {.lex_state = 738},
-  [40] = {.lex_state = 738},
-  [41] = {.lex_state = 738},
-  [42] = {.lex_state = 738},
-  [43] = {.lex_state = 738},
-  [44] = {.lex_state = 738},
-  [45] = {.lex_state = 738},
-  [46] = {.lex_state = 738},
-  [47] = {.lex_state = 738},
-  [48] = {.lex_state = 738},
-  [49] = {.lex_state = 738},
-  [50] = {.lex_state = 738},
-  [51] = {.lex_state = 738},
-  [52] = {.lex_state = 738},
-  [53] = {.lex_state = 738},
-  [54] = {.lex_state = 738},
-  [55] = {.lex_state = 738},
-  [56] = {.lex_state = 738},
-  [57] = {.lex_state = 738},
-  [58] = {.lex_state = 738},
-  [59] = {.lex_state = 734},
-  [60] = {.lex_state = 737},
-  [61] = {.lex_state = 734},
-  [62] = {.lex_state = 734},
-  [63] = {.lex_state = 737},
-  [64] = {.lex_state = 735},
-  [65] = {.lex_state = 738},
-  [66] = {.lex_state = 738},
-  [67] = {.lex_state = 738},
-  [68] = {.lex_state = 735},
-  [69] = {.lex_state = 735},
-  [70] = {.lex_state = 739},
-  [71] = {.lex_state = 737},
-  [72] = {.lex_state = 735},
-  [73] = {.lex_state = 739},
-  [74] = {.lex_state = 739},
-  [75] = {.lex_state = 739},
-  [76] = {.lex_state = 735},
-  [77] = {.lex_state = 735},
-  [78] = {.lex_state = 735},
-  [79] = {.lex_state = 735},
-  [80] = {.lex_state = 737},
-  [81] = {.lex_state = 734},
-  [82] = {.lex_state = 738},
-  [83] = {.lex_state = 734},
-  [84] = {.lex_state = 734},
-  [85] = {.lex_state = 734},
-  [86] = {.lex_state = 734},
-  [87] = {.lex_state = 738},
-  [88] = {.lex_state = 738},
-  [89] = {.lex_state = 738},
-  [90] = {.lex_state = 738},
-  [91] = {.lex_state = 738},
-  [92] = {.lex_state = 738},
-  [93] = {.lex_state = 738},
-  [94] = {.lex_state = 738},
-  [95] = {.lex_state = 738},
-  [96] = {.lex_state = 738},
-  [97] = {.lex_state = 738},
-  [98] = {.lex_state = 736},
-  [99] = {.lex_state = 736},
-  [100] = {.lex_state = 736},
-  [101] = {.lex_state = 736},
-  [102] = {.lex_state = 736},
-  [103] = {.lex_state = 736},
-  [104] = {.lex_state = 736},
-  [105] = {.lex_state = 736},
-  [106] = {.lex_state = 736},
-  [107] = {.lex_state = 736},
-  [108] = {.lex_state = 736},
-  [109] = {.lex_state = 736},
-  [110] = {.lex_state = 736},
-  [111] = {.lex_state = 736},
-  [112] = {.lex_state = 736},
-  [113] = {.lex_state = 736},
-  [114] = {.lex_state = 736},
-  [115] = {.lex_state = 736},
-  [116] = {.lex_state = 736},
-  [117] = {.lex_state = 736},
-  [118] = {.lex_state = 736},
-  [119] = {.lex_state = 736},
-  [120] = {.lex_state = 736},
-  [121] = {.lex_state = 735},
-  [122] = {.lex_state = 736},
-  [123] = {.lex_state = 736},
-  [124] = {.lex_state = 735},
-  [125] = {.lex_state = 735},
-  [126] = {.lex_state = 735},
-  [127] = {.lex_state = 735},
-  [128] = {.lex_state = 736},
-  [129] = {.lex_state = 736},
-  [130] = {.lex_state = 736},
-  [131] = {.lex_state = 736},
-  [132] = {.lex_state = 736},
-  [133] = {.lex_state = 736},
-  [134] = {.lex_state = 736},
-  [135] = {.lex_state = 736},
-  [136] = {.lex_state = 736},
-  [137] = {.lex_state = 737},
-  [138] = {.lex_state = 737},
-  [139] = {.lex_state = 737},
-  [140] = {.lex_state = 737},
-  [141] = {.lex_state = 737},
-  [142] = {.lex_state = 737},
-  [143] = {.lex_state = 737},
-  [144] = {.lex_state = 737},
-  [145] = {.lex_state = 737},
-  [146] = {.lex_state = 737},
-  [147] = {.lex_state = 737},
-  [148] = {.lex_state = 737},
-  [149] = {.lex_state = 737},
-  [150] = {.lex_state = 737},
-  [151] = {.lex_state = 737},
-  [152] = {.lex_state = 737},
-  [153] = {.lex_state = 737},
-  [154] = {.lex_state = 2},
-  [155] = {.lex_state = 2},
-  [156] = {.lex_state = 252},
-  [157] = {.lex_state = 2},
-  [158] = {.lex_state = 252},
-  [159] = {.lex_state = 3},
-  [160] = {.lex_state = 2},
-  [161] = {.lex_state = 3},
+  [1] = {.lex_state = 785},
+  [2] = {.lex_state = 786},
+  [3] = {.lex_state = 786},
+  [4] = {.lex_state = 786},
+  [5] = {.lex_state = 786},
+  [6] = {.lex_state = 786},
+  [7] = {.lex_state = 786},
+  [8] = {.lex_state = 786},
+  [9] = {.lex_state = 786},
+  [10] = {.lex_state = 786},
+  [11] = {.lex_state = 786},
+  [12] = {.lex_state = 786},
+  [13] = {.lex_state = 786},
+  [14] = {.lex_state = 786},
+  [15] = {.lex_state = 786},
+  [16] = {.lex_state = 786},
+  [17] = {.lex_state = 786},
+  [18] = {.lex_state = 786},
+  [19] = {.lex_state = 786},
+  [20] = {.lex_state = 786},
+  [21] = {.lex_state = 786},
+  [22] = {.lex_state = 786},
+  [23] = {.lex_state = 786},
+  [24] = {.lex_state = 786},
+  [25] = {.lex_state = 786},
+  [26] = {.lex_state = 786},
+  [27] = {.lex_state = 786},
+  [28] = {.lex_state = 786},
+  [29] = {.lex_state = 786},
+  [30] = {.lex_state = 786},
+  [31] = {.lex_state = 786},
+  [32] = {.lex_state = 786},
+  [33] = {.lex_state = 786},
+  [34] = {.lex_state = 786},
+  [35] = {.lex_state = 786},
+  [36] = {.lex_state = 786},
+  [37] = {.lex_state = 786},
+  [38] = {.lex_state = 786},
+  [39] = {.lex_state = 786},
+  [40] = {.lex_state = 786},
+  [41] = {.lex_state = 786},
+  [42] = {.lex_state = 786},
+  [43] = {.lex_state = 786},
+  [44] = {.lex_state = 786},
+  [45] = {.lex_state = 786},
+  [46] = {.lex_state = 786},
+  [47] = {.lex_state = 786},
+  [48] = {.lex_state = 786},
+  [49] = {.lex_state = 786},
+  [50] = {.lex_state = 786},
+  [51] = {.lex_state = 786},
+  [52] = {.lex_state = 786},
+  [53] = {.lex_state = 786},
+  [54] = {.lex_state = 786},
+  [55] = {.lex_state = 786},
+  [56] = {.lex_state = 786},
+  [57] = {.lex_state = 786},
+  [58] = {.lex_state = 786},
+  [59] = {.lex_state = 782},
+  [60] = {.lex_state = 782},
+  [61] = {.lex_state = 782},
+  [62] = {.lex_state = 785},
+  [63] = {.lex_state = 785},
+  [64] = {.lex_state = 787},
+  [65] = {.lex_state = 787},
+  [66] = {.lex_state = 787},
+  [67] = {.lex_state = 787},
+  [68] = {.lex_state = 782},
+  [69] = {.lex_state = 783},
+  [70] = {.lex_state = 783},
+  [71] = {.lex_state = 788},
+  [72] = {.lex_state = 785},
+  [73] = {.lex_state = 785},
+  [74] = {.lex_state = 782},
+  [75] = {.lex_state = 783},
+  [76] = {.lex_state = 783},
+  [77] = {.lex_state = 783},
+  [78] = {.lex_state = 786},
+  [79] = {.lex_state = 788},
+  [80] = {.lex_state = 783},
+  [81] = {.lex_state = 782},
+  [82] = {.lex_state = 782},
+  [83] = {.lex_state = 783},
+  [84] = {.lex_state = 788},
+  [85] = {.lex_state = 788},
+  [86] = {.lex_state = 782},
+  [87] = {.lex_state = 783},
+  [88] = {.lex_state = 786},
+  [89] = {.lex_state = 786},
+  [90] = {.lex_state = 786},
+  [91] = {.lex_state = 786},
+  [92] = {.lex_state = 786},
+  [93] = {.lex_state = 786},
+  [94] = {.lex_state = 786},
+  [95] = {.lex_state = 786},
+  [96] = {.lex_state = 786},
+  [97] = {.lex_state = 786},
+  [98] = {.lex_state = 786},
+  [99] = {.lex_state = 786},
+  [100] = {.lex_state = 786},
+  [101] = {.lex_state = 784},
+  [102] = {.lex_state = 784},
+  [103] = {.lex_state = 784},
+  [104] = {.lex_state = 784},
+  [105] = {.lex_state = 784},
+  [106] = {.lex_state = 784},
+  [107] = {.lex_state = 784},
+  [108] = {.lex_state = 784},
+  [109] = {.lex_state = 784},
+  [110] = {.lex_state = 784},
+  [111] = {.lex_state = 784},
+  [112] = {.lex_state = 784},
+  [113] = {.lex_state = 784},
+  [114] = {.lex_state = 784},
+  [115] = {.lex_state = 784},
+  [116] = {.lex_state = 784},
+  [117] = {.lex_state = 784},
+  [118] = {.lex_state = 784},
+  [119] = {.lex_state = 784},
+  [120] = {.lex_state = 784},
+  [121] = {.lex_state = 784},
+  [122] = {.lex_state = 784},
+  [123] = {.lex_state = 784},
+  [124] = {.lex_state = 783},
+  [125] = {.lex_state = 784},
+  [126] = {.lex_state = 784},
+  [127] = {.lex_state = 783},
+  [128] = {.lex_state = 783},
+  [129] = {.lex_state = 783},
+  [130] = {.lex_state = 783},
+  [131] = {.lex_state = 784},
+  [132] = {.lex_state = 784},
+  [133] = {.lex_state = 784},
+  [134] = {.lex_state = 784},
+  [135] = {.lex_state = 784},
+  [136] = {.lex_state = 784},
+  [137] = {.lex_state = 784},
+  [138] = {.lex_state = 784},
+  [139] = {.lex_state = 784},
+  [140] = {.lex_state = 785},
+  [141] = {.lex_state = 785},
+  [142] = {.lex_state = 785},
+  [143] = {.lex_state = 785},
+  [144] = {.lex_state = 785},
+  [145] = {.lex_state = 785},
+  [146] = {.lex_state = 785},
+  [147] = {.lex_state = 785},
+  [148] = {.lex_state = 785},
+  [149] = {.lex_state = 785},
+  [150] = {.lex_state = 785},
+  [151] = {.lex_state = 785},
+  [152] = {.lex_state = 785},
+  [153] = {.lex_state = 785},
+  [154] = {.lex_state = 785},
+  [155] = {.lex_state = 785},
+  [156] = {.lex_state = 785},
+  [157] = {.lex_state = 300},
+  [158] = {.lex_state = 2},
+  [159] = {.lex_state = 2},
+  [160] = {.lex_state = 300},
+  [161] = {.lex_state = 2},
   [162] = {.lex_state = 3},
   [163] = {.lex_state = 2},
   [164] = {.lex_state = 3},
   [165] = {.lex_state = 2},
   [166] = {.lex_state = 2},
-  [167] = {.lex_state = 2},
-  [168] = {.lex_state = 1},
+  [167] = {.lex_state = 1},
+  [168] = {.lex_state = 3},
   [169] = {.lex_state = 2},
   [170] = {.lex_state = 1},
-  [171] = {.lex_state = 3},
-  [172] = {.lex_state = 3},
-  [173] = {.lex_state = 99},
+  [171] = {.lex_state = 2},
+  [172] = {.lex_state = 2},
+  [173] = {.lex_state = 3},
   [174] = {.lex_state = 3},
-  [175] = {.lex_state = 3},
-  [176] = {.lex_state = 99},
-  [177] = {.lex_state = 1},
-  [178] = {.lex_state = 1},
+  [175] = {.lex_state = 146},
+  [176] = {.lex_state = 1},
+  [177] = {.lex_state = 3},
+  [178] = {.lex_state = 3},
   [179] = {.lex_state = 3},
   [180] = {.lex_state = 3},
   [181] = {.lex_state = 3},
   [182] = {.lex_state = 3},
   [183] = {.lex_state = 3},
   [184] = {.lex_state = 3},
-  [185] = {.lex_state = 1},
+  [185] = {.lex_state = 3},
   [186] = {.lex_state = 1},
-  [187] = {.lex_state = 2},
-  [188] = {.lex_state = 1},
+  [187] = {.lex_state = 146},
+  [188] = {.lex_state = 2},
   [189] = {.lex_state = 1},
-  [190] = {.lex_state = 99},
-  [191] = {.lex_state = 3},
-  [192] = {.lex_state = 3},
-  [193] = {.lex_state = 99},
+  [190] = {.lex_state = 1},
+  [191] = {.lex_state = 1},
+  [192] = {.lex_state = 1},
+  [193] = {.lex_state = 3},
   [194] = {.lex_state = 3},
-  [195] = {.lex_state = 2},
-  [196] = {.lex_state = 3},
-  [197] = {.lex_state = 99},
-  [198] = {.lex_state = 99},
-  [199] = {.lex_state = 105},
-  [200] = {.lex_state = 105},
-  [201] = {.lex_state = 105},
-  [202] = {.lex_state = 105},
-  [203] = {.lex_state = 100},
-  [204] = {.lex_state = 105},
-  [205] = {.lex_state = 105},
-  [206] = {.lex_state = 100},
-  [207] = {.lex_state = 100},
-  [208] = {.lex_state = 105},
-  [209] = {.lex_state = 105},
-  [210] = {.lex_state = 105},
-  [211] = {.lex_state = 105},
-  [212] = {.lex_state = 101},
-  [213] = {.lex_state = 105},
-  [214] = {.lex_state = 105},
-  [215] = {.lex_state = 105},
-  [216] = {.lex_state = 106},
-  [217] = {.lex_state = 105},
-  [218] = {.lex_state = 105},
-  [219] = {.lex_state = 105},
-  [220] = {.lex_state = 105},
-  [221] = {.lex_state = 101},
-  [222] = {.lex_state = 107},
-  [223] = {.lex_state = 105},
-  [224] = {.lex_state = 737},
-  [225] = {.lex_state = 105},
-  [226] = {.lex_state = 106},
-  [227] = {.lex_state = 106},
-  [228] = {.lex_state = 105},
-  [229] = {.lex_state = 101},
-  [230] = {.lex_state = 96},
-  [231] = {.lex_state = 96},
-  [232] = {.lex_state = 96},
-  [233] = {.lex_state = 105},
-  [234] = {.lex_state = 105},
-  [235] = {.lex_state = 737},
-  [236] = {.lex_state = 0},
-  [237] = {.lex_state = 105},
-  [238] = {.lex_state = 105},
-  [239] = {.lex_state = 104},
-  [240] = {.lex_state = 737},
-  [241] = {.lex_state = 737},
-  [242] = {.lex_state = 105},
-  [243] = {.lex_state = 0},
-  [244] = {.lex_state = 105},
-  [245] = {.lex_state = 105},
-  [246] = {.lex_state = 105},
-  [247] = {.lex_state = 105},
-  [248] = {.lex_state = 105},
-  [249] = {.lex_state = 106},
-  [250] = {.lex_state = 106},
-  [251] = {.lex_state = 105},
-  [252] = {.lex_state = 48},
-  [253] = {.lex_state = 107},
-  [254] = {.lex_state = 105},
-  [255] = {.lex_state = 105},
-  [256] = {.lex_state = 737},
-  [257] = {.lex_state = 104},
-  [258] = {.lex_state = 105},
-  [259] = {.lex_state = 106},
-  [260] = {.lex_state = 106},
-  [261] = {.lex_state = 105},
-  [262] = {.lex_state = 104},
-  [263] = {.lex_state = 104},
-  [264] = {.lex_state = 105},
-  [265] = {.lex_state = 105},
-  [266] = {.lex_state = 737},
-  [267] = {.lex_state = 105},
-  [268] = {.lex_state = 104},
-  [269] = {.lex_state = 105},
-  [270] = {.lex_state = 105},
-  [271] = {.lex_state = 105},
-  [272] = {.lex_state = 105},
-  [273] = {.lex_state = 105},
-  [274] = {.lex_state = 104},
-  [275] = {.lex_state = 105},
-  [276] = {.lex_state = 105},
-  [277] = {.lex_state = 105},
-  [278] = {.lex_state = 105},
-  [279] = {.lex_state = 105},
-  [280] = {.lex_state = 104},
-  [281] = {.lex_state = 104},
-  [282] = {.lex_state = 104},
-  [283] = {.lex_state = 105},
-  [284] = {.lex_state = 0},
-  [285] = {.lex_state = 737},
-  [286] = {.lex_state = 104},
-  [287] = {.lex_state = 104},
-  [288] = {.lex_state = 105},
-  [289] = {.lex_state = 737},
+  [195] = {.lex_state = 3},
+  [196] = {.lex_state = 146},
+  [197] = {.lex_state = 146},
+  [198] = {.lex_state = 3},
+  [199] = {.lex_state = 146},
+  [200] = {.lex_state = 146},
+  [201] = {.lex_state = 2},
+  [202] = {.lex_state = 147},
+  [203] = {.lex_state = 153},
+  [204] = {.lex_state = 153},
+  [205] = {.lex_state = 153},
+  [206] = {.lex_state = 153},
+  [207] = {.lex_state = 147},
+  [208] = {.lex_state = 153},
+  [209] = {.lex_state = 147},
+  [210] = {.lex_state = 153},
+  [211] = {.lex_state = 154},
+  [212] = {.lex_state = 143},
+  [213] = {.lex_state = 154},
+  [214] = {.lex_state = 785},
+  [215] = {.lex_state = 143},
+  [216] = {.lex_state = 153},
+  [217] = {.lex_state = 153},
+  [218] = {.lex_state = 148},
+  [219] = {.lex_state = 153},
+  [220] = {.lex_state = 153},
+  [221] = {.lex_state = 153},
+  [222] = {.lex_state = 153},
+  [223] = {.lex_state = 153},
+  [224] = {.lex_state = 155},
+  [225] = {.lex_state = 154},
+  [226] = {.lex_state = 153},
+  [227] = {.lex_state = 153},
+  [228] = {.lex_state = 148},
+  [229] = {.lex_state = 153},
+  [230] = {.lex_state = 153},
+  [231] = {.lex_state = 153},
+  [232] = {.lex_state = 153},
+  [233] = {.lex_state = 153},
+  [234] = {.lex_state = 148},
+  [235] = {.lex_state = 143},
+  [236] = {.lex_state = 153},
+  [237] = {.lex_state = 153},
+  [238] = {.lex_state = 153},
+  [239] = {.lex_state = 153},
+  [240] = {.lex_state = 152},
+  [241] = {.lex_state = 153},
+  [242] = {.lex_state = 0},
+  [243] = {.lex_state = 152},
+  [244] = {.lex_state = 153},
+  [245] = {.lex_state = 153},
+  [246] = {.lex_state = 0},
+  [247] = {.lex_state = 152},
+  [248] = {.lex_state = 785},
+  [249] = {.lex_state = 153},
+  [250] = {.lex_state = 96},
+  [251] = {.lex_state = 153},
+  [252] = {.lex_state = 154},
+  [253] = {.lex_state = 153},
+  [254] = {.lex_state = 153},
+  [255] = {.lex_state = 785},
+  [256] = {.lex_state = 785},
+  [257] = {.lex_state = 0},
+  [258] = {.lex_state = 785},
+  [259] = {.lex_state = 154},
+  [260] = {.lex_state = 153},
+  [261] = {.lex_state = 153},
+  [262] = {.lex_state = 153},
+  [263] = {.lex_state = 153},
+  [264] = {.lex_state = 785},
+  [265] = {.lex_state = 154},
+  [266] = {.lex_state = 152},
+  [267] = {.lex_state = 785},
+  [268] = {.lex_state = 153},
+  [269] = {.lex_state = 153},
+  [270] = {.lex_state = 153},
+  [271] = {.lex_state = 152},
+  [272] = {.lex_state = 153},
+  [273] = {.lex_state = 153},
+  [274] = {.lex_state = 153},
+  [275] = {.lex_state = 152},
+  [276] = {.lex_state = 155},
+  [277] = {.lex_state = 152},
+  [278] = {.lex_state = 153},
+  [279] = {.lex_state = 153},
+  [280] = {.lex_state = 153},
+  [281] = {.lex_state = 153},
+  [282] = {.lex_state = 153},
+  [283] = {.lex_state = 785},
+  [284] = {.lex_state = 152},
+  [285] = {.lex_state = 152},
+  [286] = {.lex_state = 153},
+  [287] = {.lex_state = 153},
+  [288] = {.lex_state = 154},
+  [289] = {.lex_state = 152},
+  [290] = {.lex_state = 152},
+  [291] = {.lex_state = 153},
+  [292] = {.lex_state = 153},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -5962,20 +6585,20 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym__blank_line_token1] = ACTIONS(1),
   },
   [1] = {
-    [sym_document] = STATE(236),
-    [sym__comment_prefix] = STATE(229),
-    [sym_comment] = STATE(71),
-    [sym_request_separator] = STATE(80),
-    [sym_section] = STATE(60),
-    [sym__section_content] = STATE(152),
-    [aux_sym__target_url_line] = STATE(162),
-    [sym_target_url] = STATE(228),
-    [sym_request] = STATE(151),
-    [sym_variable] = STATE(162),
-    [sym_pre_request_script] = STATE(71),
-    [sym_variable_declaration] = STATE(71),
-    [sym__blank_line] = STATE(71),
-    [aux_sym_document_repeat1] = STATE(60),
+    [sym_document] = STATE(246),
+    [sym__comment_prefix] = STATE(234),
+    [sym_comment] = STATE(73),
+    [sym_request_separator] = STATE(72),
+    [sym_section] = STATE(62),
+    [sym__section_content] = STATE(144),
+    [aux_sym__target_url_line] = STATE(168),
+    [sym_target_url] = STATE(231),
+    [sym_request] = STATE(140),
+    [sym_variable] = STATE(168),
+    [sym_pre_request_script] = STATE(73),
+    [sym_variable_declaration] = STATE(73),
+    [sym__blank_line] = STATE(73),
+    [aux_sym_document_repeat1] = STATE(62),
     [ts_builtin_sym_end] = ACTIONS(3),
     [aux_sym_WORD_CHAR_token1] = ACTIONS(5),
     [aux_sym_PUNCTUATION_token1] = ACTIONS(5),
@@ -5992,7 +6615,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
 };
 
 static const uint16_t ts_small_parse_table[] = {
-  [0] = 21,
+  [0] = 20,
     ACTIONS(29), 1,
       aux_sym_WS_token1,
     ACTIONS(31), 1,
@@ -6014,24 +6637,22 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(51), 1,
       aux_sym__blank_line_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
     ACTIONS(25), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(65), 2,
+    STATE(78), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
-    STATE(48), 3,
+    STATE(45), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
@@ -6042,14 +6663,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
       sym__external_body,
       sym_multipart_form_data,
       sym_raw_body,
-  [78] = 21,
+  [75] = 20,
     ACTIONS(29), 1,
       aux_sym_WS_token1,
     ACTIONS(33), 1,
@@ -6069,26 +6690,24 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(51), 1,
       aux_sym__blank_line_token1,
     ACTIONS(57), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
     ACTIONS(53), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(65), 2,
+    STATE(78), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
-    STATE(56), 3,
+    STATE(33), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
@@ -6099,14 +6718,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
       sym__external_body,
       sym_multipart_form_data,
       sym_raw_body,
-  [156] = 21,
+  [150] = 20,
     ACTIONS(29), 1,
       aux_sym_WS_token1,
     ACTIONS(33), 1,
@@ -6126,26 +6745,24 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(51), 1,
       aux_sym__blank_line_token1,
     ACTIONS(63), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
     ACTIONS(59), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(65), 2,
+    STATE(78), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
-    STATE(57), 3,
+    STATE(44), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
@@ -6156,14 +6773,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
       sym__external_body,
       sym_multipart_form_data,
       sym_raw_body,
-  [234] = 21,
+  [225] = 20,
     ACTIONS(29), 1,
       aux_sym_WS_token1,
     ACTIONS(33), 1,
@@ -6183,26 +6800,24 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(51), 1,
       aux_sym__blank_line_token1,
     ACTIONS(69), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
     ACTIONS(65), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(65), 2,
+    STATE(78), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
-    STATE(34), 3,
+    STATE(58), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
@@ -6213,14 +6828,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
       sym__external_body,
       sym_multipart_form_data,
       sym_raw_body,
-  [312] = 21,
+  [300] = 20,
     ACTIONS(29), 1,
       aux_sym_WS_token1,
     ACTIONS(33), 1,
@@ -6240,26 +6855,24 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(51), 1,
       aux_sym__blank_line_token1,
     ACTIONS(75), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
     ACTIONS(71), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(65), 2,
+    STATE(78), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
-    STATE(33), 3,
+    STATE(37), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
@@ -6270,14 +6883,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
       sym__external_body,
       sym_multipart_form_data,
       sym_raw_body,
-  [390] = 21,
+  [375] = 20,
     ACTIONS(29), 1,
       aux_sym_WS_token1,
     ACTIONS(33), 1,
@@ -6297,26 +6910,24 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(51), 1,
       aux_sym__blank_line_token1,
     ACTIONS(81), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
     ACTIONS(77), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(65), 2,
+    STATE(78), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
-    STATE(30), 3,
+    STATE(39), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
@@ -6327,14 +6938,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
       sym__external_body,
       sym_multipart_form_data,
       sym_raw_body,
-  [468] = 21,
+  [450] = 20,
     ACTIONS(29), 1,
       aux_sym_WS_token1,
     ACTIONS(33), 1,
@@ -6354,26 +6965,24 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(51), 1,
       aux_sym__blank_line_token1,
     ACTIONS(87), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
     ACTIONS(83), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(65), 2,
+    STATE(78), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
-    STATE(44), 3,
+    STATE(51), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
@@ -6384,14 +6993,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
       sym__external_body,
       sym_multipart_form_data,
       sym_raw_body,
-  [546] = 21,
+  [525] = 20,
     ACTIONS(29), 1,
       aux_sym_WS_token1,
     ACTIONS(33), 1,
@@ -6411,26 +7020,24 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(51), 1,
       aux_sym__blank_line_token1,
     ACTIONS(93), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
     ACTIONS(89), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(65), 2,
+    STATE(78), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
-    STATE(42), 3,
+    STATE(55), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
@@ -6441,14 +7048,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
       sym__external_body,
       sym_multipart_form_data,
       sym_raw_body,
-  [624] = 21,
+  [600] = 20,
     ACTIONS(29), 1,
       aux_sym_WS_token1,
     ACTIONS(33), 1,
@@ -6468,26 +7075,24 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(51), 1,
       aux_sym__blank_line_token1,
     ACTIONS(99), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
     ACTIONS(95), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(65), 2,
+    STATE(78), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
-    STATE(36), 3,
+    STATE(48), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
@@ -6498,14 +7103,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
       sym__external_body,
       sym_multipart_form_data,
       sym_raw_body,
-  [702] = 21,
+  [675] = 20,
     ACTIONS(29), 1,
       aux_sym_WS_token1,
     ACTIONS(33), 1,
@@ -6525,26 +7130,24 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(51), 1,
       aux_sym__blank_line_token1,
     ACTIONS(105), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
     ACTIONS(101), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(65), 2,
+    STATE(78), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
-    STATE(38), 3,
+    STATE(47), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
@@ -6555,14 +7158,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
       sym__external_body,
       sym_multipart_form_data,
       sym_raw_body,
-  [780] = 21,
+  [750] = 20,
     ACTIONS(29), 1,
       aux_sym_WS_token1,
     ACTIONS(33), 1,
@@ -6582,44 +7185,97 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(51), 1,
       aux_sym__blank_line_token1,
-    ACTIONS(107), 1,
+    ACTIONS(111), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
-    ACTIONS(83), 2,
+    ACTIONS(107), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(65), 2,
+    STATE(78), 2,
+      sym__blank_line,
+      aux_sym_request_repeat3,
+    STATE(46), 3,
+      sym_var_comment,
+      sym_res_handler_script,
+      aux_sym_request_repeat4,
+    ACTIONS(109), 6,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      sym_method,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+    STATE(96), 6,
+      sym_xml_body,
+      sym_json_body,
+      sym_graphql_body,
+      sym__external_body,
+      sym_multipart_form_data,
+      sym_raw_body,
+  [825] = 20,
+    ACTIONS(29), 1,
+      aux_sym_WS_token1,
+    ACTIONS(33), 1,
+      aux_sym__comment_prefix_token1,
+    ACTIONS(35), 1,
+      aux_sym__comment_prefix_token2,
+    ACTIONS(37), 1,
+      anon_sym_GT,
+    ACTIONS(39), 1,
+      aux_sym_xml_body_token1,
+    ACTIONS(41), 1,
+      aux_sym_json_body_token1,
+    ACTIONS(43), 1,
+      aux_sym_graphql_data_token1,
+    ACTIONS(45), 1,
+      anon_sym_LT2,
+    ACTIONS(47), 1,
+      anon_sym_DASH_DASH,
+    ACTIONS(49), 1,
+      aux_sym_raw_body_token1,
+    ACTIONS(51), 1,
+      aux_sym__blank_line_token1,
+    ACTIONS(117), 1,
+      aux_sym_NL_token1,
+    STATE(88), 1,
+      sym_graphql_data,
+    STATE(224), 1,
+      sym__comment_prefix,
+    STATE(292), 1,
+      sym_external_body,
+    ACTIONS(113), 2,
+      ts_builtin_sym_end,
+      aux_sym_request_separator_token1,
+    STATE(78), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
     STATE(41), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
-    ACTIONS(85), 6,
+    ACTIONS(115), 6,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       sym_method,
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
       sym__external_body,
       sym_multipart_form_data,
       sym_raw_body,
-  [858] = 21,
+  [900] = 20,
     ACTIONS(29), 1,
       aux_sym_WS_token1,
     ACTIONS(33), 1,
@@ -6639,44 +7295,152 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(51), 1,
       aux_sym__blank_line_token1,
-    ACTIONS(109), 1,
+    ACTIONS(119), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
-    ACTIONS(95), 2,
+    ACTIONS(65), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(65), 2,
+    STATE(78), 2,
+      sym__blank_line,
+      aux_sym_request_repeat3,
+    STATE(31), 3,
+      sym_var_comment,
+      sym_res_handler_script,
+      aux_sym_request_repeat4,
+    ACTIONS(67), 6,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      sym_method,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+    STATE(96), 6,
+      sym_xml_body,
+      sym_json_body,
+      sym_graphql_body,
+      sym__external_body,
+      sym_multipart_form_data,
+      sym_raw_body,
+  [975] = 20,
+    ACTIONS(29), 1,
+      aux_sym_WS_token1,
+    ACTIONS(33), 1,
+      aux_sym__comment_prefix_token1,
+    ACTIONS(35), 1,
+      aux_sym__comment_prefix_token2,
+    ACTIONS(37), 1,
+      anon_sym_GT,
+    ACTIONS(39), 1,
+      aux_sym_xml_body_token1,
+    ACTIONS(41), 1,
+      aux_sym_json_body_token1,
+    ACTIONS(43), 1,
+      aux_sym_graphql_data_token1,
+    ACTIONS(45), 1,
+      anon_sym_LT2,
+    ACTIONS(47), 1,
+      anon_sym_DASH_DASH,
+    ACTIONS(49), 1,
+      aux_sym_raw_body_token1,
+    ACTIONS(51), 1,
+      aux_sym__blank_line_token1,
+    ACTIONS(125), 1,
+      aux_sym_NL_token1,
+    STATE(88), 1,
+      sym_graphql_data,
+    STATE(224), 1,
+      sym__comment_prefix,
+    STATE(292), 1,
+      sym_external_body,
+    ACTIONS(121), 2,
+      ts_builtin_sym_end,
+      aux_sym_request_separator_token1,
+    STATE(78), 2,
+      sym__blank_line,
+      aux_sym_request_repeat3,
+    STATE(52), 3,
+      sym_var_comment,
+      sym_res_handler_script,
+      aux_sym_request_repeat4,
+    ACTIONS(123), 6,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      sym_method,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+    STATE(96), 6,
+      sym_xml_body,
+      sym_json_body,
+      sym_graphql_body,
+      sym__external_body,
+      sym_multipart_form_data,
+      sym_raw_body,
+  [1050] = 20,
+    ACTIONS(29), 1,
+      aux_sym_WS_token1,
+    ACTIONS(33), 1,
+      aux_sym__comment_prefix_token1,
+    ACTIONS(35), 1,
+      aux_sym__comment_prefix_token2,
+    ACTIONS(37), 1,
+      anon_sym_GT,
+    ACTIONS(39), 1,
+      aux_sym_xml_body_token1,
+    ACTIONS(41), 1,
+      aux_sym_json_body_token1,
+    ACTIONS(43), 1,
+      aux_sym_graphql_data_token1,
+    ACTIONS(45), 1,
+      anon_sym_LT2,
+    ACTIONS(47), 1,
+      anon_sym_DASH_DASH,
+    ACTIONS(49), 1,
+      aux_sym_raw_body_token1,
+    ACTIONS(51), 1,
+      aux_sym__blank_line_token1,
+    ACTIONS(131), 1,
+      aux_sym_NL_token1,
+    STATE(88), 1,
+      sym_graphql_data,
+    STATE(224), 1,
+      sym__comment_prefix,
+    STATE(292), 1,
+      sym_external_body,
+    ACTIONS(127), 2,
+      ts_builtin_sym_end,
+      aux_sym_request_separator_token1,
+    STATE(78), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
     STATE(40), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
-    ACTIONS(97), 6,
+    ACTIONS(129), 6,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       sym_method,
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
       sym__external_body,
       sym_multipart_form_data,
       sym_raw_body,
-  [936] = 21,
+  [1125] = 20,
     ACTIONS(29), 1,
       aux_sym_WS_token1,
     ACTIONS(33), 1,
@@ -6696,44 +7460,42 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(51), 1,
       aux_sym__blank_line_token1,
-    ACTIONS(115), 1,
+    ACTIONS(137), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
-    ACTIONS(111), 2,
+    ACTIONS(133), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(65), 2,
+    STATE(78), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
-    STATE(54), 3,
+    STATE(36), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
-    ACTIONS(113), 6,
+    ACTIONS(135), 6,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       sym_method,
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
       sym__external_body,
       sym_multipart_form_data,
       sym_raw_body,
-  [1014] = 21,
+  [1200] = 20,
     ACTIONS(29), 1,
       aux_sym_WS_token1,
     ACTIONS(33), 1,
@@ -6753,44 +7515,42 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(51), 1,
       aux_sym__blank_line_token1,
-    ACTIONS(121), 1,
+    ACTIONS(143), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
-    ACTIONS(117), 2,
+    ACTIONS(139), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(65), 2,
+    STATE(78), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
-    STATE(45), 3,
+    STATE(35), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
-    ACTIONS(119), 6,
+    ACTIONS(141), 6,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       sym_method,
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
       sym__external_body,
       sym_multipart_form_data,
       sym_raw_body,
-  [1092] = 21,
+  [1275] = 20,
     ACTIONS(29), 1,
       aux_sym_WS_token1,
     ACTIONS(33), 1,
@@ -6810,215 +7570,42 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
-    ACTIONS(51), 1,
-      aux_sym__blank_line_token1,
-    ACTIONS(127), 1,
-      aux_sym_NL_token1,
-    STATE(82), 1,
-      sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
-      sym__comment_prefix,
-    STATE(233), 1,
-      sym_external_body,
-    ACTIONS(123), 2,
-      ts_builtin_sym_end,
-      aux_sym_request_separator_token1,
-    STATE(65), 2,
-      sym__blank_line,
-      aux_sym_request_repeat3,
-    STATE(51), 3,
-      sym_var_comment,
-      sym_res_handler_script,
-      aux_sym_request_repeat4,
-    ACTIONS(125), 6,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      sym_method,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-    STATE(97), 6,
-      sym_xml_body,
-      sym_json_body,
-      sym_graphql_body,
-      sym__external_body,
-      sym_multipart_form_data,
-      sym_raw_body,
-  [1170] = 21,
-    ACTIONS(29), 1,
-      aux_sym_WS_token1,
-    ACTIONS(33), 1,
-      aux_sym__comment_prefix_token1,
-    ACTIONS(35), 1,
-      aux_sym__comment_prefix_token2,
-    ACTIONS(37), 1,
-      anon_sym_GT,
-    ACTIONS(39), 1,
-      aux_sym_xml_body_token1,
-    ACTIONS(41), 1,
-      aux_sym_json_body_token1,
-    ACTIONS(43), 1,
-      aux_sym_graphql_data_token1,
-    ACTIONS(45), 1,
-      anon_sym_LT2,
-    ACTIONS(47), 1,
-      anon_sym_DASH_DASH,
-    ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
-    ACTIONS(51), 1,
-      aux_sym__blank_line_token1,
-    ACTIONS(133), 1,
-      aux_sym_NL_token1,
-    STATE(82), 1,
-      sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
-      sym__comment_prefix,
-    STATE(233), 1,
-      sym_external_body,
-    ACTIONS(129), 2,
-      ts_builtin_sym_end,
-      aux_sym_request_separator_token1,
-    STATE(65), 2,
-      sym__blank_line,
-      aux_sym_request_repeat3,
-    STATE(50), 3,
-      sym_var_comment,
-      sym_res_handler_script,
-      aux_sym_request_repeat4,
-    ACTIONS(131), 6,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      sym_method,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-    STATE(97), 6,
-      sym_xml_body,
-      sym_json_body,
-      sym_graphql_body,
-      sym__external_body,
-      sym_multipart_form_data,
-      sym_raw_body,
-  [1248] = 21,
-    ACTIONS(29), 1,
-      aux_sym_WS_token1,
-    ACTIONS(33), 1,
-      aux_sym__comment_prefix_token1,
-    ACTIONS(35), 1,
-      aux_sym__comment_prefix_token2,
-    ACTIONS(37), 1,
-      anon_sym_GT,
-    ACTIONS(39), 1,
-      aux_sym_xml_body_token1,
-    ACTIONS(41), 1,
-      aux_sym_json_body_token1,
-    ACTIONS(43), 1,
-      aux_sym_graphql_data_token1,
-    ACTIONS(45), 1,
-      anon_sym_LT2,
-    ACTIONS(47), 1,
-      anon_sym_DASH_DASH,
-    ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
-    ACTIONS(51), 1,
-      aux_sym__blank_line_token1,
-    ACTIONS(139), 1,
-      aux_sym_NL_token1,
-    STATE(82), 1,
-      sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
-      sym__comment_prefix,
-    STATE(233), 1,
-      sym_external_body,
-    ACTIONS(135), 2,
-      ts_builtin_sym_end,
-      aux_sym_request_separator_token1,
-    STATE(65), 2,
-      sym__blank_line,
-      aux_sym_request_repeat3,
-    STATE(32), 3,
-      sym_var_comment,
-      sym_res_handler_script,
-      aux_sym_request_repeat4,
-    ACTIONS(137), 6,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      sym_method,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-    STATE(97), 6,
-      sym_xml_body,
-      sym_json_body,
-      sym_graphql_body,
-      sym__external_body,
-      sym_multipart_form_data,
-      sym_raw_body,
-  [1326] = 21,
-    ACTIONS(29), 1,
-      aux_sym_WS_token1,
-    ACTIONS(33), 1,
-      aux_sym__comment_prefix_token1,
-    ACTIONS(35), 1,
-      aux_sym__comment_prefix_token2,
-    ACTIONS(37), 1,
-      anon_sym_GT,
-    ACTIONS(39), 1,
-      aux_sym_xml_body_token1,
-    ACTIONS(41), 1,
-      aux_sym_json_body_token1,
-    ACTIONS(43), 1,
-      aux_sym_graphql_data_token1,
-    ACTIONS(45), 1,
-      anon_sym_LT2,
-    ACTIONS(47), 1,
-      anon_sym_DASH_DASH,
-    ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(51), 1,
       aux_sym__blank_line_token1,
     ACTIONS(145), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
-    ACTIONS(141), 2,
+    ACTIONS(133), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(65), 2,
+    STATE(78), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
-    STATE(47), 3,
+    STATE(34), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
-    ACTIONS(143), 6,
+    ACTIONS(135), 6,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       sym_method,
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
       sym__external_body,
       sym_multipart_form_data,
       sym_raw_body,
-  [1404] = 21,
+  [1350] = 20,
     ACTIONS(29), 1,
       aux_sym_WS_token1,
     ACTIONS(33), 1,
@@ -7038,26 +7625,24 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(51), 1,
       aux_sym__blank_line_token1,
     ACTIONS(151), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
     ACTIONS(147), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(65), 2,
+    STATE(78), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
-    STATE(35), 3,
+    STATE(43), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
@@ -7068,14 +7653,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
       sym__external_body,
       sym_multipart_form_data,
       sym_raw_body,
-  [1482] = 21,
+  [1425] = 20,
     ACTIONS(29), 1,
       aux_sym_WS_token1,
     ACTIONS(33), 1,
@@ -7095,26 +7680,24 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(51), 1,
       aux_sym__blank_line_token1,
     ACTIONS(157), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
     ACTIONS(153), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(65), 2,
+    STATE(78), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
-    STATE(53), 3,
+    STATE(49), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
@@ -7125,14 +7708,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
       sym__external_body,
       sym_multipart_form_data,
       sym_raw_body,
-  [1560] = 21,
+  [1500] = 20,
     ACTIONS(29), 1,
       aux_sym_WS_token1,
     ACTIONS(33), 1,
@@ -7152,26 +7735,24 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(51), 1,
       aux_sym__blank_line_token1,
     ACTIONS(163), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
     ACTIONS(159), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(65), 2,
+    STATE(78), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
-    STATE(39), 3,
+    STATE(32), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
@@ -7182,14 +7763,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
       sym__external_body,
       sym_multipart_form_data,
       sym_raw_body,
-  [1638] = 21,
+  [1575] = 20,
     ACTIONS(29), 1,
       aux_sym_WS_token1,
     ACTIONS(33), 1,
@@ -7209,44 +7790,42 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(51), 1,
       aux_sym__blank_line_token1,
-    ACTIONS(169), 1,
+    ACTIONS(165), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
-    ACTIONS(165), 2,
+    ACTIONS(147), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(65), 2,
+    STATE(78), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
-    STATE(43), 3,
+    STATE(54), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
-    ACTIONS(167), 6,
+    ACTIONS(149), 6,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       sym_method,
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
       sym__external_body,
       sym_multipart_form_data,
       sym_raw_body,
-  [1716] = 21,
+  [1650] = 20,
     ACTIONS(29), 1,
       aux_sym_WS_token1,
     ACTIONS(33), 1,
@@ -7266,44 +7845,42 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(51), 1,
       aux_sym__blank_line_token1,
-    ACTIONS(175), 1,
+    ACTIONS(171), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
-    ACTIONS(171), 2,
+    ACTIONS(167), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(65), 2,
+    STATE(78), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
-    STATE(58), 3,
+    STATE(57), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
-    ACTIONS(173), 6,
+    ACTIONS(169), 6,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       sym_method,
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
       sym__external_body,
       sym_multipart_form_data,
       sym_raw_body,
-  [1794] = 21,
+  [1725] = 20,
     ACTIONS(29), 1,
       aux_sym_WS_token1,
     ACTIONS(33), 1,
@@ -7323,44 +7900,42 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(51), 1,
       aux_sym__blank_line_token1,
-    ACTIONS(181), 1,
+    ACTIONS(177), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
-    ACTIONS(177), 2,
+    ACTIONS(173), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(65), 2,
+    STATE(78), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
-    STATE(37), 3,
+    STATE(38), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
-    ACTIONS(179), 6,
+    ACTIONS(175), 6,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       sym_method,
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
       sym__external_body,
       sym_multipart_form_data,
       sym_raw_body,
-  [1872] = 21,
+  [1800] = 20,
     ACTIONS(29), 1,
       aux_sym_WS_token1,
     ACTIONS(33), 1,
@@ -7380,44 +7955,42 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(51), 1,
       aux_sym__blank_line_token1,
-    ACTIONS(187), 1,
+    ACTIONS(183), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
-    ACTIONS(183), 2,
+    ACTIONS(179), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(65), 2,
+    STATE(78), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
-    STATE(46), 3,
+    STATE(53), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
-    ACTIONS(185), 6,
+    ACTIONS(181), 6,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       sym_method,
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
       sym__external_body,
       sym_multipart_form_data,
       sym_raw_body,
-  [1950] = 21,
+  [1875] = 20,
     ACTIONS(29), 1,
       aux_sym_WS_token1,
     ACTIONS(33), 1,
@@ -7437,44 +8010,42 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(51), 1,
       aux_sym__blank_line_token1,
     ACTIONS(189), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
-    ACTIONS(165), 2,
+    ACTIONS(185), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(65), 2,
+    STATE(78), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
-    STATE(31), 3,
+    STATE(50), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
-    ACTIONS(167), 6,
+    ACTIONS(187), 6,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       sym_method,
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
       sym__external_body,
       sym_multipart_form_data,
       sym_raw_body,
-  [2028] = 21,
+  [1950] = 20,
     ACTIONS(29), 1,
       aux_sym_WS_token1,
     ACTIONS(33), 1,
@@ -7494,26 +8065,24 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(51), 1,
       aux_sym__blank_line_token1,
     ACTIONS(195), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
     ACTIONS(191), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(65), 2,
+    STATE(78), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
-    STATE(49), 3,
+    STATE(56), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
@@ -7524,14 +8093,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
       sym__external_body,
       sym_multipart_form_data,
       sym_raw_body,
-  [2106] = 21,
+  [2025] = 20,
     ACTIONS(29), 1,
       aux_sym_WS_token1,
     ACTIONS(33), 1,
@@ -7551,44 +8120,42 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(51), 1,
       aux_sym__blank_line_token1,
     ACTIONS(197), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
-    ACTIONS(191), 2,
+    ACTIONS(53), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(65), 2,
+    STATE(78), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
-    STATE(55), 3,
+    STATE(30), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
-    ACTIONS(193), 6,
+    ACTIONS(55), 6,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       sym_method,
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
       sym__external_body,
       sym_multipart_form_data,
       sym_raw_body,
-  [2184] = 18,
+  [2100] = 17,
     ACTIONS(33), 1,
       aux_sym__comment_prefix_token1,
     ACTIONS(35), 1,
@@ -7606,25 +8173,23 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(203), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
     ACTIONS(199), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(52), 3,
+    STATE(42), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
@@ -7640,7 +8205,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
       anon_sym_AT2,
       aux_sym__blank_line_token1,
-  [2254] = 18,
+  [2167] = 17,
     ACTIONS(33), 1,
       aux_sym__comment_prefix_token1,
     ACTIONS(35), 1,
@@ -7658,25 +8223,23 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(203), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
     ACTIONS(205), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(52), 3,
+    STATE(42), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
@@ -7692,7 +8255,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
       anon_sym_AT2,
       aux_sym__blank_line_token1,
-  [2324] = 18,
+  [2234] = 17,
     ACTIONS(33), 1,
       aux_sym__comment_prefix_token1,
     ACTIONS(35), 1,
@@ -7710,25 +8273,23 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(203), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
     ACTIONS(209), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(52), 3,
+    STATE(42), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
@@ -7744,7 +8305,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
       anon_sym_AT2,
       aux_sym__blank_line_token1,
-  [2394] = 18,
+  [2301] = 17,
     ACTIONS(33), 1,
       aux_sym__comment_prefix_token1,
     ACTIONS(35), 1,
@@ -7762,25 +8323,73 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(203), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
+      sym_external_body,
+    ACTIONS(199), 2,
+      ts_builtin_sym_end,
+      aux_sym_request_separator_token1,
+    STATE(42), 3,
+      sym_var_comment,
+      sym_res_handler_script,
+      aux_sym_request_repeat4,
+    STATE(96), 6,
+      sym_xml_body,
+      sym_json_body,
+      sym_graphql_body,
+      sym__external_body,
+      sym_multipart_form_data,
+      sym_raw_body,
+    ACTIONS(201), 8,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym_WS_token1,
+      sym_method,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+      aux_sym__blank_line_token1,
+  [2368] = 17,
+    ACTIONS(33), 1,
+      aux_sym__comment_prefix_token1,
+    ACTIONS(35), 1,
+      aux_sym__comment_prefix_token2,
+    ACTIONS(37), 1,
+      anon_sym_GT,
+    ACTIONS(39), 1,
+      aux_sym_xml_body_token1,
+    ACTIONS(41), 1,
+      aux_sym_json_body_token1,
+    ACTIONS(43), 1,
+      aux_sym_graphql_data_token1,
+    ACTIONS(45), 1,
+      anon_sym_LT2,
+    ACTIONS(47), 1,
+      anon_sym_DASH_DASH,
+    ACTIONS(49), 1,
+      aux_sym_raw_body_token1,
+    ACTIONS(203), 1,
+      aux_sym_NL_token1,
+    STATE(88), 1,
+      sym_graphql_data,
+    STATE(224), 1,
+      sym__comment_prefix,
+    STATE(292), 1,
       sym_external_body,
     ACTIONS(213), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(52), 3,
+    STATE(42), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
@@ -7796,7 +8405,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
       anon_sym_AT2,
       aux_sym__blank_line_token1,
-  [2464] = 18,
+  [2435] = 17,
     ACTIONS(33), 1,
       aux_sym__comment_prefix_token1,
     ACTIONS(35), 1,
@@ -7814,25 +8423,23 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(203), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
     ACTIONS(217), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(52), 3,
+    STATE(42), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
@@ -7848,7 +8455,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
       anon_sym_AT2,
       aux_sym__blank_line_token1,
-  [2534] = 18,
+  [2502] = 17,
     ACTIONS(33), 1,
       aux_sym__comment_prefix_token1,
     ACTIONS(35), 1,
@@ -7866,25 +8473,73 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(203), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
+      sym_external_body,
+    ACTIONS(213), 2,
+      ts_builtin_sym_end,
+      aux_sym_request_separator_token1,
+    STATE(42), 3,
+      sym_var_comment,
+      sym_res_handler_script,
+      aux_sym_request_repeat4,
+    STATE(96), 6,
+      sym_xml_body,
+      sym_json_body,
+      sym_graphql_body,
+      sym__external_body,
+      sym_multipart_form_data,
+      sym_raw_body,
+    ACTIONS(215), 8,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym_WS_token1,
+      sym_method,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+      aux_sym__blank_line_token1,
+  [2569] = 17,
+    ACTIONS(33), 1,
+      aux_sym__comment_prefix_token1,
+    ACTIONS(35), 1,
+      aux_sym__comment_prefix_token2,
+    ACTIONS(37), 1,
+      anon_sym_GT,
+    ACTIONS(39), 1,
+      aux_sym_xml_body_token1,
+    ACTIONS(41), 1,
+      aux_sym_json_body_token1,
+    ACTIONS(43), 1,
+      aux_sym_graphql_data_token1,
+    ACTIONS(45), 1,
+      anon_sym_LT2,
+    ACTIONS(47), 1,
+      anon_sym_DASH_DASH,
+    ACTIONS(49), 1,
+      aux_sym_raw_body_token1,
+    ACTIONS(203), 1,
+      aux_sym_NL_token1,
+    STATE(88), 1,
+      sym_graphql_data,
+    STATE(224), 1,
+      sym__comment_prefix,
+    STATE(292), 1,
       sym_external_body,
     ACTIONS(221), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(52), 3,
+    STATE(42), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
@@ -7900,7 +8555,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
       anon_sym_AT2,
       aux_sym__blank_line_token1,
-  [2604] = 18,
+  [2636] = 17,
     ACTIONS(33), 1,
       aux_sym__comment_prefix_token1,
     ACTIONS(35), 1,
@@ -7918,25 +8573,23 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(203), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
     ACTIONS(225), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(52), 3,
+    STATE(42), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
@@ -7952,7 +8605,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
       anon_sym_AT2,
       aux_sym__blank_line_token1,
-  [2674] = 18,
+  [2703] = 17,
     ACTIONS(33), 1,
       aux_sym__comment_prefix_token1,
     ACTIONS(35), 1,
@@ -7970,25 +8623,23 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(203), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
     ACTIONS(229), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(52), 3,
+    STATE(42), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
@@ -8004,7 +8655,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
       anon_sym_AT2,
       aux_sym__blank_line_token1,
-  [2744] = 18,
+  [2770] = 17,
     ACTIONS(33), 1,
       aux_sym__comment_prefix_token1,
     ACTIONS(35), 1,
@@ -8022,25 +8673,23 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(203), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
     ACTIONS(233), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(52), 3,
+    STATE(42), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
@@ -8056,7 +8705,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
       anon_sym_AT2,
       aux_sym__blank_line_token1,
-  [2814] = 18,
+  [2837] = 17,
     ACTIONS(33), 1,
       aux_sym__comment_prefix_token1,
     ACTIONS(35), 1,
@@ -8074,25 +8723,23 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(203), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
     ACTIONS(237), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(52), 3,
+    STATE(42), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
@@ -8108,95 +8755,41 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
       anon_sym_AT2,
       aux_sym__blank_line_token1,
-  [2884] = 18,
-    ACTIONS(33), 1,
-      aux_sym__comment_prefix_token1,
-    ACTIONS(35), 1,
-      aux_sym__comment_prefix_token2,
-    ACTIONS(37), 1,
-      anon_sym_GT,
-    ACTIONS(39), 1,
-      aux_sym_xml_body_token1,
-    ACTIONS(41), 1,
-      aux_sym_json_body_token1,
-    ACTIONS(43), 1,
-      aux_sym_graphql_data_token1,
-    ACTIONS(45), 1,
-      anon_sym_LT2,
-    ACTIONS(47), 1,
-      anon_sym_DASH_DASH,
-    ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
-    ACTIONS(203), 1,
+  [2904] = 17,
+    ACTIONS(245), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
-      sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
-      sym__comment_prefix,
-    STATE(233), 1,
-      sym_external_body,
-    ACTIONS(225), 2,
-      ts_builtin_sym_end,
-      aux_sym_request_separator_token1,
-    STATE(52), 3,
-      sym_var_comment,
-      sym_res_handler_script,
-      aux_sym_request_repeat4,
-    STATE(97), 6,
-      sym_xml_body,
-      sym_json_body,
-      sym_graphql_body,
-      sym__external_body,
-      sym_multipart_form_data,
-      sym_raw_body,
-    ACTIONS(227), 8,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym_WS_token1,
-      sym_method,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-      aux_sym__blank_line_token1,
-  [2954] = 18,
-    ACTIONS(33), 1,
+    ACTIONS(248), 1,
       aux_sym__comment_prefix_token1,
-    ACTIONS(35), 1,
+    ACTIONS(251), 1,
       aux_sym__comment_prefix_token2,
-    ACTIONS(37), 1,
+    ACTIONS(254), 1,
       anon_sym_GT,
-    ACTIONS(39), 1,
+    ACTIONS(257), 1,
       aux_sym_xml_body_token1,
-    ACTIONS(41), 1,
+    ACTIONS(260), 1,
       aux_sym_json_body_token1,
-    ACTIONS(43), 1,
+    ACTIONS(263), 1,
       aux_sym_graphql_data_token1,
-    ACTIONS(45), 1,
+    ACTIONS(266), 1,
       anon_sym_LT2,
-    ACTIONS(47), 1,
+    ACTIONS(269), 1,
       anon_sym_DASH_DASH,
-    ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
-    ACTIONS(203), 1,
-      aux_sym_NL_token1,
-    STATE(82), 1,
+    ACTIONS(272), 1,
+      aux_sym_raw_body_token1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
     ACTIONS(241), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(52), 3,
+    STATE(42), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
@@ -8212,7 +8805,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
       anon_sym_AT2,
       aux_sym__blank_line_token1,
-  [3024] = 18,
+  [2971] = 17,
     ACTIONS(33), 1,
       aux_sym__comment_prefix_token1,
     ACTIONS(35), 1,
@@ -8230,32 +8823,30 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(203), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
-    ACTIONS(245), 2,
+    ACTIONS(275), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(52), 3,
+    STATE(42), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
       sym__external_body,
       sym_multipart_form_data,
       sym_raw_body,
-    ACTIONS(247), 8,
+    ACTIONS(277), 8,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       aux_sym_WS_token1,
@@ -8264,7 +8855,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
       anon_sym_AT2,
       aux_sym__blank_line_token1,
-  [3094] = 18,
+  [3038] = 17,
     ACTIONS(33), 1,
       aux_sym__comment_prefix_token1,
     ACTIONS(35), 1,
@@ -8282,32 +8873,30 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(203), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
-    ACTIONS(205), 2,
+    ACTIONS(279), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(52), 3,
+    STATE(42), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
       sym__external_body,
       sym_multipart_form_data,
       sym_raw_body,
-    ACTIONS(207), 8,
+    ACTIONS(281), 8,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       aux_sym_WS_token1,
@@ -8316,7 +8905,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
       anon_sym_AT2,
       aux_sym__blank_line_token1,
-  [3164] = 18,
+  [3105] = 17,
     ACTIONS(33), 1,
       aux_sym__comment_prefix_token1,
     ACTIONS(35), 1,
@@ -8334,32 +8923,30 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(203), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
-    ACTIONS(241), 2,
+    ACTIONS(283), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(52), 3,
+    STATE(42), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
       sym__external_body,
       sym_multipart_form_data,
       sym_raw_body,
-    ACTIONS(243), 8,
+    ACTIONS(285), 8,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       aux_sym_WS_token1,
@@ -8368,7 +8955,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
       anon_sym_AT2,
       aux_sym__blank_line_token1,
-  [3234] = 18,
+  [3172] = 17,
     ACTIONS(33), 1,
       aux_sym__comment_prefix_token1,
     ACTIONS(35), 1,
@@ -8386,32 +8973,30 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(203), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
-    ACTIONS(249), 2,
+    ACTIONS(287), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(52), 3,
+    STATE(42), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
       sym__external_body,
       sym_multipart_form_data,
       sym_raw_body,
-    ACTIONS(251), 8,
+    ACTIONS(289), 8,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       aux_sym_WS_token1,
@@ -8420,7 +9005,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
       anon_sym_AT2,
       aux_sym__blank_line_token1,
-  [3304] = 18,
+  [3239] = 17,
     ACTIONS(33), 1,
       aux_sym__comment_prefix_token1,
     ACTIONS(35), 1,
@@ -8438,32 +9023,30 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(203), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
-    ACTIONS(253), 2,
+    ACTIONS(291), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(52), 3,
+    STATE(42), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
       sym__external_body,
       sym_multipart_form_data,
       sym_raw_body,
-    ACTIONS(255), 8,
+    ACTIONS(293), 8,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       aux_sym_WS_token1,
@@ -8472,7 +9055,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
       anon_sym_AT2,
       aux_sym__blank_line_token1,
-  [3374] = 18,
+  [3306] = 17,
     ACTIONS(33), 1,
       aux_sym__comment_prefix_token1,
     ACTIONS(35), 1,
@@ -8490,32 +9073,30 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(203), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
-    ACTIONS(257), 2,
+    ACTIONS(295), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(52), 3,
+    STATE(42), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
       sym__external_body,
       sym_multipart_form_data,
       sym_raw_body,
-    ACTIONS(259), 8,
+    ACTIONS(297), 8,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       aux_sym_WS_token1,
@@ -8524,7 +9105,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
       anon_sym_AT2,
       aux_sym__blank_line_token1,
-  [3444] = 18,
+  [3373] = 17,
     ACTIONS(33), 1,
       aux_sym__comment_prefix_token1,
     ACTIONS(35), 1,
@@ -8542,32 +9123,30 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(203), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
-    ACTIONS(261), 2,
+    ACTIONS(299), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(52), 3,
+    STATE(42), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
       sym__external_body,
       sym_multipart_form_data,
       sym_raw_body,
-    ACTIONS(263), 8,
+    ACTIONS(301), 8,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       aux_sym_WS_token1,
@@ -8576,7 +9155,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
       anon_sym_AT2,
       aux_sym__blank_line_token1,
-  [3514] = 18,
+  [3440] = 17,
     ACTIONS(33), 1,
       aux_sym__comment_prefix_token1,
     ACTIONS(35), 1,
@@ -8594,32 +9173,30 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(203), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
-    ACTIONS(265), 2,
+    ACTIONS(303), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(52), 3,
+    STATE(42), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
       sym__external_body,
       sym_multipart_form_data,
       sym_raw_body,
-    ACTIONS(267), 8,
+    ACTIONS(305), 8,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       aux_sym_WS_token1,
@@ -8628,7 +9205,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
       anon_sym_AT2,
       aux_sym__blank_line_token1,
-  [3584] = 18,
+  [3507] = 17,
     ACTIONS(33), 1,
       aux_sym__comment_prefix_token1,
     ACTIONS(35), 1,
@@ -8646,32 +9223,30 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(203), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
-    ACTIONS(269), 2,
+    ACTIONS(307), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(52), 3,
+    STATE(42), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
       sym__external_body,
       sym_multipart_form_data,
       sym_raw_body,
-    ACTIONS(271), 8,
+    ACTIONS(309), 8,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       aux_sym_WS_token1,
@@ -8680,7 +9255,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
       anon_sym_AT2,
       aux_sym__blank_line_token1,
-  [3654] = 18,
+  [3574] = 17,
     ACTIONS(33), 1,
       aux_sym__comment_prefix_token1,
     ACTIONS(35), 1,
@@ -8698,129 +9273,23 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(203), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
-      sym_external_body,
-    ACTIONS(273), 2,
-      ts_builtin_sym_end,
-      aux_sym_request_separator_token1,
-    STATE(52), 3,
-      sym_var_comment,
-      sym_res_handler_script,
-      aux_sym_request_repeat4,
-    STATE(97), 6,
-      sym_xml_body,
-      sym_json_body,
-      sym_graphql_body,
-      sym__external_body,
-      sym_multipart_form_data,
-      sym_raw_body,
-    ACTIONS(275), 8,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym_WS_token1,
-      sym_method,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-      aux_sym__blank_line_token1,
-  [3724] = 18,
-    ACTIONS(281), 1,
-      aux_sym_NL_token1,
-    ACTIONS(284), 1,
-      aux_sym__comment_prefix_token1,
-    ACTIONS(287), 1,
-      aux_sym__comment_prefix_token2,
-    ACTIONS(290), 1,
-      anon_sym_GT,
-    ACTIONS(293), 1,
-      aux_sym_xml_body_token1,
-    ACTIONS(296), 1,
-      aux_sym_json_body_token1,
-    ACTIONS(299), 1,
-      aux_sym_graphql_data_token1,
-    ACTIONS(302), 1,
-      anon_sym_LT2,
-    ACTIONS(305), 1,
-      anon_sym_DASH_DASH,
-    ACTIONS(308), 1,
-      aux_sym_multipart_form_data_token1,
-    STATE(82), 1,
-      sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
-      sym__comment_prefix,
-    STATE(233), 1,
-      sym_external_body,
-    ACTIONS(277), 2,
-      ts_builtin_sym_end,
-      aux_sym_request_separator_token1,
-    STATE(52), 3,
-      sym_var_comment,
-      sym_res_handler_script,
-      aux_sym_request_repeat4,
-    STATE(97), 6,
-      sym_xml_body,
-      sym_json_body,
-      sym_graphql_body,
-      sym__external_body,
-      sym_multipart_form_data,
-      sym_raw_body,
-    ACTIONS(279), 8,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym_WS_token1,
-      sym_method,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-      aux_sym__blank_line_token1,
-  [3794] = 18,
-    ACTIONS(33), 1,
-      aux_sym__comment_prefix_token1,
-    ACTIONS(35), 1,
-      aux_sym__comment_prefix_token2,
-    ACTIONS(37), 1,
-      anon_sym_GT,
-    ACTIONS(39), 1,
-      aux_sym_xml_body_token1,
-    ACTIONS(41), 1,
-      aux_sym_json_body_token1,
-    ACTIONS(43), 1,
-      aux_sym_graphql_data_token1,
-    ACTIONS(45), 1,
-      anon_sym_LT2,
-    ACTIONS(47), 1,
-      anon_sym_DASH_DASH,
-    ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
-    ACTIONS(203), 1,
-      aux_sym_NL_token1,
-    STATE(82), 1,
-      sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
-      sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
     ACTIONS(311), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(52), 3,
+    STATE(42), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
@@ -8836,7 +9305,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
       anon_sym_AT2,
       aux_sym__blank_line_token1,
-  [3864] = 18,
+  [3641] = 17,
     ACTIONS(33), 1,
       aux_sym__comment_prefix_token1,
     ACTIONS(35), 1,
@@ -8854,25 +9323,23 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(203), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
     ACTIONS(315), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(52), 3,
+    STATE(42), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
@@ -8888,7 +9355,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
       anon_sym_AT2,
       aux_sym__blank_line_token1,
-  [3934] = 18,
+  [3708] = 17,
     ACTIONS(33), 1,
       aux_sym__comment_prefix_token1,
     ACTIONS(35), 1,
@@ -8906,32 +9373,30 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(203), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
-    ACTIONS(265), 2,
+    ACTIONS(275), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(52), 3,
+    STATE(42), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
       sym__external_body,
       sym_multipart_form_data,
       sym_raw_body,
-    ACTIONS(267), 8,
+    ACTIONS(277), 8,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       aux_sym_WS_token1,
@@ -8940,7 +9405,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
       anon_sym_AT2,
       aux_sym__blank_line_token1,
-  [4004] = 18,
+  [3775] = 17,
     ACTIONS(33), 1,
       aux_sym__comment_prefix_token1,
     ACTIONS(35), 1,
@@ -8958,25 +9423,23 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(203), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
     ACTIONS(319), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(52), 3,
+    STATE(42), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
@@ -8992,7 +9455,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
       anon_sym_AT2,
       aux_sym__blank_line_token1,
-  [4074] = 18,
+  [3842] = 17,
     ACTIONS(33), 1,
       aux_sym__comment_prefix_token1,
     ACTIONS(35), 1,
@@ -9010,25 +9473,23 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(203), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
     ACTIONS(323), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(52), 3,
+    STATE(42), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
@@ -9044,7 +9505,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
       anon_sym_AT2,
       aux_sym__blank_line_token1,
-  [4144] = 18,
+  [3909] = 17,
     ACTIONS(33), 1,
       aux_sym__comment_prefix_token1,
     ACTIONS(35), 1,
@@ -9062,25 +9523,23 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 1,
       anon_sym_DASH_DASH,
     ACTIONS(49), 1,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
     ACTIONS(203), 1,
       aux_sym_NL_token1,
-    STATE(82), 1,
+    STATE(88), 1,
       sym_graphql_data,
-    STATE(87), 1,
-      sym__raw_body,
-    STATE(222), 1,
+    STATE(224), 1,
       sym__comment_prefix,
-    STATE(233), 1,
+    STATE(292), 1,
       sym_external_body,
     ACTIONS(327), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(52), 3,
+    STATE(42), 3,
       sym_var_comment,
       sym_res_handler_script,
       aux_sym_request_repeat4,
-    STATE(97), 6,
+    STATE(96), 6,
       sym_xml_body,
       sym_json_body,
       sym_graphql_body,
@@ -9096,20 +9555,70 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
       anon_sym_AT2,
       aux_sym__blank_line_token1,
-  [4214] = 10,
+  [3976] = 17,
+    ACTIONS(33), 1,
+      aux_sym__comment_prefix_token1,
+    ACTIONS(35), 1,
+      aux_sym__comment_prefix_token2,
+    ACTIONS(37), 1,
+      anon_sym_GT,
+    ACTIONS(39), 1,
+      aux_sym_xml_body_token1,
+    ACTIONS(41), 1,
+      aux_sym_json_body_token1,
+    ACTIONS(43), 1,
+      aux_sym_graphql_data_token1,
     ACTIONS(45), 1,
       anon_sym_LT2,
+    ACTIONS(47), 1,
+      anon_sym_DASH_DASH,
+    ACTIONS(49), 1,
+      aux_sym_raw_body_token1,
+    ACTIONS(203), 1,
+      aux_sym_NL_token1,
+    STATE(88), 1,
+      sym_graphql_data,
+    STATE(224), 1,
+      sym__comment_prefix,
+    STATE(292), 1,
+      sym_external_body,
+    ACTIONS(205), 2,
+      ts_builtin_sym_end,
+      aux_sym_request_separator_token1,
+    STATE(42), 3,
+      sym_var_comment,
+      sym_res_handler_script,
+      aux_sym_request_repeat4,
+    STATE(96), 6,
+      sym_xml_body,
+      sym_json_body,
+      sym_graphql_body,
+      sym__external_body,
+      sym_multipart_form_data,
+      sym_raw_body,
+    ACTIONS(207), 8,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym_WS_token1,
+      sym_method,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+      aux_sym__blank_line_token1,
+  [4043] = 10,
     ACTIONS(335), 1,
       aux_sym__comment_prefix_token1,
-    ACTIONS(337), 1,
+    ACTIONS(338), 1,
       aux_sym__comment_prefix_token2,
-    ACTIONS(341), 1,
+    ACTIONS(344), 1,
+      anon_sym_LT2,
+    ACTIONS(347), 1,
       aux_sym_multipart_form_data_token1,
-    STATE(219), 1,
+    STATE(226), 1,
       sym_external_body,
-    STATE(221), 1,
+    STATE(228), 1,
       sym__comment_prefix,
-    STATE(61), 2,
+    STATE(59), 2,
       sym_comment,
       aux_sym_multipart_form_data_repeat1,
     ACTIONS(331), 4,
@@ -9117,12 +9626,12 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_request_separator_token1,
       anon_sym_GT,
       aux_sym_graphql_data_token1,
-    ACTIONS(339), 4,
+    ACTIONS(341), 4,
       aux_sym_xml_body_token1,
       aux_sym_json_body_token1,
       anon_sym_DASH_DASH,
       aux_sym_multipart_form_data_token2,
-    ACTIONS(333), 9,
+    ACTIONS(333), 10,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       aux_sym_WS_token1,
@@ -9131,8 +9640,83 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
+      aux_sym_raw_body_token1,
       aux_sym__blank_line_token1,
-  [4260] = 19,
+  [4090] = 10,
+    ACTIONS(45), 1,
+      anon_sym_LT2,
+    ACTIONS(354), 1,
+      aux_sym__comment_prefix_token1,
+    ACTIONS(356), 1,
+      aux_sym__comment_prefix_token2,
+    ACTIONS(360), 1,
+      aux_sym_multipart_form_data_token1,
+    STATE(226), 1,
+      sym_external_body,
+    STATE(228), 1,
+      sym__comment_prefix,
+    STATE(61), 2,
+      sym_comment,
+      aux_sym_multipart_form_data_repeat1,
+    ACTIONS(350), 4,
+      ts_builtin_sym_end,
+      aux_sym_request_separator_token1,
+      anon_sym_GT,
+      aux_sym_graphql_data_token1,
+    ACTIONS(358), 4,
+      aux_sym_xml_body_token1,
+      aux_sym_json_body_token1,
+      anon_sym_DASH_DASH,
+      aux_sym_multipart_form_data_token2,
+    ACTIONS(352), 10,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym_WS_token1,
+      aux_sym_NL_token1,
+      sym_method,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+      aux_sym_raw_body_token1,
+      aux_sym__blank_line_token1,
+  [4137] = 10,
+    ACTIONS(45), 1,
+      anon_sym_LT2,
+    ACTIONS(354), 1,
+      aux_sym__comment_prefix_token1,
+    ACTIONS(356), 1,
+      aux_sym__comment_prefix_token2,
+    ACTIONS(368), 1,
+      aux_sym_multipart_form_data_token1,
+    STATE(226), 1,
+      sym_external_body,
+    STATE(228), 1,
+      sym__comment_prefix,
+    STATE(59), 2,
+      sym_comment,
+      aux_sym_multipart_form_data_repeat1,
+    ACTIONS(362), 4,
+      ts_builtin_sym_end,
+      aux_sym_request_separator_token1,
+      anon_sym_GT,
+      aux_sym_graphql_data_token1,
+    ACTIONS(366), 4,
+      aux_sym_xml_body_token1,
+      aux_sym_json_body_token1,
+      anon_sym_DASH_DASH,
+      aux_sym_multipart_form_data_token2,
+    ACTIONS(364), 10,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym_WS_token1,
+      aux_sym_NL_token1,
+      sym_method,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+      aux_sym_raw_body_token1,
+      aux_sym__blank_line_token1,
+  [4184] = 19,
     ACTIONS(7), 1,
       aux_sym_WS_token1,
     ACTIONS(9), 1,
@@ -9151,17 +9735,17 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AT2,
     ACTIONS(23), 1,
       aux_sym__blank_line_token1,
-    ACTIONS(343), 1,
+    ACTIONS(370), 1,
       ts_builtin_sym_end,
-    STATE(80), 1,
+    STATE(72), 1,
       sym_request_separator,
-    STATE(151), 1,
+    STATE(140), 1,
       sym_request,
-    STATE(152), 1,
+    STATE(144), 1,
       sym__section_content,
-    STATE(228), 1,
+    STATE(231), 1,
       sym_target_url,
-    STATE(229), 1,
+    STATE(234), 1,
       sym__comment_prefix,
     ACTIONS(5), 2,
       aux_sym_WORD_CHAR_token1,
@@ -9169,87 +9753,15 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(63), 2,
       sym_section,
       aux_sym_document_repeat1,
-    STATE(162), 2,
+    STATE(168), 2,
       aux_sym__target_url_line,
       sym_variable,
-    STATE(71), 4,
+    STATE(73), 4,
       sym_comment,
       sym_pre_request_script,
       sym_variable_declaration,
       sym__blank_line,
-  [4324] = 10,
-    ACTIONS(45), 1,
-      anon_sym_LT2,
-    ACTIONS(335), 1,
-      aux_sym__comment_prefix_token1,
-    ACTIONS(337), 1,
-      aux_sym__comment_prefix_token2,
-    ACTIONS(351), 1,
-      aux_sym_multipart_form_data_token1,
-    STATE(219), 1,
-      sym_external_body,
-    STATE(221), 1,
-      sym__comment_prefix,
-    STATE(62), 2,
-      sym_comment,
-      aux_sym_multipart_form_data_repeat1,
-    ACTIONS(345), 4,
-      ts_builtin_sym_end,
-      aux_sym_request_separator_token1,
-      anon_sym_GT,
-      aux_sym_graphql_data_token1,
-    ACTIONS(349), 4,
-      aux_sym_xml_body_token1,
-      aux_sym_json_body_token1,
-      anon_sym_DASH_DASH,
-      aux_sym_multipart_form_data_token2,
-    ACTIONS(347), 9,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym_WS_token1,
-      aux_sym_NL_token1,
-      sym_method,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-      aux_sym__blank_line_token1,
-  [4370] = 10,
-    ACTIONS(357), 1,
-      aux_sym__comment_prefix_token1,
-    ACTIONS(360), 1,
-      aux_sym__comment_prefix_token2,
-    ACTIONS(366), 1,
-      anon_sym_LT2,
-    ACTIONS(369), 1,
-      aux_sym_multipart_form_data_token1,
-    STATE(219), 1,
-      sym_external_body,
-    STATE(221), 1,
-      sym__comment_prefix,
-    STATE(62), 2,
-      sym_comment,
-      aux_sym_multipart_form_data_repeat1,
-    ACTIONS(353), 4,
-      ts_builtin_sym_end,
-      aux_sym_request_separator_token1,
-      anon_sym_GT,
-      aux_sym_graphql_data_token1,
-    ACTIONS(363), 4,
-      aux_sym_xml_body_token1,
-      aux_sym_json_body_token1,
-      anon_sym_DASH_DASH,
-      aux_sym_multipart_form_data_token2,
-    ACTIONS(355), 9,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym_WS_token1,
-      aux_sym_NL_token1,
-      sym_method,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-      aux_sym__blank_line_token1,
-  [4416] = 19,
+  [4248] = 19,
     ACTIONS(372), 1,
       ts_builtin_sym_end,
     ACTIONS(377), 1,
@@ -9270,15 +9782,15 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AT2,
     ACTIONS(401), 1,
       aux_sym__blank_line_token1,
-    STATE(80), 1,
+    STATE(72), 1,
       sym_request_separator,
-    STATE(151), 1,
+    STATE(140), 1,
       sym_request,
-    STATE(152), 1,
+    STATE(144), 1,
       sym__section_content,
-    STATE(228), 1,
+    STATE(231), 1,
       sym_target_url,
-    STATE(229), 1,
+    STATE(234), 1,
       sym__comment_prefix,
     ACTIONS(374), 2,
       aux_sym_WORD_CHAR_token1,
@@ -9286,91 +9798,26 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(63), 2,
       sym_section,
       aux_sym_document_repeat1,
-    STATE(162), 2,
+    STATE(168), 2,
       aux_sym__target_url_line,
       sym_variable,
-    STATE(71), 4,
+    STATE(73), 4,
       sym_comment,
       sym_pre_request_script,
       sym_variable_declaration,
       sym__blank_line,
-  [4480] = 14,
+  [4312] = 7,
     ACTIONS(408), 1,
-      aux_sym_WS_token1,
-    ACTIONS(410), 1,
       aux_sym__comment_prefix_token1,
-    ACTIONS(412), 1,
+    ACTIONS(411), 1,
       aux_sym__comment_prefix_token2,
     ACTIONS(414), 1,
-      sym_http_version,
-    ACTIONS(416), 1,
-      sym_header_entity,
-    ACTIONS(418), 1,
-      aux_sym__blank_line_token1,
-    STATE(100), 1,
-      aux_sym_request_repeat2,
-    STATE(113), 1,
-      sym_response,
-    STATE(129), 1,
-      sym_header,
-    STATE(212), 1,
-      sym__comment_prefix,
-    STATE(22), 2,
-      sym__blank_line,
-      aux_sym_request_repeat3,
-    STATE(69), 2,
-      sym_comment,
-      aux_sym_request_repeat1,
-    ACTIONS(406), 3,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      sym_method,
-    ACTIONS(404), 5,
-      ts_builtin_sym_end,
-      aux_sym_request_separator_token1,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-  [4531] = 5,
-    ACTIONS(424), 1,
-      aux_sym_WS_token1,
-    ACTIONS(427), 1,
-      aux_sym__blank_line_token1,
-    STATE(65), 2,
-      sym__blank_line,
-      aux_sym_request_repeat3,
-    ACTIONS(420), 8,
-      ts_builtin_sym_end,
-      aux_sym__comment_prefix_token2,
-      aux_sym_request_separator_token1,
-      anon_sym_GT,
-      aux_sym_xml_body_token1,
-      aux_sym_json_body_token1,
-      aux_sym_graphql_data_token1,
-      anon_sym_DASH_DASH,
-    ACTIONS(422), 10,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym_NL_token1,
-      aux_sym__comment_prefix_token1,
-      sym_method,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-      anon_sym_LT2,
       aux_sym_multipart_form_data_token1,
-  [4564] = 7,
-    ACTIONS(434), 1,
-      aux_sym__comment_prefix_token1,
-    ACTIONS(437), 1,
-      aux_sym__comment_prefix_token2,
-    ACTIONS(440), 1,
-      aux_sym_multipart_form_data_token1,
-    STATE(93), 1,
+    STATE(97), 1,
       sym__raw_body,
-    STATE(253), 1,
+    STATE(276), 1,
       sym__comment_prefix,
-    ACTIONS(430), 7,
+    ACTIONS(404), 7,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
       anon_sym_GT,
@@ -9378,7 +9825,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_json_body_token1,
       aux_sym_graphql_data_token1,
       anon_sym_DASH_DASH,
-    ACTIONS(432), 10,
+    ACTIONS(406), 11,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       aux_sym_WS_token1,
@@ -9388,19 +9835,82 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
       anon_sym_AT2,
       anon_sym_LT2,
+      aux_sym_raw_body_token1,
       aux_sym__blank_line_token1,
-  [4601] = 7,
-    ACTIONS(447), 1,
-      aux_sym__comment_prefix_token1,
-    ACTIONS(450), 1,
-      aux_sym__comment_prefix_token2,
-    ACTIONS(453), 1,
+  [4350] = 7,
+    ACTIONS(414), 1,
       aux_sym_multipart_form_data_token1,
+    ACTIONS(420), 1,
+      aux_sym__comment_prefix_token1,
+    ACTIONS(423), 1,
+      aux_sym__comment_prefix_token2,
+    STATE(92), 1,
+      sym__raw_body,
+    STATE(276), 1,
+      sym__comment_prefix,
+    ACTIONS(416), 7,
+      ts_builtin_sym_end,
+      aux_sym_request_separator_token1,
+      anon_sym_GT,
+      aux_sym_xml_body_token1,
+      aux_sym_json_body_token1,
+      aux_sym_graphql_data_token1,
+      anon_sym_DASH_DASH,
+    ACTIONS(418), 11,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym_WS_token1,
+      aux_sym_NL_token1,
+      sym_method,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+      anon_sym_LT2,
+      aux_sym_raw_body_token1,
+      aux_sym__blank_line_token1,
+  [4388] = 7,
+    ACTIONS(414), 1,
+      aux_sym_multipart_form_data_token1,
+    ACTIONS(430), 1,
+      aux_sym__comment_prefix_token1,
+    ACTIONS(433), 1,
+      aux_sym__comment_prefix_token2,
+    STATE(94), 1,
+      sym__raw_body,
+    STATE(276), 1,
+      sym__comment_prefix,
+    ACTIONS(426), 7,
+      ts_builtin_sym_end,
+      aux_sym_request_separator_token1,
+      anon_sym_GT,
+      aux_sym_xml_body_token1,
+      aux_sym_json_body_token1,
+      aux_sym_graphql_data_token1,
+      anon_sym_DASH_DASH,
+    ACTIONS(428), 11,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym_WS_token1,
+      aux_sym_NL_token1,
+      sym_method,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+      anon_sym_LT2,
+      aux_sym_raw_body_token1,
+      aux_sym__blank_line_token1,
+  [4426] = 7,
+    ACTIONS(414), 1,
+      aux_sym_multipart_form_data_token1,
+    ACTIONS(440), 1,
+      aux_sym__comment_prefix_token1,
+    ACTIONS(443), 1,
+      aux_sym__comment_prefix_token2,
     STATE(90), 1,
       sym__raw_body,
-    STATE(253), 1,
+    STATE(276), 1,
       sym__comment_prefix,
-    ACTIONS(443), 7,
+    ACTIONS(436), 7,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
       anon_sym_GT,
@@ -9408,7 +9918,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_json_body_token1,
       aux_sym_graphql_data_token1,
       anon_sym_DASH_DASH,
-    ACTIONS(445), 10,
+    ACTIONS(438), 11,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       aux_sym_WS_token1,
@@ -9418,414 +9928,135 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
       anon_sym_AT2,
       anon_sym_LT2,
+      aux_sym_raw_body_token1,
       aux_sym__blank_line_token1,
-  [4638] = 14,
-    ACTIONS(408), 1,
-      aux_sym_WS_token1,
-    ACTIONS(410), 1,
-      aux_sym__comment_prefix_token1,
-    ACTIONS(412), 1,
+  [4464] = 2,
+    ACTIONS(446), 9,
+      ts_builtin_sym_end,
       aux_sym__comment_prefix_token2,
-    ACTIONS(414), 1,
-      sym_http_version,
-    ACTIONS(416), 1,
-      sym_header_entity,
+      aux_sym_request_separator_token1,
+      anon_sym_GT,
+      aux_sym_xml_body_token1,
+      aux_sym_json_body_token1,
+      aux_sym_graphql_data_token1,
+      anon_sym_DASH_DASH,
+      aux_sym_multipart_form_data_token2,
+    ACTIONS(448), 13,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym_WS_token1,
+      aux_sym_NL_token1,
+      aux_sym__comment_prefix_token1,
+      sym_method,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+      anon_sym_LT2,
+      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
+      aux_sym__blank_line_token1,
+  [4491] = 14,
+    ACTIONS(454), 1,
+      aux_sym_WS_token1,
+    ACTIONS(456), 1,
+      aux_sym__comment_prefix_token1,
+    ACTIONS(458), 1,
+      aux_sym__comment_prefix_token2,
     ACTIONS(460), 1,
-      aux_sym__blank_line_token1,
-    STATE(104), 1,
-      sym_response,
-    STATE(106), 1,
-      aux_sym_request_repeat2,
-    STATE(129), 1,
-      sym_header,
-    STATE(212), 1,
-      sym__comment_prefix,
-    STATE(2), 2,
-      sym__blank_line,
-      aux_sym_request_repeat3,
-    STATE(79), 2,
-      sym_comment,
-      aux_sym_request_repeat1,
-    ACTIONS(458), 3,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      sym_method,
-    ACTIONS(456), 5,
-      ts_builtin_sym_end,
-      aux_sym_request_separator_token1,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-  [4689] = 14,
-    ACTIONS(408), 1,
-      aux_sym_WS_token1,
-    ACTIONS(410), 1,
-      aux_sym__comment_prefix_token1,
-    ACTIONS(412), 1,
-      aux_sym__comment_prefix_token2,
-    ACTIONS(414), 1,
       sym_http_version,
-    ACTIONS(416), 1,
-      sym_header_entity,
     ACTIONS(462), 1,
-      aux_sym__blank_line_token1,
-    STATE(107), 1,
-      aux_sym_request_repeat2,
-    STATE(108), 1,
-      sym_response,
-    STATE(129), 1,
-      sym_header,
-    STATE(212), 1,
-      sym__comment_prefix,
-    STATE(3), 2,
-      sym__blank_line,
-      aux_sym_request_repeat3,
-    STATE(121), 2,
-      sym_comment,
-      aux_sym_request_repeat1,
-    ACTIONS(161), 3,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      sym_method,
-    ACTIONS(159), 5,
-      ts_builtin_sym_end,
-      aux_sym_request_separator_token1,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-  [4740] = 4,
-    ACTIONS(468), 1,
-      aux_sym_xml_body_token2,
-    STATE(70), 1,
-      aux_sym_xml_body_repeat1,
-    ACTIONS(464), 3,
-      ts_builtin_sym_end,
-      aux_sym_request_separator_token1,
-      anon_sym_GT,
-    ACTIONS(466), 17,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym_WS_token1,
-      aux_sym_NL_token1,
-      aux_sym__comment_prefix_token1,
-      aux_sym__comment_prefix_token2,
-      sym_method,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-      aux_sym_xml_body_token1,
-      aux_sym_json_body_token1,
-      aux_sym_graphql_data_token1,
-      anon_sym_LT2,
-      anon_sym_DASH_DASH,
-      aux_sym_multipart_form_data_token1,
-      aux_sym__blank_line_token1,
-  [4771] = 16,
-    ACTIONS(476), 1,
-      aux_sym_WS_token1,
-    ACTIONS(479), 1,
-      aux_sym__comment_prefix_token1,
-    ACTIONS(482), 1,
-      aux_sym__comment_prefix_token2,
-    ACTIONS(485), 1,
-      sym_method,
-    ACTIONS(488), 1,
-      anon_sym_LBRACE_LBRACE,
-    ACTIONS(491), 1,
-      anon_sym_LT,
-    ACTIONS(494), 1,
-      anon_sym_AT2,
-    ACTIONS(497), 1,
-      aux_sym__blank_line_token1,
-    STATE(139), 1,
-      sym__section_content,
-    STATE(151), 1,
-      sym_request,
-    STATE(228), 1,
-      sym_target_url,
-    STATE(229), 1,
-      sym__comment_prefix,
-    ACTIONS(471), 2,
-      ts_builtin_sym_end,
-      aux_sym_request_separator_token1,
-    ACTIONS(473), 2,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-    STATE(162), 2,
-      aux_sym__target_url_line,
-      sym_variable,
-    STATE(71), 4,
-      sym_comment,
-      sym_pre_request_script,
-      sym_variable_declaration,
-      sym__blank_line,
-  [4826] = 14,
-    ACTIONS(408), 1,
-      aux_sym_WS_token1,
-    ACTIONS(410), 1,
-      aux_sym__comment_prefix_token1,
-    ACTIONS(412), 1,
-      aux_sym__comment_prefix_token2,
-    ACTIONS(414), 1,
-      sym_http_version,
-    ACTIONS(416), 1,
       sym_header_entity,
-    ACTIONS(504), 1,
+    ACTIONS(464), 1,
       aux_sym__blank_line_token1,
-    STATE(114), 1,
+    STATE(111), 1,
       sym_response,
-    STATE(117), 1,
+    STATE(112), 1,
       aux_sym_request_repeat2,
-    STATE(129), 1,
+    STATE(132), 1,
       sym_header,
-    STATE(212), 1,
-      sym__comment_prefix,
-    STATE(16), 2,
-      sym__blank_line,
-      aux_sym_request_repeat3,
-    STATE(76), 2,
-      sym_comment,
-      aux_sym_request_repeat1,
-    ACTIONS(502), 3,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      sym_method,
-    ACTIONS(500), 5,
-      ts_builtin_sym_end,
-      aux_sym_request_separator_token1,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-  [4877] = 4,
-    ACTIONS(510), 1,
-      aux_sym_xml_body_token2,
-    STATE(70), 1,
-      aux_sym_xml_body_repeat1,
-    ACTIONS(506), 3,
-      ts_builtin_sym_end,
-      aux_sym_request_separator_token1,
-      anon_sym_GT,
-    ACTIONS(508), 17,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym_WS_token1,
-      aux_sym_NL_token1,
-      aux_sym__comment_prefix_token1,
-      aux_sym__comment_prefix_token2,
-      sym_method,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-      aux_sym_xml_body_token1,
-      aux_sym_json_body_token1,
-      aux_sym_graphql_data_token1,
-      anon_sym_LT2,
-      anon_sym_DASH_DASH,
-      aux_sym_multipart_form_data_token1,
-      aux_sym__blank_line_token1,
-  [4908] = 4,
-    ACTIONS(510), 1,
-      aux_sym_xml_body_token2,
-    STATE(70), 1,
-      aux_sym_xml_body_repeat1,
-    ACTIONS(512), 3,
-      ts_builtin_sym_end,
-      aux_sym_request_separator_token1,
-      anon_sym_GT,
-    ACTIONS(514), 17,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym_WS_token1,
-      aux_sym_NL_token1,
-      aux_sym__comment_prefix_token1,
-      aux_sym__comment_prefix_token2,
-      sym_method,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-      aux_sym_xml_body_token1,
-      aux_sym_json_body_token1,
-      aux_sym_graphql_data_token1,
-      anon_sym_LT2,
-      anon_sym_DASH_DASH,
-      aux_sym_multipart_form_data_token1,
-      aux_sym__blank_line_token1,
-  [4939] = 4,
-    ACTIONS(510), 1,
-      aux_sym_xml_body_token2,
-    STATE(70), 1,
-      aux_sym_xml_body_repeat1,
-    ACTIONS(516), 3,
-      ts_builtin_sym_end,
-      aux_sym_request_separator_token1,
-      anon_sym_GT,
-    ACTIONS(518), 17,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym_WS_token1,
-      aux_sym_NL_token1,
-      aux_sym__comment_prefix_token1,
-      aux_sym__comment_prefix_token2,
-      sym_method,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-      aux_sym_xml_body_token1,
-      aux_sym_json_body_token1,
-      aux_sym_graphql_data_token1,
-      anon_sym_LT2,
-      anon_sym_DASH_DASH,
-      aux_sym_multipart_form_data_token1,
-      aux_sym__blank_line_token1,
-  [4970] = 14,
-    ACTIONS(408), 1,
-      aux_sym_WS_token1,
-    ACTIONS(410), 1,
-      aux_sym__comment_prefix_token1,
-    ACTIONS(412), 1,
-      aux_sym__comment_prefix_token2,
-    ACTIONS(414), 1,
-      sym_http_version,
-    ACTIONS(416), 1,
-      sym_header_entity,
-    ACTIONS(520), 1,
-      aux_sym__blank_line_token1,
-    STATE(99), 1,
-      aux_sym_request_repeat2,
-    STATE(118), 1,
-      sym_response,
-    STATE(129), 1,
-      sym_header,
-    STATE(212), 1,
+    STATE(218), 1,
       sym__comment_prefix,
     STATE(4), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
-    STATE(121), 2,
+    STATE(87), 2,
       sym_comment,
       aux_sym_request_repeat1,
-    ACTIONS(125), 3,
+    ACTIONS(452), 3,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       sym_method,
-    ACTIONS(123), 5,
+    ACTIONS(450), 5,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [5021] = 14,
-    ACTIONS(408), 1,
+  [4542] = 14,
+    ACTIONS(454), 1,
       aux_sym_WS_token1,
-    ACTIONS(410), 1,
+    ACTIONS(456), 1,
       aux_sym__comment_prefix_token1,
-    ACTIONS(412), 1,
+    ACTIONS(458), 1,
       aux_sym__comment_prefix_token2,
-    ACTIONS(414), 1,
+    ACTIONS(460), 1,
       sym_http_version,
-    ACTIONS(416), 1,
+    ACTIONS(462), 1,
       sym_header_entity,
-    ACTIONS(522), 1,
+    ACTIONS(466), 1,
       aux_sym__blank_line_token1,
-    STATE(111), 1,
+    STATE(105), 1,
       aux_sym_request_repeat2,
-    STATE(112), 1,
+    STATE(106), 1,
       sym_response,
-    STATE(129), 1,
+    STATE(132), 1,
       sym_header,
-    STATE(212), 1,
+    STATE(218), 1,
       sym__comment_prefix,
-    STATE(18), 2,
+    STATE(28), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
-    STATE(121), 2,
+    STATE(124), 2,
       sym_comment,
       aux_sym_request_repeat1,
-    ACTIONS(119), 3,
+    ACTIONS(73), 3,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       sym_method,
-    ACTIONS(117), 5,
+    ACTIONS(71), 5,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [5072] = 14,
-    ACTIONS(408), 1,
+  [4593] = 4,
+    ACTIONS(472), 1,
+      aux_sym_xml_body_token2,
+    STATE(79), 1,
+      aux_sym_xml_body_repeat1,
+    ACTIONS(468), 3,
+      ts_builtin_sym_end,
+      aux_sym_request_separator_token1,
+      anon_sym_GT,
+    ACTIONS(470), 17,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
       aux_sym_WS_token1,
-    ACTIONS(410), 1,
+      aux_sym_NL_token1,
       aux_sym__comment_prefix_token1,
-    ACTIONS(412), 1,
       aux_sym__comment_prefix_token2,
-    ACTIONS(414), 1,
-      sym_http_version,
-    ACTIONS(416), 1,
-      sym_header_entity,
-    ACTIONS(528), 1,
-      aux_sym__blank_line_token1,
-    STATE(116), 1,
-      aux_sym_request_repeat2,
-    STATE(120), 1,
-      sym_response,
-    STATE(129), 1,
-      sym_header,
-    STATE(212), 1,
-      sym__comment_prefix,
-    STATE(15), 2,
-      sym__blank_line,
-      aux_sym_request_repeat3,
-    STATE(77), 2,
-      sym_comment,
-      aux_sym_request_repeat1,
-    ACTIONS(526), 3,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
       sym_method,
-    ACTIONS(524), 5,
-      ts_builtin_sym_end,
-      aux_sym_request_separator_token1,
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [5123] = 14,
-    ACTIONS(408), 1,
-      aux_sym_WS_token1,
-    ACTIONS(410), 1,
-      aux_sym__comment_prefix_token1,
-    ACTIONS(412), 1,
-      aux_sym__comment_prefix_token2,
-    ACTIONS(414), 1,
-      sym_http_version,
-    ACTIONS(416), 1,
-      sym_header_entity,
-    ACTIONS(530), 1,
+      aux_sym_xml_body_token1,
+      aux_sym_json_body_token1,
+      aux_sym_graphql_data_token1,
+      anon_sym_LT2,
+      anon_sym_DASH_DASH,
+      aux_sym_raw_body_token1,
       aux_sym__blank_line_token1,
-    STATE(101), 1,
-      sym_response,
-    STATE(103), 1,
-      aux_sym_request_repeat2,
-    STATE(129), 1,
-      sym_header,
-    STATE(212), 1,
-      sym__comment_prefix,
-    STATE(25), 2,
-      sym__blank_line,
-      aux_sym_request_repeat3,
-    STATE(121), 2,
-      sym_comment,
-      aux_sym_request_repeat1,
-    ACTIONS(27), 3,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      sym_method,
-    ACTIONS(25), 5,
-      ts_builtin_sym_end,
-      aux_sym_request_separator_token1,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-  [5174] = 16,
+  [4624] = 16,
     ACTIONS(7), 1,
       aux_sym_WS_token1,
     ACTIONS(9), 1,
@@ -9843,29 +10074,68 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(23), 1,
       aux_sym__blank_line_token1,
     STATE(140), 1,
-      sym__section_content,
-    STATE(151), 1,
       sym_request,
-    STATE(228), 1,
+    STATE(151), 1,
+      sym__section_content,
+    STATE(231), 1,
       sym_target_url,
-    STATE(229), 1,
+    STATE(234), 1,
       sym__comment_prefix,
     ACTIONS(5), 2,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
-    ACTIONS(532), 2,
+    ACTIONS(474), 2,
       ts_builtin_sym_end,
       aux_sym_request_separator_token1,
-    STATE(162), 2,
+    STATE(168), 2,
       aux_sym__target_url_line,
       sym_variable,
-    STATE(71), 4,
+    STATE(73), 4,
       sym_comment,
       sym_pre_request_script,
       sym_variable_declaration,
       sym__blank_line,
-  [5229] = 2,
-    ACTIONS(353), 9,
+  [4679] = 16,
+    ACTIONS(481), 1,
+      aux_sym_WS_token1,
+    ACTIONS(484), 1,
+      aux_sym__comment_prefix_token1,
+    ACTIONS(487), 1,
+      aux_sym__comment_prefix_token2,
+    ACTIONS(490), 1,
+      sym_method,
+    ACTIONS(493), 1,
+      anon_sym_LBRACE_LBRACE,
+    ACTIONS(496), 1,
+      anon_sym_LT,
+    ACTIONS(499), 1,
+      anon_sym_AT2,
+    ACTIONS(502), 1,
+      aux_sym__blank_line_token1,
+    STATE(140), 1,
+      sym_request,
+    STATE(148), 1,
+      sym__section_content,
+    STATE(231), 1,
+      sym_target_url,
+    STATE(234), 1,
+      sym__comment_prefix,
+    ACTIONS(476), 2,
+      ts_builtin_sym_end,
+      aux_sym_request_separator_token1,
+    ACTIONS(478), 2,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+    STATE(168), 2,
+      aux_sym__target_url_line,
+      sym_variable,
+    STATE(73), 4,
+      sym_comment,
+      sym_pre_request_script,
+      sym_variable_declaration,
+      sym__blank_line,
+  [4734] = 2,
+    ACTIONS(331), 9,
       ts_builtin_sym_end,
       aux_sym__comment_prefix_token2,
       aux_sym_request_separator_token1,
@@ -9875,7 +10145,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_graphql_data_token1,
       anon_sym_DASH_DASH,
       aux_sym_multipart_form_data_token2,
-    ACTIONS(355), 12,
+    ACTIONS(333), 13,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       aux_sym_WS_token1,
@@ -9887,48 +10157,139 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AT2,
       anon_sym_LT2,
       aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
       aux_sym__blank_line_token1,
-  [5255] = 4,
-    ACTIONS(41), 1,
-      aux_sym_json_body_token1,
-    STATE(89), 1,
-      sym_json_body,
-    ACTIONS(534), 7,
+  [4761] = 14,
+    ACTIONS(454), 1,
+      aux_sym_WS_token1,
+    ACTIONS(456), 1,
+      aux_sym__comment_prefix_token1,
+    ACTIONS(458), 1,
+      aux_sym__comment_prefix_token2,
+    ACTIONS(460), 1,
+      sym_http_version,
+    ACTIONS(462), 1,
+      sym_header_entity,
+    ACTIONS(509), 1,
+      aux_sym__blank_line_token1,
+    STATE(113), 1,
+      aux_sym_request_repeat2,
+    STATE(114), 1,
+      sym_response,
+    STATE(132), 1,
+      sym_header,
+    STATE(218), 1,
+      sym__comment_prefix,
+    STATE(6), 2,
+      sym__blank_line,
+      aux_sym_request_repeat3,
+    STATE(70), 2,
+      sym_comment,
+      aux_sym_request_repeat1,
+    ACTIONS(507), 3,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      sym_method,
+    ACTIONS(505), 5,
+      ts_builtin_sym_end,
+      aux_sym_request_separator_token1,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+  [4812] = 14,
+    ACTIONS(454), 1,
+      aux_sym_WS_token1,
+    ACTIONS(456), 1,
+      aux_sym__comment_prefix_token1,
+    ACTIONS(458), 1,
+      aux_sym__comment_prefix_token2,
+    ACTIONS(460), 1,
+      sym_http_version,
+    ACTIONS(462), 1,
+      sym_header_entity,
+    ACTIONS(515), 1,
+      aux_sym__blank_line_token1,
+    STATE(121), 1,
+      sym_response,
+    STATE(122), 1,
+      aux_sym_request_repeat2,
+    STATE(132), 1,
+      sym_header,
+    STATE(218), 1,
+      sym__comment_prefix,
+    STATE(9), 2,
+      sym__blank_line,
+      aux_sym_request_repeat3,
+    STATE(83), 2,
+      sym_comment,
+      aux_sym_request_repeat1,
+    ACTIONS(513), 3,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      sym_method,
+    ACTIONS(511), 5,
+      ts_builtin_sym_end,
+      aux_sym_request_separator_token1,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+  [4863] = 14,
+    ACTIONS(454), 1,
+      aux_sym_WS_token1,
+    ACTIONS(456), 1,
+      aux_sym__comment_prefix_token1,
+    ACTIONS(458), 1,
+      aux_sym__comment_prefix_token2,
+    ACTIONS(460), 1,
+      sym_http_version,
+    ACTIONS(462), 1,
+      sym_header_entity,
+    ACTIONS(521), 1,
+      aux_sym__blank_line_token1,
+    STATE(102), 1,
+      aux_sym_request_repeat2,
+    STATE(115), 1,
+      sym_response,
+    STATE(132), 1,
+      sym_header,
+    STATE(218), 1,
+      sym__comment_prefix,
+    STATE(25), 2,
+      sym__blank_line,
+      aux_sym_request_repeat3,
+    STATE(80), 2,
+      sym_comment,
+      aux_sym_request_repeat1,
+    ACTIONS(519), 3,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      sym_method,
+    ACTIONS(517), 5,
+      ts_builtin_sym_end,
+      aux_sym_request_separator_token1,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+  [4914] = 5,
+    ACTIONS(527), 1,
+      aux_sym_WS_token1,
+    ACTIONS(530), 1,
+      aux_sym__blank_line_token1,
+    STATE(78), 2,
+      sym__blank_line,
+      aux_sym_request_repeat3,
+    ACTIONS(523), 8,
       ts_builtin_sym_end,
       aux_sym__comment_prefix_token2,
       aux_sym_request_separator_token1,
       anon_sym_GT,
       aux_sym_xml_body_token1,
-      aux_sym_graphql_data_token1,
-      anon_sym_DASH_DASH,
-    ACTIONS(536), 12,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym_WS_token1,
-      aux_sym_NL_token1,
-      aux_sym__comment_prefix_token1,
-      sym_method,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-      anon_sym_LT2,
-      aux_sym_multipart_form_data_token1,
-      aux_sym__blank_line_token1,
-  [5285] = 2,
-    ACTIONS(538), 9,
-      ts_builtin_sym_end,
-      aux_sym__comment_prefix_token2,
-      aux_sym_request_separator_token1,
-      anon_sym_GT,
-      aux_sym_xml_body_token1,
       aux_sym_json_body_token1,
       aux_sym_graphql_data_token1,
       anon_sym_DASH_DASH,
-      aux_sym_multipart_form_data_token2,
-    ACTIONS(540), 12,
+    ACTIONS(525), 10,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
-      aux_sym_WS_token1,
       aux_sym_NL_token1,
       aux_sym__comment_prefix_token1,
       sym_method,
@@ -9936,9 +10297,72 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
       anon_sym_AT2,
       anon_sym_LT2,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
+  [4947] = 4,
+    ACTIONS(537), 1,
+      aux_sym_xml_body_token2,
+    STATE(79), 1,
+      aux_sym_xml_body_repeat1,
+    ACTIONS(533), 3,
+      ts_builtin_sym_end,
+      aux_sym_request_separator_token1,
+      anon_sym_GT,
+    ACTIONS(535), 17,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym_WS_token1,
+      aux_sym_NL_token1,
+      aux_sym__comment_prefix_token1,
+      aux_sym__comment_prefix_token2,
+      sym_method,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+      aux_sym_xml_body_token1,
+      aux_sym_json_body_token1,
+      aux_sym_graphql_data_token1,
+      anon_sym_LT2,
+      anon_sym_DASH_DASH,
+      aux_sym_raw_body_token1,
       aux_sym__blank_line_token1,
-  [5311] = 2,
+  [4978] = 14,
+    ACTIONS(454), 1,
+      aux_sym_WS_token1,
+    ACTIONS(456), 1,
+      aux_sym__comment_prefix_token1,
+    ACTIONS(458), 1,
+      aux_sym__comment_prefix_token2,
+    ACTIONS(460), 1,
+      sym_http_version,
+    ACTIONS(462), 1,
+      sym_header_entity,
+    ACTIONS(540), 1,
+      aux_sym__blank_line_token1,
+    STATE(118), 1,
+      sym_response,
+    STATE(123), 1,
+      aux_sym_request_repeat2,
+    STATE(132), 1,
+      sym_header,
+    STATE(218), 1,
+      sym__comment_prefix,
+    STATE(7), 2,
+      sym__blank_line,
+      aux_sym_request_repeat3,
+    STATE(124), 2,
+      sym_comment,
+      aux_sym_request_repeat1,
+    ACTIONS(175), 3,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      sym_method,
+    ACTIONS(173), 5,
+      ts_builtin_sym_end,
+      aux_sym_request_separator_token1,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+  [5029] = 2,
     ACTIONS(542), 9,
       ts_builtin_sym_end,
       aux_sym__comment_prefix_token2,
@@ -9949,7 +10373,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_graphql_data_token1,
       anon_sym_DASH_DASH,
       aux_sym_multipart_form_data_token2,
-    ACTIONS(544), 12,
+    ACTIONS(544), 13,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       aux_sym_WS_token1,
@@ -9961,8 +10385,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AT2,
       anon_sym_LT2,
       aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
       aux_sym__blank_line_token1,
-  [5337] = 2,
+  [5056] = 2,
     ACTIONS(546), 9,
       ts_builtin_sym_end,
       aux_sym__comment_prefix_token2,
@@ -9973,7 +10398,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_graphql_data_token1,
       anon_sym_DASH_DASH,
       aux_sym_multipart_form_data_token2,
-    ACTIONS(548), 12,
+    ACTIONS(548), 13,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       aux_sym_WS_token1,
@@ -9985,9 +10410,101 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AT2,
       anon_sym_LT2,
       aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
       aux_sym__blank_line_token1,
-  [5363] = 2,
-    ACTIONS(550), 9,
+  [5083] = 14,
+    ACTIONS(454), 1,
+      aux_sym_WS_token1,
+    ACTIONS(456), 1,
+      aux_sym__comment_prefix_token1,
+    ACTIONS(458), 1,
+      aux_sym__comment_prefix_token2,
+    ACTIONS(460), 1,
+      sym_http_version,
+    ACTIONS(462), 1,
+      sym_header_entity,
+    ACTIONS(550), 1,
+      aux_sym__blank_line_token1,
+    STATE(117), 1,
+      aux_sym_request_repeat2,
+    STATE(119), 1,
+      sym_response,
+    STATE(132), 1,
+      sym_header,
+    STATE(218), 1,
+      sym__comment_prefix,
+    STATE(11), 2,
+      sym__blank_line,
+      aux_sym_request_repeat3,
+    STATE(124), 2,
+      sym_comment,
+      aux_sym_request_repeat1,
+    ACTIONS(91), 3,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      sym_method,
+    ACTIONS(89), 5,
+      ts_builtin_sym_end,
+      aux_sym_request_separator_token1,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+  [5134] = 4,
+    ACTIONS(472), 1,
+      aux_sym_xml_body_token2,
+    STATE(79), 1,
+      aux_sym_xml_body_repeat1,
+    ACTIONS(552), 3,
+      ts_builtin_sym_end,
+      aux_sym_request_separator_token1,
+      anon_sym_GT,
+    ACTIONS(554), 17,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym_WS_token1,
+      aux_sym_NL_token1,
+      aux_sym__comment_prefix_token1,
+      aux_sym__comment_prefix_token2,
+      sym_method,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+      aux_sym_xml_body_token1,
+      aux_sym_json_body_token1,
+      aux_sym_graphql_data_token1,
+      anon_sym_LT2,
+      anon_sym_DASH_DASH,
+      aux_sym_raw_body_token1,
+      aux_sym__blank_line_token1,
+  [5165] = 4,
+    ACTIONS(472), 1,
+      aux_sym_xml_body_token2,
+    STATE(79), 1,
+      aux_sym_xml_body_repeat1,
+    ACTIONS(556), 3,
+      ts_builtin_sym_end,
+      aux_sym_request_separator_token1,
+      anon_sym_GT,
+    ACTIONS(558), 17,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym_WS_token1,
+      aux_sym_NL_token1,
+      aux_sym__comment_prefix_token1,
+      aux_sym__comment_prefix_token2,
+      sym_method,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+      aux_sym_xml_body_token1,
+      aux_sym_json_body_token1,
+      aux_sym_graphql_data_token1,
+      anon_sym_LT2,
+      anon_sym_DASH_DASH,
+      aux_sym_raw_body_token1,
+      aux_sym__blank_line_token1,
+  [5196] = 2,
+    ACTIONS(560), 9,
       ts_builtin_sym_end,
       aux_sym__comment_prefix_token2,
       aux_sym_request_separator_token1,
@@ -9997,7 +10514,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_graphql_data_token1,
       anon_sym_DASH_DASH,
       aux_sym_multipart_form_data_token2,
-    ACTIONS(552), 12,
+    ACTIONS(562), 13,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       aux_sym_WS_token1,
@@ -10009,107 +10526,56 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AT2,
       anon_sym_LT2,
       aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
       aux_sym__blank_line_token1,
-  [5389] = 2,
-    ACTIONS(554), 8,
-      ts_builtin_sym_end,
+  [5223] = 14,
+    ACTIONS(454), 1,
+      aux_sym_WS_token1,
+    ACTIONS(456), 1,
+      aux_sym__comment_prefix_token1,
+    ACTIONS(458), 1,
       aux_sym__comment_prefix_token2,
-      aux_sym_request_separator_token1,
-      anon_sym_GT,
-      aux_sym_xml_body_token1,
-      aux_sym_json_body_token1,
-      aux_sym_graphql_data_token1,
-      anon_sym_DASH_DASH,
-    ACTIONS(556), 12,
+    ACTIONS(460), 1,
+      sym_http_version,
+    ACTIONS(462), 1,
+      sym_header_entity,
+    ACTIONS(564), 1,
+      aux_sym__blank_line_token1,
+    STATE(101), 1,
+      sym_response,
+    STATE(125), 1,
+      aux_sym_request_repeat2,
+    STATE(132), 1,
+      sym_header,
+    STATE(218), 1,
+      sym__comment_prefix,
+    STATE(8), 2,
+      sym__blank_line,
+      aux_sym_request_repeat3,
+    STATE(124), 2,
+      sym_comment,
+      aux_sym_request_repeat1,
+    ACTIONS(61), 3,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
-      aux_sym_WS_token1,
-      aux_sym_NL_token1,
-      aux_sym__comment_prefix_token1,
       sym_method,
+    ACTIONS(59), 5,
+      ts_builtin_sym_end,
+      aux_sym_request_separator_token1,
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-      anon_sym_LT2,
-      aux_sym_multipart_form_data_token1,
-      aux_sym__blank_line_token1,
-  [5414] = 2,
-    ACTIONS(558), 8,
+  [5274] = 4,
+    ACTIONS(41), 1,
+      aux_sym_json_body_token1,
+    STATE(98), 1,
+      sym_json_body,
+    ACTIONS(566), 7,
       ts_builtin_sym_end,
       aux_sym__comment_prefix_token2,
       aux_sym_request_separator_token1,
       anon_sym_GT,
       aux_sym_xml_body_token1,
-      aux_sym_json_body_token1,
-      aux_sym_graphql_data_token1,
-      anon_sym_DASH_DASH,
-    ACTIONS(560), 12,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym_WS_token1,
-      aux_sym_NL_token1,
-      aux_sym__comment_prefix_token1,
-      sym_method,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-      anon_sym_LT2,
-      aux_sym_multipart_form_data_token1,
-      aux_sym__blank_line_token1,
-  [5439] = 2,
-    ACTIONS(562), 8,
-      ts_builtin_sym_end,
-      aux_sym__comment_prefix_token2,
-      aux_sym_request_separator_token1,
-      anon_sym_GT,
-      aux_sym_xml_body_token1,
-      aux_sym_json_body_token1,
-      aux_sym_graphql_data_token1,
-      anon_sym_DASH_DASH,
-    ACTIONS(564), 12,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym_WS_token1,
-      aux_sym_NL_token1,
-      aux_sym__comment_prefix_token1,
-      sym_method,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-      anon_sym_LT2,
-      aux_sym_multipart_form_data_token1,
-      aux_sym__blank_line_token1,
-  [5464] = 2,
-    ACTIONS(430), 8,
-      ts_builtin_sym_end,
-      aux_sym__comment_prefix_token2,
-      aux_sym_request_separator_token1,
-      anon_sym_GT,
-      aux_sym_xml_body_token1,
-      aux_sym_json_body_token1,
-      aux_sym_graphql_data_token1,
-      anon_sym_DASH_DASH,
-    ACTIONS(432), 12,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym_WS_token1,
-      aux_sym_NL_token1,
-      aux_sym__comment_prefix_token1,
-      sym_method,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-      anon_sym_LT2,
-      aux_sym_multipart_form_data_token1,
-      aux_sym__blank_line_token1,
-  [5489] = 2,
-    ACTIONS(566), 8,
-      ts_builtin_sym_end,
-      aux_sym__comment_prefix_token2,
-      aux_sym_request_separator_token1,
-      anon_sym_GT,
-      aux_sym_xml_body_token1,
-      aux_sym_json_body_token1,
       aux_sym_graphql_data_token1,
       anon_sym_DASH_DASH,
     ACTIONS(568), 12,
@@ -10123,9 +10589,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
       anon_sym_AT2,
       anon_sym_LT2,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
       aux_sym__blank_line_token1,
-  [5514] = 2,
+  [5304] = 2,
     ACTIONS(570), 8,
       ts_builtin_sym_end,
       aux_sym__comment_prefix_token2,
@@ -10146,9 +10612,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
       anon_sym_AT2,
       anon_sym_LT2,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
       aux_sym__blank_line_token1,
-  [5539] = 2,
+  [5329] = 2,
     ACTIONS(574), 8,
       ts_builtin_sym_end,
       aux_sym__comment_prefix_token2,
@@ -10169,9 +10635,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
       anon_sym_AT2,
       anon_sym_LT2,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
       aux_sym__blank_line_token1,
-  [5564] = 2,
+  [5354] = 2,
     ACTIONS(578), 8,
       ts_builtin_sym_end,
       aux_sym__comment_prefix_token2,
@@ -10192,9 +10658,32 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
       anon_sym_AT2,
       anon_sym_LT2,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
       aux_sym__blank_line_token1,
-  [5589] = 2,
+  [5379] = 2,
+    ACTIONS(436), 8,
+      ts_builtin_sym_end,
+      aux_sym__comment_prefix_token2,
+      aux_sym_request_separator_token1,
+      anon_sym_GT,
+      aux_sym_xml_body_token1,
+      aux_sym_json_body_token1,
+      aux_sym_graphql_data_token1,
+      anon_sym_DASH_DASH,
+    ACTIONS(438), 12,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym_WS_token1,
+      aux_sym_NL_token1,
+      aux_sym__comment_prefix_token1,
+      sym_method,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+      anon_sym_LT2,
+      aux_sym_raw_body_token1,
+      aux_sym__blank_line_token1,
+  [5404] = 2,
     ACTIONS(582), 8,
       ts_builtin_sym_end,
       aux_sym__comment_prefix_token2,
@@ -10215,9 +10704,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
       anon_sym_AT2,
       anon_sym_LT2,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
       aux_sym__blank_line_token1,
-  [5614] = 2,
+  [5429] = 2,
     ACTIONS(586), 8,
       ts_builtin_sym_end,
       aux_sym__comment_prefix_token2,
@@ -10238,9 +10727,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
       anon_sym_AT2,
       anon_sym_LT2,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
       aux_sym__blank_line_token1,
-  [5639] = 2,
+  [5454] = 2,
     ACTIONS(590), 8,
       ts_builtin_sym_end,
       aux_sym__comment_prefix_token2,
@@ -10261,228 +10750,213 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT,
       anon_sym_AT2,
       anon_sym_LT2,
-      aux_sym_multipart_form_data_token1,
+      aux_sym_raw_body_token1,
       aux_sym__blank_line_token1,
-  [5664] = 8,
-    ACTIONS(408), 1,
+  [5479] = 2,
+    ACTIONS(594), 8,
+      ts_builtin_sym_end,
+      aux_sym__comment_prefix_token2,
+      aux_sym_request_separator_token1,
+      anon_sym_GT,
+      aux_sym_xml_body_token1,
+      aux_sym_json_body_token1,
+      aux_sym_graphql_data_token1,
+      anon_sym_DASH_DASH,
+    ACTIONS(596), 12,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
       aux_sym_WS_token1,
-    ACTIONS(416), 1,
-      sym_header_entity,
-    ACTIONS(598), 1,
+      aux_sym_NL_token1,
+      aux_sym__comment_prefix_token1,
+      sym_method,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+      anon_sym_LT2,
+      aux_sym_raw_body_token1,
       aux_sym__blank_line_token1,
-    STATE(123), 1,
+  [5504] = 2,
+    ACTIONS(426), 8,
+      ts_builtin_sym_end,
+      aux_sym__comment_prefix_token2,
+      aux_sym_request_separator_token1,
+      anon_sym_GT,
+      aux_sym_xml_body_token1,
+      aux_sym_json_body_token1,
+      aux_sym_graphql_data_token1,
+      anon_sym_DASH_DASH,
+    ACTIONS(428), 12,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym_WS_token1,
+      aux_sym_NL_token1,
+      aux_sym__comment_prefix_token1,
+      sym_method,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+      anon_sym_LT2,
+      aux_sym_raw_body_token1,
+      aux_sym__blank_line_token1,
+  [5529] = 2,
+    ACTIONS(598), 8,
+      ts_builtin_sym_end,
+      aux_sym__comment_prefix_token2,
+      aux_sym_request_separator_token1,
+      anon_sym_GT,
+      aux_sym_xml_body_token1,
+      aux_sym_json_body_token1,
+      aux_sym_graphql_data_token1,
+      anon_sym_DASH_DASH,
+    ACTIONS(600), 12,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym_WS_token1,
+      aux_sym_NL_token1,
+      aux_sym__comment_prefix_token1,
+      sym_method,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+      anon_sym_LT2,
+      aux_sym_raw_body_token1,
+      aux_sym__blank_line_token1,
+  [5554] = 2,
+    ACTIONS(602), 8,
+      ts_builtin_sym_end,
+      aux_sym__comment_prefix_token2,
+      aux_sym_request_separator_token1,
+      anon_sym_GT,
+      aux_sym_xml_body_token1,
+      aux_sym_json_body_token1,
+      aux_sym_graphql_data_token1,
+      anon_sym_DASH_DASH,
+    ACTIONS(604), 12,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym_WS_token1,
+      aux_sym_NL_token1,
+      aux_sym__comment_prefix_token1,
+      sym_method,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+      anon_sym_LT2,
+      aux_sym_raw_body_token1,
+      aux_sym__blank_line_token1,
+  [5579] = 2,
+    ACTIONS(606), 8,
+      ts_builtin_sym_end,
+      aux_sym__comment_prefix_token2,
+      aux_sym_request_separator_token1,
+      anon_sym_GT,
+      aux_sym_xml_body_token1,
+      aux_sym_json_body_token1,
+      aux_sym_graphql_data_token1,
+      anon_sym_DASH_DASH,
+    ACTIONS(608), 12,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym_WS_token1,
+      aux_sym_NL_token1,
+      aux_sym__comment_prefix_token1,
+      sym_method,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+      anon_sym_LT2,
+      aux_sym_raw_body_token1,
+      aux_sym__blank_line_token1,
+  [5604] = 8,
+    ACTIONS(454), 1,
+      aux_sym_WS_token1,
+    ACTIONS(462), 1,
+      sym_header_entity,
+    ACTIONS(610), 1,
+      aux_sym__blank_line_token1,
+    STATE(109), 1,
       aux_sym_request_repeat2,
-    STATE(129), 1,
+    STATE(132), 1,
       sym_header,
-    STATE(8), 2,
+    STATE(18), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
-    ACTIONS(596), 4,
+    ACTIONS(85), 4,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       aux_sym__comment_prefix_token1,
       sym_method,
-    ACTIONS(594), 6,
+    ACTIONS(83), 6,
       ts_builtin_sym_end,
       aux_sym__comment_prefix_token2,
       aux_sym_request_separator_token1,
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [5698] = 8,
-    ACTIONS(408), 1,
+  [5638] = 8,
+    ACTIONS(454), 1,
       aux_sym_WS_token1,
-    ACTIONS(416), 1,
+    ACTIONS(462), 1,
       sym_header_entity,
-    ACTIONS(600), 1,
+    ACTIONS(616), 1,
       aux_sym__blank_line_token1,
-    STATE(123), 1,
+    STATE(126), 1,
       aux_sym_request_repeat2,
-    STATE(129), 1,
+    STATE(132), 1,
       sym_header,
-    STATE(12), 2,
+    STATE(16), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
-    ACTIONS(596), 4,
+    ACTIONS(614), 4,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       aux_sym__comment_prefix_token1,
       sym_method,
-    ACTIONS(594), 6,
+    ACTIONS(612), 6,
       ts_builtin_sym_end,
       aux_sym__comment_prefix_token2,
       aux_sym_request_separator_token1,
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [5732] = 8,
-    ACTIONS(408), 1,
+  [5672] = 8,
+    ACTIONS(454), 1,
       aux_sym_WS_token1,
-    ACTIONS(416), 1,
-      sym_header_entity,
-    ACTIONS(606), 1,
-      aux_sym__blank_line_token1,
-    STATE(123), 1,
-      aux_sym_request_repeat2,
-    STATE(129), 1,
-      sym_header,
-    STATE(24), 2,
-      sym__blank_line,
-      aux_sym_request_repeat3,
-    ACTIONS(604), 4,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym__comment_prefix_token1,
-      sym_method,
-    ACTIONS(602), 6,
-      ts_builtin_sym_end,
-      aux_sym__comment_prefix_token2,
-      aux_sym_request_separator_token1,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-  [5766] = 8,
-    ACTIONS(408), 1,
-      aux_sym_WS_token1,
-    ACTIONS(416), 1,
-      sym_header_entity,
-    ACTIONS(608), 1,
-      aux_sym__blank_line_token1,
-    STATE(102), 1,
-      aux_sym_request_repeat2,
-    STATE(129), 1,
-      sym_header,
-    STATE(26), 2,
-      sym__blank_line,
-      aux_sym_request_repeat3,
-    ACTIONS(179), 4,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym__comment_prefix_token1,
-      sym_method,
-    ACTIONS(177), 6,
-      ts_builtin_sym_end,
-      aux_sym__comment_prefix_token2,
-      aux_sym_request_separator_token1,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-  [5800] = 8,
-    ACTIONS(408), 1,
-      aux_sym_WS_token1,
-    ACTIONS(416), 1,
-      sym_header_entity,
-    ACTIONS(614), 1,
-      aux_sym__blank_line_token1,
-    STATE(123), 1,
-      aux_sym_request_repeat2,
-    STATE(129), 1,
-      sym_header,
-    STATE(21), 2,
-      sym__blank_line,
-      aux_sym_request_repeat3,
-    ACTIONS(612), 4,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym__comment_prefix_token1,
-      sym_method,
-    ACTIONS(610), 6,
-      ts_builtin_sym_end,
-      aux_sym__comment_prefix_token2,
-      aux_sym_request_separator_token1,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-  [5834] = 8,
-    ACTIONS(408), 1,
-      aux_sym_WS_token1,
-    ACTIONS(416), 1,
-      sym_header_entity,
-    ACTIONS(620), 1,
-      aux_sym__blank_line_token1,
-    STATE(123), 1,
-      aux_sym_request_repeat2,
-    STATE(129), 1,
-      sym_header,
-    STATE(27), 2,
-      sym__blank_line,
-      aux_sym_request_repeat3,
-    ACTIONS(618), 4,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym__comment_prefix_token1,
-      sym_method,
-    ACTIONS(616), 6,
-      ts_builtin_sym_end,
-      aux_sym__comment_prefix_token2,
-      aux_sym_request_separator_token1,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-  [5868] = 8,
-    ACTIONS(408), 1,
-      aux_sym_WS_token1,
-    ACTIONS(416), 1,
-      sym_header_entity,
-    ACTIONS(530), 1,
-      aux_sym__blank_line_token1,
-    STATE(105), 1,
-      aux_sym_request_repeat2,
-    STATE(129), 1,
-      sym_header,
-    STATE(25), 2,
-      sym__blank_line,
-      aux_sym_request_repeat3,
-    ACTIONS(27), 4,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym__comment_prefix_token1,
-      sym_method,
-    ACTIONS(25), 6,
-      ts_builtin_sym_end,
-      aux_sym__comment_prefix_token2,
-      aux_sym_request_separator_token1,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-  [5902] = 8,
-    ACTIONS(408), 1,
-      aux_sym_WS_token1,
-    ACTIONS(416), 1,
+    ACTIONS(462), 1,
       sym_header_entity,
     ACTIONS(622), 1,
       aux_sym__blank_line_token1,
-    STATE(123), 1,
+    STATE(126), 1,
       aux_sym_request_repeat2,
-    STATE(129), 1,
+    STATE(132), 1,
       sym_header,
-    STATE(23), 2,
+    STATE(14), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
-    ACTIONS(618), 4,
+    ACTIONS(620), 4,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       aux_sym__comment_prefix_token1,
       sym_method,
-    ACTIONS(616), 6,
+    ACTIONS(618), 6,
       ts_builtin_sym_end,
       aux_sym__comment_prefix_token2,
       aux_sym_request_separator_token1,
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [5936] = 8,
-    ACTIONS(408), 1,
+  [5706] = 8,
+    ACTIONS(454), 1,
       aux_sym_WS_token1,
-    ACTIONS(416), 1,
+    ACTIONS(462), 1,
       sym_header_entity,
     ACTIONS(628), 1,
       aux_sym__blank_line_token1,
-    STATE(123), 1,
+    STATE(126), 1,
       aux_sym_request_repeat2,
-    STATE(129), 1,
+    STATE(132), 1,
       sym_header,
-    STATE(6), 2,
+    STATE(13), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
     ACTIONS(626), 4,
@@ -10497,18 +10971,18 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [5970] = 8,
-    ACTIONS(408), 1,
+  [5740] = 8,
+    ACTIONS(454), 1,
       aux_sym_WS_token1,
-    ACTIONS(416), 1,
+    ACTIONS(462), 1,
       sym_header_entity,
     ACTIONS(634), 1,
       aux_sym__blank_line_token1,
-    STATE(123), 1,
+    STATE(126), 1,
       aux_sym_request_repeat2,
-    STATE(129), 1,
+    STATE(132), 1,
       sym_header,
-    STATE(10), 2,
+    STATE(20), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
     ACTIONS(632), 4,
@@ -10523,44 +10997,44 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [6004] = 8,
-    ACTIONS(408), 1,
+  [5774] = 8,
+    ACTIONS(454), 1,
       aux_sym_WS_token1,
-    ACTIONS(416), 1,
+    ACTIONS(462), 1,
       sym_header_entity,
     ACTIONS(636), 1,
       aux_sym__blank_line_token1,
-    STATE(110), 1,
+    STATE(104), 1,
       aux_sym_request_repeat2,
-    STATE(129), 1,
+    STATE(132), 1,
       sym_header,
-    STATE(11), 2,
+    STATE(21), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
-    ACTIONS(55), 4,
+    ACTIONS(193), 4,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       aux_sym__comment_prefix_token1,
       sym_method,
-    ACTIONS(53), 6,
+    ACTIONS(191), 6,
       ts_builtin_sym_end,
       aux_sym__comment_prefix_token2,
       aux_sym_request_separator_token1,
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [6038] = 8,
-    ACTIONS(408), 1,
+  [5808] = 8,
+    ACTIONS(454), 1,
       aux_sym_WS_token1,
-    ACTIONS(416), 1,
+    ACTIONS(462), 1,
       sym_header_entity,
     ACTIONS(638), 1,
       aux_sym__blank_line_token1,
-    STATE(123), 1,
+    STATE(126), 1,
       aux_sym_request_repeat2,
-    STATE(129), 1,
+    STATE(132), 1,
       sym_header,
-    STATE(13), 2,
+    STATE(23), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
     ACTIONS(632), 4,
@@ -10575,18 +11049,18 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [6072] = 8,
-    ACTIONS(408), 1,
+  [5842] = 8,
+    ACTIONS(454), 1,
       aux_sym_WS_token1,
-    ACTIONS(416), 1,
+    ACTIONS(462), 1,
       sym_header_entity,
     ACTIONS(644), 1,
       aux_sym__blank_line_token1,
-    STATE(123), 1,
+    STATE(126), 1,
       aux_sym_request_repeat2,
-    STATE(129), 1,
+    STATE(132), 1,
       sym_header,
-    STATE(5), 2,
+    STATE(26), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
     ACTIONS(642), 4,
@@ -10601,18 +11075,18 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [6106] = 8,
-    ACTIONS(408), 1,
+  [5876] = 8,
+    ACTIONS(454), 1,
       aux_sym_WS_token1,
-    ACTIONS(416), 1,
+    ACTIONS(462), 1,
       sym_header_entity,
     ACTIONS(650), 1,
       aux_sym__blank_line_token1,
-    STATE(123), 1,
+    STATE(126), 1,
       aux_sym_request_repeat2,
-    STATE(129), 1,
+    STATE(132), 1,
       sym_header,
-    STATE(29), 2,
+    STATE(15), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
     ACTIONS(648), 4,
@@ -10627,174 +11101,44 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [6140] = 8,
-    ACTIONS(408), 1,
+  [5910] = 8,
+    ACTIONS(454), 1,
       aux_sym_WS_token1,
-    ACTIONS(416), 1,
-      sym_header_entity,
-    ACTIONS(652), 1,
-      aux_sym__blank_line_token1,
-    STATE(122), 1,
-      aux_sym_request_repeat2,
-    STATE(129), 1,
-      sym_header,
-    STATE(7), 2,
-      sym__blank_line,
-      aux_sym_request_repeat3,
-    ACTIONS(137), 4,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym__comment_prefix_token1,
-      sym_method,
-    ACTIONS(135), 6,
-      ts_builtin_sym_end,
-      aux_sym__comment_prefix_token2,
-      aux_sym_request_separator_token1,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-  [6174] = 8,
-    ACTIONS(408), 1,
-      aux_sym_WS_token1,
-    ACTIONS(416), 1,
-      sym_header_entity,
     ACTIONS(462), 1,
+      sym_header_entity,
+    ACTIONS(656), 1,
       aux_sym__blank_line_token1,
-    STATE(109), 1,
+    STATE(126), 1,
       aux_sym_request_repeat2,
-    STATE(129), 1,
+    STATE(132), 1,
       sym_header,
-    STATE(3), 2,
+    STATE(17), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
-    ACTIONS(161), 4,
+    ACTIONS(654), 4,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       aux_sym__comment_prefix_token1,
       sym_method,
-    ACTIONS(159), 6,
+    ACTIONS(652), 6,
       ts_builtin_sym_end,
       aux_sym__comment_prefix_token2,
       aux_sym_request_separator_token1,
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [6208] = 8,
-    ACTIONS(408), 1,
+  [5944] = 8,
+    ACTIONS(454), 1,
       aux_sym_WS_token1,
-    ACTIONS(416), 1,
+    ACTIONS(462), 1,
       sym_header_entity,
-    ACTIONS(520), 1,
+    ACTIONS(564), 1,
       aux_sym__blank_line_token1,
-    STATE(98), 1,
+    STATE(110), 1,
       aux_sym_request_repeat2,
-    STATE(129), 1,
+    STATE(132), 1,
       sym_header,
-    STATE(4), 2,
-      sym__blank_line,
-      aux_sym_request_repeat3,
-    ACTIONS(125), 4,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym__comment_prefix_token1,
-      sym_method,
-    ACTIONS(123), 6,
-      ts_builtin_sym_end,
-      aux_sym__comment_prefix_token2,
-      aux_sym_request_separator_token1,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-  [6242] = 8,
-    ACTIONS(408), 1,
-      aux_sym_WS_token1,
-    ACTIONS(416), 1,
-      sym_header_entity,
-    ACTIONS(654), 1,
-      aux_sym__blank_line_token1,
-    STATE(123), 1,
-      aux_sym_request_repeat2,
-    STATE(129), 1,
-      sym_header,
-    STATE(28), 2,
-      sym__blank_line,
-      aux_sym_request_repeat3,
-    ACTIONS(648), 4,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym__comment_prefix_token1,
-      sym_method,
-    ACTIONS(646), 6,
-      ts_builtin_sym_end,
-      aux_sym__comment_prefix_token2,
-      aux_sym_request_separator_token1,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-  [6276] = 8,
-    ACTIONS(408), 1,
-      aux_sym_WS_token1,
-    ACTIONS(416), 1,
-      sym_header_entity,
-    ACTIONS(660), 1,
-      aux_sym__blank_line_token1,
-    STATE(123), 1,
-      aux_sym_request_repeat2,
-    STATE(129), 1,
-      sym_header,
-    STATE(19), 2,
-      sym__blank_line,
-      aux_sym_request_repeat3,
-    ACTIONS(658), 4,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym__comment_prefix_token1,
-      sym_method,
-    ACTIONS(656), 6,
-      ts_builtin_sym_end,
-      aux_sym__comment_prefix_token2,
-      aux_sym_request_separator_token1,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-  [6310] = 8,
-    ACTIONS(408), 1,
-      aux_sym_WS_token1,
-    ACTIONS(416), 1,
-      sym_header_entity,
-    ACTIONS(666), 1,
-      aux_sym__blank_line_token1,
-    STATE(123), 1,
-      aux_sym_request_repeat2,
-    STATE(129), 1,
-      sym_header,
-    STATE(14), 2,
-      sym__blank_line,
-      aux_sym_request_repeat3,
-    ACTIONS(664), 4,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym__comment_prefix_token1,
-      sym_method,
-    ACTIONS(662), 6,
-      ts_builtin_sym_end,
-      aux_sym__comment_prefix_token2,
-      aux_sym_request_separator_token1,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-  [6344] = 8,
-    ACTIONS(408), 1,
-      aux_sym_WS_token1,
-    ACTIONS(416), 1,
-      sym_header_entity,
-    ACTIONS(668), 1,
-      aux_sym__blank_line_token1,
-    STATE(119), 1,
-      aux_sym_request_repeat2,
-    STATE(129), 1,
-      sym_header,
-    STATE(9), 2,
+    STATE(8), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
     ACTIONS(61), 4,
@@ -10809,18 +11153,122 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [6378] = 8,
-    ACTIONS(408), 1,
+  [5978] = 8,
+    ACTIONS(454), 1,
       aux_sym_WS_token1,
-    ACTIONS(416), 1,
+    ACTIONS(462), 1,
+      sym_header_entity,
+    ACTIONS(662), 1,
+      aux_sym__blank_line_token1,
+    STATE(126), 1,
+      aux_sym_request_repeat2,
+    STATE(132), 1,
+      sym_header,
+    STATE(10), 2,
+      sym__blank_line,
+      aux_sym_request_repeat3,
+    ACTIONS(660), 4,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym__comment_prefix_token1,
+      sym_method,
+    ACTIONS(658), 6,
+      ts_builtin_sym_end,
+      aux_sym__comment_prefix_token2,
+      aux_sym_request_separator_token1,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+  [6012] = 8,
+    ACTIONS(454), 1,
+      aux_sym_WS_token1,
+    ACTIONS(462), 1,
+      sym_header_entity,
+    ACTIONS(668), 1,
+      aux_sym__blank_line_token1,
+    STATE(126), 1,
+      aux_sym_request_repeat2,
+    STATE(132), 1,
+      sym_header,
+    STATE(27), 2,
+      sym__blank_line,
+      aux_sym_request_repeat3,
+    ACTIONS(666), 4,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym__comment_prefix_token1,
+      sym_method,
+    ACTIONS(664), 6,
+      ts_builtin_sym_end,
+      aux_sym__comment_prefix_token2,
+      aux_sym_request_separator_token1,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+  [6046] = 8,
+    ACTIONS(454), 1,
+      aux_sym_WS_token1,
+    ACTIONS(462), 1,
+      sym_header_entity,
+    ACTIONS(466), 1,
+      aux_sym__blank_line_token1,
+    STATE(107), 1,
+      aux_sym_request_repeat2,
+    STATE(132), 1,
+      sym_header,
+    STATE(28), 2,
+      sym__blank_line,
+      aux_sym_request_repeat3,
+    ACTIONS(73), 4,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym__comment_prefix_token1,
+      sym_method,
+    ACTIONS(71), 6,
+      ts_builtin_sym_end,
+      aux_sym__comment_prefix_token2,
+      aux_sym_request_separator_token1,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+  [6080] = 8,
+    ACTIONS(454), 1,
+      aux_sym_WS_token1,
+    ACTIONS(462), 1,
+      sym_header_entity,
+    ACTIONS(540), 1,
+      aux_sym__blank_line_token1,
+    STATE(103), 1,
+      aux_sym_request_repeat2,
+    STATE(132), 1,
+      sym_header,
+    STATE(7), 2,
+      sym__blank_line,
+      aux_sym_request_repeat3,
+    ACTIONS(175), 4,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym__comment_prefix_token1,
+      sym_method,
+    ACTIONS(173), 6,
+      ts_builtin_sym_end,
+      aux_sym__comment_prefix_token2,
+      aux_sym_request_separator_token1,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+  [6114] = 8,
+    ACTIONS(454), 1,
+      aux_sym_WS_token1,
+    ACTIONS(462), 1,
       sym_header_entity,
     ACTIONS(674), 1,
       aux_sym__blank_line_token1,
-    STATE(123), 1,
+    STATE(126), 1,
       aux_sym_request_repeat2,
-    STATE(129), 1,
+    STATE(132), 1,
       sym_header,
-    STATE(20), 2,
+    STATE(2), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
     ACTIONS(672), 4,
@@ -10835,49 +11283,205 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [6412] = 8,
-    ACTIONS(408), 1,
+  [6148] = 8,
+    ACTIONS(454), 1,
       aux_sym_WS_token1,
-    ACTIONS(416), 1,
+    ACTIONS(462), 1,
       sym_header_entity,
-    ACTIONS(522), 1,
+    ACTIONS(680), 1,
       aux_sym__blank_line_token1,
-    STATE(115), 1,
+    STATE(126), 1,
       aux_sym_request_repeat2,
-    STATE(129), 1,
+    STATE(132), 1,
       sym_header,
-    STATE(18), 2,
+    STATE(29), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
-    ACTIONS(119), 4,
+    ACTIONS(678), 4,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       aux_sym__comment_prefix_token1,
       sym_method,
-    ACTIONS(117), 6,
+    ACTIONS(676), 6,
       ts_builtin_sym_end,
       aux_sym__comment_prefix_token2,
       aux_sym_request_separator_token1,
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [6446] = 6,
-    ACTIONS(680), 1,
+  [6182] = 8,
+    ACTIONS(454), 1,
+      aux_sym_WS_token1,
+    ACTIONS(462), 1,
+      sym_header_entity,
+    ACTIONS(682), 1,
+      aux_sym__blank_line_token1,
+    STATE(116), 1,
+      aux_sym_request_repeat2,
+    STATE(132), 1,
+      sym_header,
+    STATE(24), 2,
+      sym__blank_line,
+      aux_sym_request_repeat3,
+    ACTIONS(79), 4,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
       aux_sym__comment_prefix_token1,
-    ACTIONS(683), 1,
+      sym_method,
+    ACTIONS(77), 6,
+      ts_builtin_sym_end,
       aux_sym__comment_prefix_token2,
-    STATE(212), 1,
+      aux_sym_request_separator_token1,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+  [6216] = 8,
+    ACTIONS(454), 1,
+      aux_sym_WS_token1,
+    ACTIONS(462), 1,
+      sym_header_entity,
+    ACTIONS(684), 1,
+      aux_sym__blank_line_token1,
+    STATE(108), 1,
+      aux_sym_request_repeat2,
+    STATE(132), 1,
+      sym_header,
+    STATE(22), 2,
+      sym__blank_line,
+      aux_sym_request_repeat3,
+    ACTIONS(103), 4,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym__comment_prefix_token1,
+      sym_method,
+    ACTIONS(101), 6,
+      ts_builtin_sym_end,
+      aux_sym__comment_prefix_token2,
+      aux_sym_request_separator_token1,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+  [6250] = 8,
+    ACTIONS(454), 1,
+      aux_sym_WS_token1,
+    ACTIONS(462), 1,
+      sym_header_entity,
+    ACTIONS(686), 1,
+      aux_sym__blank_line_token1,
+    STATE(126), 1,
+      aux_sym_request_repeat2,
+    STATE(132), 1,
+      sym_header,
+    STATE(3), 2,
+      sym__blank_line,
+      aux_sym_request_repeat3,
+    ACTIONS(678), 4,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym__comment_prefix_token1,
+      sym_method,
+    ACTIONS(676), 6,
+      ts_builtin_sym_end,
+      aux_sym__comment_prefix_token2,
+      aux_sym_request_separator_token1,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+  [6284] = 8,
+    ACTIONS(454), 1,
+      aux_sym_WS_token1,
+    ACTIONS(462), 1,
+      sym_header_entity,
+    ACTIONS(550), 1,
+      aux_sym__blank_line_token1,
+    STATE(120), 1,
+      aux_sym_request_repeat2,
+    STATE(132), 1,
+      sym_header,
+    STATE(11), 2,
+      sym__blank_line,
+      aux_sym_request_repeat3,
+    ACTIONS(91), 4,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym__comment_prefix_token1,
+      sym_method,
+    ACTIONS(89), 6,
+      ts_builtin_sym_end,
+      aux_sym__comment_prefix_token2,
+      aux_sym_request_separator_token1,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+  [6318] = 8,
+    ACTIONS(454), 1,
+      aux_sym_WS_token1,
+    ACTIONS(462), 1,
+      sym_header_entity,
+    ACTIONS(692), 1,
+      aux_sym__blank_line_token1,
+    STATE(126), 1,
+      aux_sym_request_repeat2,
+    STATE(132), 1,
+      sym_header,
+    STATE(12), 2,
+      sym__blank_line,
+      aux_sym_request_repeat3,
+    ACTIONS(690), 4,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym__comment_prefix_token1,
+      sym_method,
+    ACTIONS(688), 6,
+      ts_builtin_sym_end,
+      aux_sym__comment_prefix_token2,
+      aux_sym_request_separator_token1,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+  [6352] = 8,
+    ACTIONS(454), 1,
+      aux_sym_WS_token1,
+    ACTIONS(462), 1,
+      sym_header_entity,
+    ACTIONS(694), 1,
+      aux_sym__blank_line_token1,
+    STATE(126), 1,
+      aux_sym_request_repeat2,
+    STATE(132), 1,
+      sym_header,
+    STATE(5), 2,
+      sym__blank_line,
+      aux_sym_request_repeat3,
+    ACTIONS(620), 4,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym__comment_prefix_token1,
+      sym_method,
+    ACTIONS(618), 6,
+      ts_builtin_sym_end,
+      aux_sym__comment_prefix_token2,
+      aux_sym_request_separator_token1,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+  [6386] = 6,
+    ACTIONS(700), 1,
+      aux_sym__comment_prefix_token1,
+    ACTIONS(703), 1,
+      aux_sym__comment_prefix_token2,
+    STATE(218), 1,
       sym__comment_prefix,
-    STATE(121), 2,
+    STATE(124), 2,
       sym_comment,
       aux_sym_request_repeat1,
-    ACTIONS(678), 5,
+    ACTIONS(698), 5,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       sym_method,
       sym_header_entity,
       aux_sym__blank_line_token1,
-    ACTIONS(676), 7,
+    ACTIONS(696), 7,
       ts_builtin_sym_end,
       aux_sym_WS_token1,
       aux_sym_request_separator_token1,
@@ -10885,46 +11489,46 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [6476] = 8,
-    ACTIONS(408), 1,
+  [6416] = 8,
+    ACTIONS(454), 1,
       aux_sym_WS_token1,
-    ACTIONS(416), 1,
+    ACTIONS(462), 1,
       sym_header_entity,
-    ACTIONS(690), 1,
+    ACTIONS(706), 1,
       aux_sym__blank_line_token1,
-    STATE(123), 1,
+    STATE(126), 1,
       aux_sym_request_repeat2,
-    STATE(129), 1,
+    STATE(132), 1,
       sym_header,
-    STATE(17), 2,
+    STATE(19), 2,
       sym__blank_line,
       aux_sym_request_repeat3,
-    ACTIONS(688), 4,
+    ACTIONS(654), 4,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       aux_sym__comment_prefix_token1,
       sym_method,
-    ACTIONS(686), 6,
+    ACTIONS(652), 6,
       ts_builtin_sym_end,
       aux_sym__comment_prefix_token2,
       aux_sym_request_separator_token1,
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [6510] = 5,
-    ACTIONS(696), 1,
+  [6450] = 5,
+    ACTIONS(712), 1,
       sym_header_entity,
-    STATE(123), 1,
+    STATE(126), 1,
       aux_sym_request_repeat2,
-    STATE(129), 1,
+    STATE(132), 1,
       sym_header,
-    ACTIONS(694), 5,
+    ACTIONS(710), 5,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       aux_sym__comment_prefix_token1,
       sym_method,
       aux_sym__blank_line_token1,
-    ACTIONS(692), 7,
+    ACTIONS(708), 7,
       ts_builtin_sym_end,
       aux_sym_WS_token1,
       aux_sym__comment_prefix_token2,
@@ -10932,15 +11536,15 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [6536] = 2,
-    ACTIONS(548), 6,
+  [6476] = 2,
+    ACTIONS(448), 6,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       aux_sym__comment_prefix_token1,
       sym_method,
       sym_header_entity,
       aux_sym__blank_line_token1,
-    ACTIONS(546), 8,
+    ACTIONS(446), 8,
       ts_builtin_sym_end,
       aux_sym_WS_token1,
       aux_sym__comment_prefix_token2,
@@ -10949,7 +11553,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [6555] = 2,
+  [6495] = 2,
     ACTIONS(544), 6,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
@@ -10966,15 +11570,15 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [6574] = 2,
-    ACTIONS(540), 6,
+  [6514] = 2,
+    ACTIONS(548), 6,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       aux_sym__comment_prefix_token1,
       sym_method,
       sym_header_entity,
       aux_sym__blank_line_token1,
-    ACTIONS(538), 8,
+    ACTIONS(546), 8,
       ts_builtin_sym_end,
       aux_sym_WS_token1,
       aux_sym__comment_prefix_token2,
@@ -10983,15 +11587,15 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [6593] = 2,
-    ACTIONS(552), 6,
+  [6533] = 2,
+    ACTIONS(562), 6,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       aux_sym__comment_prefix_token1,
       sym_method,
       sym_header_entity,
       aux_sym__blank_line_token1,
-    ACTIONS(550), 8,
+    ACTIONS(560), 8,
       ts_builtin_sym_end,
       aux_sym_WS_token1,
       aux_sym__comment_prefix_token2,
@@ -11000,71 +11604,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [6612] = 2,
-    ACTIONS(701), 6,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym__comment_prefix_token1,
-      sym_method,
-      sym_header_entity,
-      aux_sym__blank_line_token1,
-    ACTIONS(699), 7,
-      ts_builtin_sym_end,
-      aux_sym_WS_token1,
-      aux_sym__comment_prefix_token2,
-      aux_sym_request_separator_token1,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-  [6630] = 2,
-    ACTIONS(705), 6,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym__comment_prefix_token1,
-      sym_method,
-      sym_header_entity,
-      aux_sym__blank_line_token1,
-    ACTIONS(703), 7,
-      ts_builtin_sym_end,
-      aux_sym_WS_token1,
-      aux_sym__comment_prefix_token2,
-      aux_sym_request_separator_token1,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-  [6648] = 2,
-    ACTIONS(709), 6,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym__comment_prefix_token1,
-      sym_method,
-      sym_header_entity,
-      aux_sym__blank_line_token1,
-    ACTIONS(707), 7,
-      ts_builtin_sym_end,
-      aux_sym_WS_token1,
-      aux_sym__comment_prefix_token2,
-      aux_sym_request_separator_token1,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-  [6666] = 2,
-    ACTIONS(713), 6,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym__comment_prefix_token1,
-      sym_method,
-      sym_header_entity,
-      aux_sym__blank_line_token1,
-    ACTIONS(711), 7,
-      ts_builtin_sym_end,
-      aux_sym_WS_token1,
-      aux_sym__comment_prefix_token2,
-      aux_sym_request_separator_token1,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-  [6684] = 2,
+  [6552] = 2,
     ACTIONS(717), 6,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
@@ -11080,7 +11620,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [6702] = 2,
+  [6570] = 2,
     ACTIONS(721), 6,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
@@ -11096,7 +11636,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [6720] = 2,
+  [6588] = 2,
     ACTIONS(725), 6,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
@@ -11112,7 +11652,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [6738] = 2,
+  [6606] = 2,
     ACTIONS(729), 6,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
@@ -11128,7 +11668,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [6756] = 2,
+  [6624] = 2,
     ACTIONS(733), 6,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
@@ -11144,82 +11684,71 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [6774] = 2,
-    ACTIONS(540), 4,
+  [6642] = 2,
+    ACTIONS(737), 6,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       aux_sym__comment_prefix_token1,
+      sym_method,
+      sym_header_entity,
       aux_sym__blank_line_token1,
-    ACTIONS(538), 8,
+    ACTIONS(735), 7,
       ts_builtin_sym_end,
       aux_sym_WS_token1,
       aux_sym__comment_prefix_token2,
       aux_sym_request_separator_token1,
-      sym_method,
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [6791] = 2,
-    ACTIONS(737), 4,
+  [6660] = 2,
+    ACTIONS(741), 6,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       aux_sym__comment_prefix_token1,
+      sym_method,
+      sym_header_entity,
       aux_sym__blank_line_token1,
-    ACTIONS(735), 8,
+    ACTIONS(739), 7,
       ts_builtin_sym_end,
       aux_sym_WS_token1,
       aux_sym__comment_prefix_token2,
       aux_sym_request_separator_token1,
-      sym_method,
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [6808] = 2,
-    ACTIONS(741), 4,
+  [6678] = 2,
+    ACTIONS(745), 6,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       aux_sym__comment_prefix_token1,
+      sym_method,
+      sym_header_entity,
       aux_sym__blank_line_token1,
-    ACTIONS(739), 8,
+    ACTIONS(743), 7,
       ts_builtin_sym_end,
       aux_sym_WS_token1,
       aux_sym__comment_prefix_token2,
       aux_sym_request_separator_token1,
-      sym_method,
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [6825] = 2,
-    ACTIONS(745), 4,
+  [6696] = 2,
+    ACTIONS(749), 6,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       aux_sym__comment_prefix_token1,
+      sym_method,
+      sym_header_entity,
       aux_sym__blank_line_token1,
-    ACTIONS(743), 8,
+    ACTIONS(747), 7,
       ts_builtin_sym_end,
       aux_sym_WS_token1,
       aux_sym__comment_prefix_token2,
       aux_sym_request_separator_token1,
-      sym_method,
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [6842] = 2,
-    ACTIONS(749), 4,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym__comment_prefix_token1,
-      aux_sym__blank_line_token1,
-    ACTIONS(747), 8,
-      ts_builtin_sym_end,
-      aux_sym_WS_token1,
-      aux_sym__comment_prefix_token2,
-      aux_sym_request_separator_token1,
-      sym_method,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-  [6859] = 2,
+  [6714] = 2,
     ACTIONS(753), 4,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
@@ -11234,13 +11763,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [6876] = 2,
-    ACTIONS(552), 4,
+  [6731] = 2,
+    ACTIONS(448), 4,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       aux_sym__comment_prefix_token1,
       aux_sym__blank_line_token1,
-    ACTIONS(550), 8,
+    ACTIONS(446), 8,
       ts_builtin_sym_end,
       aux_sym_WS_token1,
       aux_sym__comment_prefix_token2,
@@ -11249,7 +11778,22 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [6893] = 2,
+  [6748] = 2,
+    ACTIONS(572), 4,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym__comment_prefix_token1,
+      aux_sym__blank_line_token1,
+    ACTIONS(570), 8,
+      ts_builtin_sym_end,
+      aux_sym_WS_token1,
+      aux_sym__comment_prefix_token2,
+      aux_sym_request_separator_token1,
+      sym_method,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+  [6765] = 2,
     ACTIONS(757), 4,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
@@ -11264,7 +11808,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [6910] = 2,
+  [6782] = 2,
     ACTIONS(761), 4,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
@@ -11279,7 +11823,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [6927] = 2,
+  [6799] = 2,
     ACTIONS(765), 4,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
@@ -11294,7 +11838,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [6944] = 2,
+  [6816] = 2,
     ACTIONS(769), 4,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
@@ -11309,13 +11853,13 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [6961] = 2,
-    ACTIONS(544), 4,
+  [6833] = 2,
+    ACTIONS(562), 4,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
       aux_sym__comment_prefix_token1,
       aux_sym__blank_line_token1,
-    ACTIONS(542), 8,
+    ACTIONS(560), 8,
       ts_builtin_sym_end,
       aux_sym_WS_token1,
       aux_sym__comment_prefix_token2,
@@ -11324,7 +11868,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [6978] = 2,
+  [6850] = 2,
     ACTIONS(773), 4,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
@@ -11339,52 +11883,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [6995] = 2,
-    ACTIONS(560), 4,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym__comment_prefix_token1,
-      aux_sym__blank_line_token1,
-    ACTIONS(558), 8,
-      ts_builtin_sym_end,
-      aux_sym_WS_token1,
-      aux_sym__comment_prefix_token2,
-      aux_sym_request_separator_token1,
-      sym_method,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-  [7012] = 2,
-    ACTIONS(777), 4,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym__comment_prefix_token1,
-      aux_sym__blank_line_token1,
-    ACTIONS(775), 8,
-      ts_builtin_sym_end,
-      aux_sym_WS_token1,
-      aux_sym__comment_prefix_token2,
-      aux_sym_request_separator_token1,
-      sym_method,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-  [7029] = 2,
-    ACTIONS(781), 4,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym__comment_prefix_token1,
-      aux_sym__blank_line_token1,
-    ACTIONS(779), 8,
-      ts_builtin_sym_end,
-      aux_sym_WS_token1,
-      aux_sym__comment_prefix_token2,
-      aux_sym_request_separator_token1,
-      sym_method,
-      anon_sym_LBRACE_LBRACE,
-      anon_sym_LT,
-      anon_sym_AT2,
-  [7046] = 2,
+  [6867] = 2,
     ACTIONS(548), 4,
       aux_sym_WORD_CHAR_token1,
       aux_sym_PUNCTUATION_token1,
@@ -11399,1775 +11898,1891 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE_LBRACE,
       anon_sym_LT,
       anon_sym_AT2,
-  [7063] = 7,
-    ACTIONS(17), 1,
-      anon_sym_LBRACE_LBRACE,
-    ACTIONS(783), 1,
+  [6884] = 2,
+    ACTIONS(777), 4,
       aux_sym_WORD_CHAR_token1,
-    ACTIONS(787), 1,
-      aux_sym_NL_token1,
-    ACTIONS(789), 1,
-      aux_sym_comment_token1,
-    STATE(272), 1,
-      sym_value,
-    ACTIONS(785), 2,
       aux_sym_PUNCTUATION_token1,
+      aux_sym__comment_prefix_token1,
+      aux_sym__blank_line_token1,
+    ACTIONS(775), 8,
+      ts_builtin_sym_end,
       aux_sym_WS_token1,
-    STATE(181), 2,
-      sym_variable,
-      aux_sym_value_repeat1,
-  [7087] = 7,
-    ACTIONS(17), 1,
+      aux_sym__comment_prefix_token2,
+      aux_sym_request_separator_token1,
+      sym_method,
       anon_sym_LBRACE_LBRACE,
-    ACTIONS(783), 1,
+      anon_sym_LT,
+      anon_sym_AT2,
+  [6901] = 2,
+    ACTIONS(781), 4,
       aux_sym_WORD_CHAR_token1,
-    ACTIONS(791), 1,
-      aux_sym_NL_token1,
-    ACTIONS(793), 1,
-      aux_sym_comment_token1,
-    STATE(288), 1,
-      sym_value,
-    ACTIONS(785), 2,
       aux_sym_PUNCTUATION_token1,
+      aux_sym__comment_prefix_token1,
+      aux_sym__blank_line_token1,
+    ACTIONS(779), 8,
+      ts_builtin_sym_end,
       aux_sym_WS_token1,
-    STATE(181), 2,
-      sym_variable,
-      aux_sym_value_repeat1,
-  [7111] = 6,
-    ACTIONS(797), 1,
-      aux_sym_PUNCTUATION_token1,
-    ACTIONS(799), 1,
+      aux_sym__comment_prefix_token2,
+      aux_sym_request_separator_token1,
+      sym_method,
       anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+  [6918] = 2,
+    ACTIONS(785), 4,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym__comment_prefix_token1,
+      aux_sym__blank_line_token1,
+    ACTIONS(783), 8,
+      ts_builtin_sym_end,
+      aux_sym_WS_token1,
+      aux_sym__comment_prefix_token2,
+      aux_sym_request_separator_token1,
+      sym_method,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+  [6935] = 2,
+    ACTIONS(789), 4,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym__comment_prefix_token1,
+      aux_sym__blank_line_token1,
+    ACTIONS(787), 8,
+      ts_builtin_sym_end,
+      aux_sym_WS_token1,
+      aux_sym__comment_prefix_token2,
+      aux_sym_request_separator_token1,
+      sym_method,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+  [6952] = 2,
+    ACTIONS(793), 4,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym__comment_prefix_token1,
+      aux_sym__blank_line_token1,
+    ACTIONS(791), 8,
+      ts_builtin_sym_end,
+      aux_sym_WS_token1,
+      aux_sym__comment_prefix_token2,
+      aux_sym_request_separator_token1,
+      sym_method,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+  [6969] = 2,
+    ACTIONS(797), 4,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym__comment_prefix_token1,
+      aux_sym__blank_line_token1,
+    ACTIONS(795), 8,
+      ts_builtin_sym_end,
+      aux_sym_WS_token1,
+      aux_sym__comment_prefix_token2,
+      aux_sym_request_separator_token1,
+      sym_method,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+  [6986] = 2,
+    ACTIONS(544), 4,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym__comment_prefix_token1,
+      aux_sym__blank_line_token1,
+    ACTIONS(542), 8,
+      ts_builtin_sym_end,
+      aux_sym_WS_token1,
+      aux_sym__comment_prefix_token2,
+      aux_sym_request_separator_token1,
+      sym_method,
+      anon_sym_LBRACE_LBRACE,
+      anon_sym_LT,
+      anon_sym_AT2,
+  [7003] = 6,
     ACTIONS(801), 1,
-      anon_sym_LBRACE_PERCENT,
-    ACTIONS(795), 2,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_path_token1,
-    STATE(176), 2,
-      sym_variable,
-      aux_sym_path_repeat1,
-    STATE(250), 2,
-      sym_script,
-      sym_path,
-  [7133] = 7,
-    ACTIONS(17), 1,
-      anon_sym_LBRACE_LBRACE,
-    ACTIONS(783), 1,
-      aux_sym_WORD_CHAR_token1,
+      aux_sym_PUNCTUATION_token1,
     ACTIONS(803), 1,
-      aux_sym_NL_token1,
-    ACTIONS(805), 1,
-      aux_sym_comment_token1,
-    STATE(255), 1,
-      sym_value,
-    ACTIONS(785), 2,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym_WS_token1,
-    STATE(181), 2,
-      sym_variable,
-      aux_sym_value_repeat1,
-  [7157] = 6,
-    ACTIONS(797), 1,
-      aux_sym_PUNCTUATION_token1,
-    ACTIONS(799), 1,
       anon_sym_LBRACE_LBRACE,
-    ACTIONS(801), 1,
+    ACTIONS(805), 1,
       anon_sym_LBRACE_PERCENT,
-    ACTIONS(795), 2,
+    ACTIONS(799), 2,
       aux_sym_WORD_CHAR_token1,
       aux_sym_path_token1,
-    STATE(176), 2,
+    STATE(187), 2,
       sym_variable,
       aux_sym_path_repeat1,
     STATE(259), 2,
       sym_script,
       sym_path,
-  [7179] = 6,
+  [7025] = 7,
     ACTIONS(17), 1,
       anon_sym_LBRACE_LBRACE,
-    ACTIONS(785), 1,
-      aux_sym_PUNCTUATION_token1,
-    ACTIONS(791), 1,
-      aux_sym_NL_token1,
-    STATE(288), 1,
-      sym_value,
-    ACTIONS(783), 2,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_WS_token1,
-    STATE(181), 2,
-      sym_variable,
-      aux_sym_value_repeat1,
-  [7200] = 6,
-    ACTIONS(17), 1,
-      anon_sym_LBRACE_LBRACE,
-    ACTIONS(783), 1,
-      aux_sym_WORD_CHAR_token1,
     ACTIONS(807), 1,
-      aux_sym_comment_token1,
-    STATE(264), 1,
-      sym_value,
-    ACTIONS(785), 2,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym_WS_token1,
-    STATE(181), 2,
-      sym_variable,
-      aux_sym_value_repeat1,
-  [7221] = 6,
-    ACTIONS(17), 1,
-      anon_sym_LBRACE_LBRACE,
-    ACTIONS(785), 1,
-      aux_sym_PUNCTUATION_token1,
-    ACTIONS(809), 1,
-      aux_sym_NL_token1,
-    STATE(247), 1,
-      sym_value,
-    ACTIONS(783), 2,
       aux_sym_WORD_CHAR_token1,
-      aux_sym_WS_token1,
-    STATE(181), 2,
-      sym_variable,
-      aux_sym_value_repeat1,
-  [7242] = 7,
-    ACTIONS(17), 1,
-      anon_sym_LBRACE_LBRACE,
     ACTIONS(811), 1,
-      aux_sym_WORD_CHAR_token1,
+      aux_sym_NL_token1,
     ACTIONS(813), 1,
+      aux_sym_comment_token1,
+    STATE(249), 1,
+      sym_value,
+    ACTIONS(809), 2,
       aux_sym_PUNCTUATION_token1,
+      aux_sym_WS_token1,
+    STATE(177), 2,
+      sym_variable,
+      aux_sym_value_repeat1,
+  [7049] = 7,
+    ACTIONS(17), 1,
+      anon_sym_LBRACE_LBRACE,
+    ACTIONS(807), 1,
+      aux_sym_WORD_CHAR_token1,
     ACTIONS(815), 1,
-      aux_sym_WS_token1,
+      aux_sym_NL_token1,
     ACTIONS(817), 1,
-      aux_sym_NL_token1,
-    STATE(199), 1,
-      aux_sym_target_url_repeat1,
-    STATE(172), 2,
-      aux_sym__target_url_line,
-      sym_variable,
-  [7265] = 6,
-    ACTIONS(17), 1,
-      anon_sym_LBRACE_LBRACE,
-    ACTIONS(783), 1,
-      aux_sym_WORD_CHAR_token1,
-    ACTIONS(820), 1,
       aux_sym_comment_token1,
-    STATE(278), 1,
+    STATE(261), 1,
       sym_value,
-    ACTIONS(785), 2,
+    ACTIONS(809), 2,
       aux_sym_PUNCTUATION_token1,
       aux_sym_WS_token1,
-    STATE(181), 2,
+    STATE(177), 2,
       sym_variable,
       aux_sym_value_repeat1,
-  [7286] = 6,
-    ACTIONS(17), 1,
-      anon_sym_LBRACE_LBRACE,
-    ACTIONS(785), 1,
+  [7073] = 6,
+    ACTIONS(801), 1,
       aux_sym_PUNCTUATION_token1,
-    ACTIONS(822), 1,
-      aux_sym_NL_token1,
-    STATE(273), 1,
-      sym_value,
-    ACTIONS(783), 2,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_WS_token1,
-    STATE(181), 2,
-      sym_variable,
-      aux_sym_value_repeat1,
-  [7307] = 6,
-    ACTIONS(17), 1,
+    ACTIONS(803), 1,
       anon_sym_LBRACE_LBRACE,
-    ACTIONS(783), 1,
-      aux_sym_WORD_CHAR_token1,
-    ACTIONS(824), 1,
-      aux_sym_comment_token1,
-    STATE(248), 1,
-      sym_value,
-    ACTIONS(785), 2,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym_WS_token1,
-    STATE(181), 2,
-      sym_variable,
-      aux_sym_value_repeat1,
-  [7328] = 6,
-    ACTIONS(17), 1,
-      anon_sym_LBRACE_LBRACE,
-    ACTIONS(783), 1,
-      aux_sym_WORD_CHAR_token1,
-    ACTIONS(826), 1,
-      aux_sym_comment_token1,
-    STATE(270), 1,
-      sym_value,
-    ACTIONS(785), 2,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym_WS_token1,
-    STATE(181), 2,
-      sym_variable,
-      aux_sym_value_repeat1,
-  [7349] = 6,
-    ACTIONS(17), 1,
-      anon_sym_LBRACE_LBRACE,
-    ACTIONS(783), 1,
-      aux_sym_WORD_CHAR_token1,
-    ACTIONS(828), 1,
-      aux_sym_comment_token1,
-    STATE(265), 1,
-      sym_value,
-    ACTIONS(785), 2,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym_WS_token1,
-    STATE(181), 2,
-      sym_variable,
-      aux_sym_value_repeat1,
-  [7370] = 6,
-    ACTIONS(832), 1,
-      aux_sym_PUNCTUATION_token1,
-    ACTIONS(834), 1,
-      aux_sym_WS_token1,
-    ACTIONS(836), 1,
-      aux_sym_NL_token1,
-    ACTIONS(838), 1,
-      anon_sym_LBRACE_LBRACE,
-    ACTIONS(830), 2,
+    ACTIONS(805), 1,
+      anon_sym_LBRACE_PERCENT,
+    ACTIONS(799), 2,
       aux_sym_WORD_CHAR_token1,
       aux_sym_path_token1,
-    STATE(170), 2,
+    STATE(187), 2,
       sym_variable,
       aux_sym_path_repeat1,
-  [7391] = 6,
-    ACTIONS(17), 1,
-      anon_sym_LBRACE_LBRACE,
-    ACTIONS(783), 1,
-      aux_sym_WORD_CHAR_token1,
-    ACTIONS(840), 1,
-      aux_sym_comment_token1,
-    STATE(245), 1,
-      sym_value,
-    ACTIONS(785), 2,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym_WS_token1,
-    STATE(181), 2,
-      sym_variable,
-      aux_sym_value_repeat1,
-  [7412] = 6,
-    ACTIONS(845), 1,
-      aux_sym_PUNCTUATION_token1,
-    ACTIONS(848), 1,
-      aux_sym_WS_token1,
-    ACTIONS(850), 1,
-      aux_sym_NL_token1,
-    ACTIONS(852), 1,
-      anon_sym_LBRACE_LBRACE,
-    ACTIONS(842), 2,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_path_token1,
-    STATE(170), 2,
-      sym_variable,
-      aux_sym_path_repeat1,
-  [7433] = 6,
-    ACTIONS(17), 1,
-      anon_sym_LBRACE_LBRACE,
-    ACTIONS(811), 1,
-      aux_sym_WORD_CHAR_token1,
-    ACTIONS(813), 1,
-      aux_sym_PUNCTUATION_token1,
-    ACTIONS(855), 1,
-      aux_sym_WS_token1,
-    ACTIONS(857), 1,
-      aux_sym_NL_token1,
-    STATE(172), 2,
-      aux_sym__target_url_line,
-      sym_variable,
-  [7453] = 6,
-    ACTIONS(859), 1,
-      aux_sym_WORD_CHAR_token1,
-    ACTIONS(862), 1,
-      aux_sym_PUNCTUATION_token1,
-    ACTIONS(865), 1,
-      aux_sym_WS_token1,
-    ACTIONS(867), 1,
-      aux_sym_NL_token1,
-    ACTIONS(869), 1,
-      anon_sym_LBRACE_LBRACE,
-    STATE(172), 2,
-      aux_sym__target_url_line,
-      sym_variable,
-  [7473] = 5,
-    ACTIONS(850), 1,
-      aux_sym_pre_request_script_token1,
-    ACTIONS(875), 1,
-      aux_sym_PUNCTUATION_token1,
-    ACTIONS(878), 1,
-      anon_sym_LBRACE_LBRACE,
-    ACTIONS(872), 2,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_path_token1,
-    STATE(173), 2,
-      sym_variable,
-      aux_sym_path_repeat1,
-  [7491] = 5,
-    ACTIONS(17), 1,
-      anon_sym_LBRACE_LBRACE,
-    ACTIONS(785), 1,
-      aux_sym_PUNCTUATION_token1,
-    STATE(258), 1,
-      sym_value,
-    ACTIONS(783), 2,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_WS_token1,
-    STATE(181), 2,
-      sym_variable,
-      aux_sym_value_repeat1,
-  [7509] = 5,
-    ACTIONS(17), 1,
-      anon_sym_LBRACE_LBRACE,
-    ACTIONS(785), 1,
-      aux_sym_PUNCTUATION_token1,
-    STATE(264), 1,
-      sym_value,
-    ACTIONS(783), 2,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_WS_token1,
-    STATE(181), 2,
-      sym_variable,
-      aux_sym_value_repeat1,
-  [7527] = 5,
-    ACTIONS(799), 1,
-      anon_sym_LBRACE_LBRACE,
-    ACTIONS(836), 1,
-      aux_sym_pre_request_script_token1,
-    ACTIONS(883), 1,
-      aux_sym_PUNCTUATION_token1,
-    ACTIONS(881), 2,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_path_token1,
-    STATE(173), 2,
-      sym_variable,
-      aux_sym_path_repeat1,
-  [7545] = 5,
-    ACTIONS(838), 1,
-      anon_sym_LBRACE_LBRACE,
-    ACTIONS(887), 1,
-      aux_sym_PUNCTUATION_token1,
-    STATE(208), 1,
+    STATE(252), 2,
+      sym_script,
       sym_path,
-    ACTIONS(885), 2,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_path_token1,
-    STATE(168), 2,
-      sym_variable,
-      aux_sym_path_repeat1,
-  [7563] = 5,
-    ACTIONS(838), 1,
-      anon_sym_LBRACE_LBRACE,
-    ACTIONS(887), 1,
-      aux_sym_PUNCTUATION_token1,
-    STATE(225), 1,
-      sym_path,
-    ACTIONS(885), 2,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_path_token1,
-    STATE(168), 2,
-      sym_variable,
-      aux_sym_path_repeat1,
-  [7581] = 5,
-    ACTIONS(892), 1,
-      aux_sym_PUNCTUATION_token1,
-    ACTIONS(895), 1,
-      aux_sym_NL_token1,
-    ACTIONS(897), 1,
-      anon_sym_LBRACE_LBRACE,
-    ACTIONS(889), 2,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_WS_token1,
-    STATE(179), 2,
-      sym_variable,
-      aux_sym_value_repeat1,
-  [7599] = 5,
+  [7095] = 7,
     ACTIONS(17), 1,
       anon_sym_LBRACE_LBRACE,
-    ACTIONS(785), 1,
-      aux_sym_PUNCTUATION_token1,
+    ACTIONS(807), 1,
+      aux_sym_WORD_CHAR_token1,
+    ACTIONS(819), 1,
+      aux_sym_NL_token1,
+    ACTIONS(821), 1,
+      aux_sym_comment_token1,
     STATE(279), 1,
       sym_value,
-    ACTIONS(783), 2,
-      aux_sym_WORD_CHAR_token1,
+    ACTIONS(809), 2,
+      aux_sym_PUNCTUATION_token1,
       aux_sym_WS_token1,
-    STATE(181), 2,
+    STATE(177), 2,
       sym_variable,
       aux_sym_value_repeat1,
-  [7617] = 5,
+  [7119] = 6,
     ACTIONS(17), 1,
       anon_sym_LBRACE_LBRACE,
+    ACTIONS(809), 1,
+      aux_sym_PUNCTUATION_token1,
+    ACTIONS(823), 1,
+      aux_sym_NL_token1,
+    STATE(238), 1,
+      sym_value,
+    ACTIONS(807), 2,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_WS_token1,
+    STATE(177), 2,
+      sym_variable,
+      aux_sym_value_repeat1,
+  [7140] = 6,
+    ACTIONS(17), 1,
+      anon_sym_LBRACE_LBRACE,
+    ACTIONS(807), 1,
+      aux_sym_WORD_CHAR_token1,
+    ACTIONS(825), 1,
+      aux_sym_comment_token1,
+    STATE(241), 1,
+      sym_value,
+    ACTIONS(809), 2,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym_WS_token1,
+    STATE(177), 2,
+      sym_variable,
+      aux_sym_value_repeat1,
+  [7161] = 6,
+    ACTIONS(17), 1,
+      anon_sym_LBRACE_LBRACE,
+    ACTIONS(809), 1,
+      aux_sym_PUNCTUATION_token1,
+    ACTIONS(827), 1,
+      aux_sym_NL_token1,
+    STATE(244), 1,
+      sym_value,
+    ACTIONS(807), 2,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_WS_token1,
+    STATE(177), 2,
+      sym_variable,
+      aux_sym_value_repeat1,
+  [7182] = 6,
+    ACTIONS(17), 1,
+      anon_sym_LBRACE_LBRACE,
+    ACTIONS(807), 1,
+      aux_sym_WORD_CHAR_token1,
+    ACTIONS(829), 1,
+      aux_sym_comment_token1,
+    STATE(281), 1,
+      sym_value,
+    ACTIONS(809), 2,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym_WS_token1,
+    STATE(177), 2,
+      sym_variable,
+      aux_sym_value_repeat1,
+  [7203] = 6,
+    ACTIONS(17), 1,
+      anon_sym_LBRACE_LBRACE,
+    ACTIONS(807), 1,
+      aux_sym_WORD_CHAR_token1,
+    ACTIONS(831), 1,
+      aux_sym_comment_token1,
+    STATE(287), 1,
+      sym_value,
+    ACTIONS(809), 2,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym_WS_token1,
+    STATE(177), 2,
+      sym_variable,
+      aux_sym_value_repeat1,
+  [7224] = 6,
+    ACTIONS(835), 1,
+      aux_sym_PUNCTUATION_token1,
+    ACTIONS(837), 1,
+      aux_sym_WS_token1,
+    ACTIONS(839), 1,
+      aux_sym_NL_token1,
+    ACTIONS(841), 1,
+      anon_sym_LBRACE_LBRACE,
+    ACTIONS(833), 2,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_path_token1,
+    STATE(170), 2,
+      sym_variable,
+      aux_sym_path_repeat1,
+  [7245] = 7,
+    ACTIONS(17), 1,
+      anon_sym_LBRACE_LBRACE,
+    ACTIONS(843), 1,
+      aux_sym_WORD_CHAR_token1,
+    ACTIONS(845), 1,
+      aux_sym_PUNCTUATION_token1,
+    ACTIONS(847), 1,
+      aux_sym_WS_token1,
+    ACTIONS(849), 1,
+      aux_sym_NL_token1,
+    STATE(208), 1,
+      aux_sym_target_url_repeat1,
+    STATE(183), 2,
+      aux_sym__target_url_line,
+      sym_variable,
+  [7268] = 6,
+    ACTIONS(17), 1,
+      anon_sym_LBRACE_LBRACE,
+    ACTIONS(807), 1,
+      aux_sym_WORD_CHAR_token1,
+    ACTIONS(852), 1,
+      aux_sym_comment_token1,
+    STATE(236), 1,
+      sym_value,
+    ACTIONS(809), 2,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym_WS_token1,
+    STATE(177), 2,
+      sym_variable,
+      aux_sym_value_repeat1,
+  [7289] = 6,
+    ACTIONS(857), 1,
+      aux_sym_PUNCTUATION_token1,
+    ACTIONS(860), 1,
+      aux_sym_WS_token1,
+    ACTIONS(862), 1,
+      aux_sym_NL_token1,
+    ACTIONS(864), 1,
+      anon_sym_LBRACE_LBRACE,
+    ACTIONS(854), 2,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_path_token1,
+    STATE(170), 2,
+      sym_variable,
+      aux_sym_path_repeat1,
+  [7310] = 6,
+    ACTIONS(17), 1,
+      anon_sym_LBRACE_LBRACE,
+    ACTIONS(807), 1,
+      aux_sym_WORD_CHAR_token1,
+    ACTIONS(867), 1,
+      aux_sym_comment_token1,
+    STATE(286), 1,
+      sym_value,
+    ACTIONS(809), 2,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym_WS_token1,
+    STATE(177), 2,
+      sym_variable,
+      aux_sym_value_repeat1,
+  [7331] = 6,
+    ACTIONS(17), 1,
+      anon_sym_LBRACE_LBRACE,
+    ACTIONS(807), 1,
+      aux_sym_WORD_CHAR_token1,
+    ACTIONS(869), 1,
+      aux_sym_comment_token1,
+    STATE(273), 1,
+      sym_value,
+    ACTIONS(809), 2,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym_WS_token1,
+    STATE(177), 2,
+      sym_variable,
+      aux_sym_value_repeat1,
+  [7352] = 6,
+    ACTIONS(17), 1,
+      anon_sym_LBRACE_LBRACE,
+    ACTIONS(809), 1,
+      aux_sym_PUNCTUATION_token1,
+    ACTIONS(815), 1,
+      aux_sym_NL_token1,
+    STATE(261), 1,
+      sym_value,
+    ACTIONS(807), 2,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_WS_token1,
+    STATE(177), 2,
+      sym_variable,
+      aux_sym_value_repeat1,
+  [7373] = 5,
+    ACTIONS(17), 1,
+      anon_sym_LBRACE_LBRACE,
+    ACTIONS(809), 1,
+      aux_sym_PUNCTUATION_token1,
+    STATE(274), 1,
+      sym_value,
+    ACTIONS(807), 2,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_WS_token1,
+    STATE(177), 2,
+      sym_variable,
+      aux_sym_value_repeat1,
+  [7391] = 5,
+    ACTIONS(862), 1,
+      aux_sym_pre_request_script_token1,
+    ACTIONS(874), 1,
+      aux_sym_PUNCTUATION_token1,
+    ACTIONS(877), 1,
+      anon_sym_LBRACE_LBRACE,
+    ACTIONS(871), 2,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_path_token1,
+    STATE(175), 2,
+      sym_variable,
+      aux_sym_path_repeat1,
+  [7409] = 5,
+    ACTIONS(841), 1,
+      anon_sym_LBRACE_LBRACE,
+    ACTIONS(882), 1,
+      aux_sym_PUNCTUATION_token1,
+    STATE(230), 1,
+      sym_path,
+    ACTIONS(880), 2,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_path_token1,
+    STATE(167), 2,
+      sym_variable,
+      aux_sym_path_repeat1,
+  [7427] = 5,
+    ACTIONS(17), 1,
+      anon_sym_LBRACE_LBRACE,
+    ACTIONS(886), 1,
+      aux_sym_PUNCTUATION_token1,
+    ACTIONS(888), 1,
+      aux_sym_NL_token1,
+    ACTIONS(884), 2,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_WS_token1,
+    STATE(185), 2,
+      sym_variable,
+      aux_sym_value_repeat1,
+  [7445] = 5,
+    ACTIONS(17), 1,
+      anon_sym_LBRACE_LBRACE,
+    ACTIONS(809), 1,
+      aux_sym_PUNCTUATION_token1,
+    STATE(239), 1,
+      sym_value,
+    ACTIONS(807), 2,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_WS_token1,
+    STATE(177), 2,
+      sym_variable,
+      aux_sym_value_repeat1,
+  [7463] = 5,
+    ACTIONS(17), 1,
+      anon_sym_LBRACE_LBRACE,
+    ACTIONS(809), 1,
+      aux_sym_PUNCTUATION_token1,
+    STATE(263), 1,
+      sym_value,
+    ACTIONS(807), 2,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_WS_token1,
+    STATE(177), 2,
+      sym_variable,
+      aux_sym_value_repeat1,
+  [7481] = 6,
+    ACTIONS(17), 1,
+      anon_sym_LBRACE_LBRACE,
+    ACTIONS(843), 1,
+      aux_sym_WORD_CHAR_token1,
+    ACTIONS(845), 1,
+      aux_sym_PUNCTUATION_token1,
+    ACTIONS(890), 1,
+      aux_sym_WS_token1,
+    ACTIONS(892), 1,
+      aux_sym_NL_token1,
+    STATE(183), 2,
+      aux_sym__target_url_line,
+      sym_variable,
+  [7501] = 5,
+    ACTIONS(17), 1,
+      anon_sym_LBRACE_LBRACE,
+    ACTIONS(809), 1,
+      aux_sym_PUNCTUATION_token1,
+    STATE(287), 1,
+      sym_value,
+    ACTIONS(807), 2,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_WS_token1,
+    STATE(177), 2,
+      sym_variable,
+      aux_sym_value_repeat1,
+  [7519] = 5,
+    ACTIONS(17), 1,
+      anon_sym_LBRACE_LBRACE,
+    ACTIONS(809), 1,
+      aux_sym_PUNCTUATION_token1,
+    STATE(262), 1,
+      sym_value,
+    ACTIONS(807), 2,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_WS_token1,
+    STATE(177), 2,
+      sym_variable,
+      aux_sym_value_repeat1,
+  [7537] = 6,
+    ACTIONS(894), 1,
+      aux_sym_WORD_CHAR_token1,
+    ACTIONS(897), 1,
+      aux_sym_PUNCTUATION_token1,
+    ACTIONS(900), 1,
+      aux_sym_WS_token1,
     ACTIONS(902), 1,
-      aux_sym_PUNCTUATION_token1,
+      aux_sym_NL_token1,
     ACTIONS(904), 1,
+      anon_sym_LBRACE_LBRACE,
+    STATE(183), 2,
+      aux_sym__target_url_line,
+      sym_variable,
+  [7557] = 5,
+    ACTIONS(17), 1,
+      anon_sym_LBRACE_LBRACE,
+    ACTIONS(809), 1,
+      aux_sym_PUNCTUATION_token1,
+    STATE(282), 1,
+      sym_value,
+    ACTIONS(807), 2,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_WS_token1,
+    STATE(177), 2,
+      sym_variable,
+      aux_sym_value_repeat1,
+  [7575] = 5,
+    ACTIONS(910), 1,
+      aux_sym_PUNCTUATION_token1,
+    ACTIONS(913), 1,
       aux_sym_NL_token1,
-    ACTIONS(900), 2,
+    ACTIONS(915), 1,
+      anon_sym_LBRACE_LBRACE,
+    ACTIONS(907), 2,
       aux_sym_WORD_CHAR_token1,
       aux_sym_WS_token1,
-    STATE(179), 2,
+    STATE(185), 2,
       sym_variable,
       aux_sym_value_repeat1,
-  [7635] = 5,
-    ACTIONS(17), 1,
+  [7593] = 5,
+    ACTIONS(841), 1,
       anon_sym_LBRACE_LBRACE,
-    ACTIONS(785), 1,
+    ACTIONS(882), 1,
       aux_sym_PUNCTUATION_token1,
-    STATE(271), 1,
-      sym_value,
-    ACTIONS(783), 2,
+    STATE(221), 1,
+      sym_path,
+    ACTIONS(880), 2,
       aux_sym_WORD_CHAR_token1,
-      aux_sym_WS_token1,
-    STATE(181), 2,
-      sym_variable,
-      aux_sym_value_repeat1,
-  [7653] = 5,
-    ACTIONS(17), 1,
-      anon_sym_LBRACE_LBRACE,
-    ACTIONS(785), 1,
-      aux_sym_PUNCTUATION_token1,
-    STATE(237), 1,
-      sym_value,
-    ACTIONS(783), 2,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_WS_token1,
-    STATE(181), 2,
-      sym_variable,
-      aux_sym_value_repeat1,
-  [7671] = 5,
-    ACTIONS(17), 1,
-      anon_sym_LBRACE_LBRACE,
-    ACTIONS(785), 1,
-      aux_sym_PUNCTUATION_token1,
-    STATE(251), 1,
-      sym_value,
-    ACTIONS(783), 2,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_WS_token1,
-    STATE(181), 2,
-      sym_variable,
-      aux_sym_value_repeat1,
-  [7689] = 2,
-    ACTIONS(908), 2,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym_NL_token1,
-    ACTIONS(906), 4,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_WS_token1,
-      anon_sym_LBRACE_LBRACE,
       aux_sym_path_token1,
-  [7700] = 2,
-    ACTIONS(912), 2,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym_NL_token1,
-    ACTIONS(910), 4,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_WS_token1,
+    STATE(167), 2,
+      sym_variable,
+      aux_sym_path_repeat1,
+  [7611] = 5,
+    ACTIONS(803), 1,
       anon_sym_LBRACE_LBRACE,
+    ACTIONS(839), 1,
+      aux_sym_pre_request_script_token1,
+    ACTIONS(920), 1,
+      aux_sym_PUNCTUATION_token1,
+    ACTIONS(918), 2,
+      aux_sym_WORD_CHAR_token1,
       aux_sym_path_token1,
-  [7711] = 5,
+    STATE(175), 2,
+      sym_variable,
+      aux_sym_path_repeat1,
+  [7629] = 5,
     ACTIONS(5), 1,
       aux_sym_PUNCTUATION_token1,
     ACTIONS(17), 1,
       anon_sym_LBRACE_LBRACE,
-    ACTIONS(914), 1,
+    ACTIONS(922), 1,
       aux_sym_WORD_CHAR_token1,
-    STATE(220), 1,
+    STATE(227), 1,
       sym_target_url,
-    STATE(162), 2,
+    STATE(168), 2,
       aux_sym__target_url_line,
       sym_variable,
-  [7728] = 2,
-    ACTIONS(918), 2,
+  [7646] = 2,
+    ACTIONS(926), 2,
       aux_sym_PUNCTUATION_token1,
       aux_sym_NL_token1,
-    ACTIONS(916), 4,
+    ACTIONS(924), 4,
       aux_sym_WORD_CHAR_token1,
       aux_sym_WS_token1,
       anon_sym_LBRACE_LBRACE,
       aux_sym_path_token1,
-  [7739] = 2,
-    ACTIONS(922), 2,
+  [7657] = 2,
+    ACTIONS(930), 2,
       aux_sym_PUNCTUATION_token1,
       aux_sym_NL_token1,
-    ACTIONS(920), 4,
+    ACTIONS(928), 4,
       aux_sym_WORD_CHAR_token1,
       aux_sym_WS_token1,
       anon_sym_LBRACE_LBRACE,
       aux_sym_path_token1,
-  [7750] = 2,
-    ACTIONS(912), 2,
+  [7668] = 2,
+    ACTIONS(934), 2,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym_NL_token1,
+    ACTIONS(932), 4,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_WS_token1,
+      anon_sym_LBRACE_LBRACE,
+      aux_sym_path_token1,
+  [7679] = 2,
+    ACTIONS(938), 2,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym_NL_token1,
+    ACTIONS(936), 4,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_WS_token1,
+      anon_sym_LBRACE_LBRACE,
+      aux_sym_path_token1,
+  [7690] = 2,
+    ACTIONS(938), 2,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym_NL_token1,
+    ACTIONS(936), 3,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_WS_token1,
+      anon_sym_LBRACE_LBRACE,
+  [7700] = 2,
+    ACTIONS(926), 2,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym_NL_token1,
+    ACTIONS(924), 3,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_WS_token1,
+      anon_sym_LBRACE_LBRACE,
+  [7710] = 2,
+    ACTIONS(930), 2,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym_NL_token1,
+    ACTIONS(928), 3,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_WS_token1,
+      anon_sym_LBRACE_LBRACE,
+  [7720] = 2,
+    ACTIONS(930), 2,
       aux_sym_PUNCTUATION_token1,
       aux_sym_pre_request_script_token1,
-    ACTIONS(910), 3,
+    ACTIONS(928), 3,
+      aux_sym_WORD_CHAR_token1,
+      anon_sym_LBRACE_LBRACE,
+      aux_sym_path_token1,
+  [7730] = 2,
+    ACTIONS(938), 2,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym_pre_request_script_token1,
+    ACTIONS(936), 3,
+      aux_sym_WORD_CHAR_token1,
+      anon_sym_LBRACE_LBRACE,
+      aux_sym_path_token1,
+  [7740] = 2,
+    ACTIONS(934), 2,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym_NL_token1,
+    ACTIONS(932), 3,
+      aux_sym_WORD_CHAR_token1,
+      aux_sym_WS_token1,
+      anon_sym_LBRACE_LBRACE,
+  [7750] = 2,
+    ACTIONS(934), 2,
+      aux_sym_PUNCTUATION_token1,
+      aux_sym_pre_request_script_token1,
+    ACTIONS(932), 3,
       aux_sym_WORD_CHAR_token1,
       anon_sym_LBRACE_LBRACE,
       aux_sym_path_token1,
   [7760] = 2,
-    ACTIONS(908), 2,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym_NL_token1,
-    ACTIONS(906), 3,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_WS_token1,
-      anon_sym_LBRACE_LBRACE,
-  [7770] = 2,
-    ACTIONS(918), 2,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym_NL_token1,
-    ACTIONS(916), 3,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_WS_token1,
-      anon_sym_LBRACE_LBRACE,
-  [7780] = 2,
-    ACTIONS(918), 2,
+    ACTIONS(926), 2,
       aux_sym_PUNCTUATION_token1,
       aux_sym_pre_request_script_token1,
-    ACTIONS(916), 3,
+    ACTIONS(924), 3,
       aux_sym_WORD_CHAR_token1,
       anon_sym_LBRACE_LBRACE,
       aux_sym_path_token1,
-  [7790] = 2,
-    ACTIONS(912), 2,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym_NL_token1,
-    ACTIONS(910), 3,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_WS_token1,
-      anon_sym_LBRACE_LBRACE,
-  [7800] = 4,
+  [7770] = 4,
     ACTIONS(17), 1,
       anon_sym_LBRACE_LBRACE,
-    ACTIONS(924), 1,
+    ACTIONS(940), 1,
       aux_sym_WORD_CHAR_token1,
-    ACTIONS(926), 1,
+    ACTIONS(942), 1,
       aux_sym_PUNCTUATION_token1,
-    STATE(171), 2,
+    STATE(180), 2,
       aux_sym__target_url_line,
       sym_variable,
-  [7814] = 2,
-    ACTIONS(922), 2,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym_NL_token1,
-    ACTIONS(920), 3,
-      aux_sym_WORD_CHAR_token1,
-      aux_sym_WS_token1,
-      anon_sym_LBRACE_LBRACE,
-  [7824] = 2,
-    ACTIONS(908), 2,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym_pre_request_script_token1,
-    ACTIONS(906), 3,
-      aux_sym_WORD_CHAR_token1,
-      anon_sym_LBRACE_LBRACE,
-      aux_sym_path_token1,
-  [7834] = 2,
-    ACTIONS(922), 2,
-      aux_sym_PUNCTUATION_token1,
-      aux_sym_pre_request_script_token1,
-    ACTIONS(920), 3,
-      aux_sym_WORD_CHAR_token1,
-      anon_sym_LBRACE_LBRACE,
-      aux_sym_path_token1,
-  [7844] = 3,
-    ACTIONS(928), 1,
-      aux_sym_WS_token1,
-    ACTIONS(930), 1,
-      aux_sym_NL_token1,
-    STATE(201), 1,
-      aux_sym_target_url_repeat1,
-  [7854] = 2,
-    ACTIONS(935), 1,
-      aux_sym_NL_token1,
-    ACTIONS(933), 2,
-      aux_sym_WS_token1,
-      anon_sym_EQ,
-  [7862] = 3,
-    ACTIONS(937), 1,
-      aux_sym_WS_token1,
-    ACTIONS(939), 1,
-      aux_sym_NL_token1,
-    STATE(201), 1,
-      aux_sym_target_url_repeat1,
-  [7872] = 2,
+  [7784] = 3,
     ACTIONS(944), 1,
-      aux_sym_NL_token1,
-    ACTIONS(942), 2,
-      aux_sym_WS_token1,
-      anon_sym_EQ,
-  [7880] = 3,
+      aux_sym_LINE_TAIL_token1,
     ACTIONS(946), 1,
-      aux_sym_LINE_TAIL_token1,
-    ACTIONS(949), 1,
-      anon_sym_PERCENT_RBRACE,
-    STATE(203), 1,
-      aux_sym_script_repeat1,
-  [7890] = 2,
-    ACTIONS(953), 1,
-      aux_sym_NL_token1,
-    ACTIONS(951), 2,
-      aux_sym_WS_token1,
-      anon_sym_EQ,
-  [7898] = 2,
-    ACTIONS(957), 1,
-      aux_sym_NL_token1,
-    ACTIONS(955), 2,
-      aux_sym_WS_token1,
-      anon_sym_EQ,
-  [7906] = 3,
-    ACTIONS(959), 1,
-      aux_sym_LINE_TAIL_token1,
-    ACTIONS(961), 1,
       anon_sym_PERCENT_RBRACE,
     STATE(207), 1,
       aux_sym_script_repeat1,
-  [7916] = 3,
-    ACTIONS(963), 1,
-      aux_sym_LINE_TAIL_token1,
-    ACTIONS(965), 1,
-      anon_sym_PERCENT_RBRACE,
-    STATE(203), 1,
-      aux_sym_script_repeat1,
-  [7926] = 1,
-    ACTIONS(967), 2,
-      aux_sym_WS_token1,
+  [7794] = 2,
+    ACTIONS(950), 1,
       aux_sym_NL_token1,
-  [7931] = 2,
-    ACTIONS(969), 1,
+    ACTIONS(948), 2,
       aux_sym_WS_token1,
-    ACTIONS(971), 1,
-      anon_sym_RBRACE_RBRACE,
-  [7938] = 2,
-    ACTIONS(973), 1,
+      anon_sym_EQ,
+  [7802] = 2,
+    ACTIONS(954), 1,
+      aux_sym_NL_token1,
+    ACTIONS(952), 2,
       aux_sym_WS_token1,
-    ACTIONS(975), 1,
-      anon_sym_RBRACE_RBRACE,
-  [7945] = 2,
-    ACTIONS(977), 1,
+      anon_sym_EQ,
+  [7810] = 2,
+    ACTIONS(958), 1,
+      aux_sym_NL_token1,
+    ACTIONS(956), 2,
       aux_sym_WS_token1,
-    ACTIONS(979), 1,
-      anon_sym_RBRACE_RBRACE,
-  [7952] = 2,
-    ACTIONS(981), 1,
+      anon_sym_EQ,
+  [7818] = 2,
+    ACTIONS(962), 1,
+      aux_sym_NL_token1,
+    ACTIONS(960), 2,
+      aux_sym_WS_token1,
+      anon_sym_EQ,
+  [7826] = 3,
+    ACTIONS(964), 1,
       aux_sym_LINE_TAIL_token1,
-    ACTIONS(983), 1,
-      anon_sym_AT,
-  [7959] = 2,
-    ACTIONS(985), 1,
+    ACTIONS(966), 1,
+      anon_sym_PERCENT_RBRACE,
+    STATE(209), 1,
+      aux_sym_script_repeat1,
+  [7836] = 3,
+    ACTIONS(968), 1,
       aux_sym_WS_token1,
+    ACTIONS(970), 1,
+      aux_sym_NL_token1,
+    STATE(210), 1,
+      aux_sym_target_url_repeat1,
+  [7846] = 3,
+    ACTIONS(973), 1,
+      aux_sym_LINE_TAIL_token1,
+    ACTIONS(976), 1,
+      anon_sym_PERCENT_RBRACE,
+    STATE(209), 1,
+      aux_sym_script_repeat1,
+  [7856] = 3,
+    ACTIONS(978), 1,
+      aux_sym_WS_token1,
+    ACTIONS(980), 1,
+      aux_sym_NL_token1,
+    STATE(210), 1,
+      aux_sym_target_url_repeat1,
+  [7866] = 2,
+    ACTIONS(983), 1,
+      aux_sym_WS_token1,
+    ACTIONS(985), 1,
+      sym_identifier,
+  [7873] = 2,
     ACTIONS(987), 1,
-      anon_sym_RBRACE_RBRACE,
-  [7966] = 2,
+      aux_sym_xml_body_token2,
+    STATE(84), 1,
+      aux_sym_xml_body_repeat1,
+  [7880] = 2,
     ACTIONS(989), 1,
       aux_sym_WS_token1,
     ACTIONS(991), 1,
-      anon_sym_EQ,
-  [7973] = 2,
-    ACTIONS(993), 1,
-      aux_sym_NL_token1,
-    ACTIONS(995), 1,
-      sym_status_text,
-  [7980] = 2,
-    ACTIONS(997), 1,
-      aux_sym_WS_token1,
-    ACTIONS(999), 1,
       sym_identifier,
-  [7987] = 2,
+  [7887] = 2,
+    ACTIONS(993), 1,
+      aux_sym_WS_token1,
+    ACTIONS(995), 1,
+      anon_sym_AT2,
+  [7894] = 2,
+    ACTIONS(997), 1,
+      aux_sym_xml_body_token2,
+    STATE(71), 1,
+      aux_sym_xml_body_repeat1,
+  [7901] = 2,
+    ACTIONS(999), 1,
+      aux_sym_WS_token1,
     ACTIONS(1001), 1,
-      aux_sym_WS_token1,
+      anon_sym_COLON,
+  [7908] = 2,
     ACTIONS(1003), 1,
-      anon_sym_RBRACE_RBRACE,
-  [7994] = 2,
+      aux_sym_WS_token1,
     ACTIONS(1005), 1,
-      aux_sym_WS_token1,
+      anon_sym_EQ,
+  [7915] = 2,
     ACTIONS(1007), 1,
-      anon_sym_RBRACE_RBRACE,
-  [8001] = 1,
-    ACTIONS(1009), 2,
-      aux_sym_WS_token1,
-      aux_sym_NL_token1,
-  [8006] = 2,
+      aux_sym_LINE_TAIL_token1,
+    ACTIONS(1009), 1,
+      anon_sym_AT,
+  [7922] = 2,
     ACTIONS(1011), 1,
       aux_sym_WS_token1,
     ACTIONS(1013), 1,
-      aux_sym_NL_token1,
-  [8013] = 2,
+      anon_sym_RBRACE_RBRACE,
+  [7929] = 2,
     ACTIONS(1015), 1,
-      aux_sym_LINE_TAIL_token1,
+      aux_sym_WS_token1,
     ACTIONS(1017), 1,
-      anon_sym_AT,
-  [8020] = 2,
-    ACTIONS(1019), 1,
-      anon_sym_AT,
-    ACTIONS(1021), 1,
-      sym__not_comment,
-  [8027] = 2,
-    ACTIONS(1023), 1,
-      aux_sym_WS_token1,
-    ACTIONS(1025), 1,
-      anon_sym_COLON,
-  [8034] = 2,
-    ACTIONS(1027), 1,
-      aux_sym_WS_token1,
-    ACTIONS(1029), 1,
-      anon_sym_AT2,
-  [8041] = 1,
-    ACTIONS(1031), 2,
+      anon_sym_RBRACE_RBRACE,
+  [7936] = 1,
+    ACTIONS(1019), 2,
       aux_sym_WS_token1,
       aux_sym_NL_token1,
-  [8046] = 2,
+  [7941] = 2,
+    ACTIONS(1021), 1,
+      aux_sym_NL_token1,
+    ACTIONS(1023), 1,
+      sym_status_text,
+  [7948] = 2,
+    ACTIONS(1025), 1,
+      aux_sym_WS_token1,
+    ACTIONS(1027), 1,
+      anon_sym_RBRACE_RBRACE,
+  [7955] = 2,
+    ACTIONS(1029), 1,
+      anon_sym_AT,
+    ACTIONS(1031), 1,
+      sym__not_comment,
+  [7962] = 2,
     ACTIONS(1033), 1,
       aux_sym_WS_token1,
     ACTIONS(1035), 1,
       sym_identifier,
-  [8053] = 2,
-    ACTIONS(1037), 1,
+  [7969] = 1,
+    ACTIONS(1037), 2,
       aux_sym_WS_token1,
-    ACTIONS(1039), 1,
-      sym_identifier,
-  [8060] = 2,
-    ACTIONS(1041), 1,
-      aux_sym_WS_token1,
-    ACTIONS(1043), 1,
       aux_sym_NL_token1,
-  [8067] = 2,
-    ACTIONS(1045), 1,
+  [7974] = 2,
+    ACTIONS(1039), 1,
+      aux_sym_WS_token1,
+    ACTIONS(1041), 1,
+      aux_sym_NL_token1,
+  [7981] = 2,
+    ACTIONS(1043), 1,
       aux_sym_LINE_TAIL_token1,
-    ACTIONS(1047), 1,
+    ACTIONS(1045), 1,
       anon_sym_AT,
-  [8074] = 2,
+  [7988] = 2,
+    ACTIONS(1047), 1,
+      aux_sym_WS_token1,
     ACTIONS(1049), 1,
-      aux_sym_xml_body_token2,
-    STATE(73), 1,
-      aux_sym_xml_body_repeat1,
-  [8081] = 2,
-    ACTIONS(1051), 1,
-      aux_sym_xml_body_token2,
-    STATE(74), 1,
-      aux_sym_xml_body_repeat1,
-  [8088] = 2,
+      anon_sym_RBRACE_RBRACE,
+  [7995] = 1,
+    ACTIONS(1051), 2,
+      aux_sym_WS_token1,
+      aux_sym_NL_token1,
+  [8000] = 2,
     ACTIONS(1053), 1,
-      aux_sym_xml_body_token2,
-    STATE(75), 1,
-      aux_sym_xml_body_repeat1,
-  [8095] = 1,
+      aux_sym_WS_token1,
     ACTIONS(1055), 1,
       aux_sym_NL_token1,
-  [8099] = 1,
+  [8007] = 2,
     ACTIONS(1057), 1,
-      anon_sym_RBRACE_RBRACE,
-  [8103] = 1,
+      aux_sym_WS_token1,
     ACTIONS(1059), 1,
-      aux_sym_WS_token1,
-  [8107] = 1,
+      anon_sym_RBRACE_RBRACE,
+  [8014] = 2,
     ACTIONS(1061), 1,
-      ts_builtin_sym_end,
-  [8111] = 1,
+      aux_sym_WS_token1,
     ACTIONS(1063), 1,
-      aux_sym_NL_token1,
-  [8115] = 1,
+      anon_sym_RBRACE_RBRACE,
+  [8021] = 2,
     ACTIONS(1065), 1,
-      anon_sym_COLON,
-  [8119] = 1,
+      aux_sym_LINE_TAIL_token1,
     ACTIONS(1067), 1,
-      sym_identifier,
-  [8123] = 1,
+      anon_sym_AT,
+  [8028] = 2,
     ACTIONS(1069), 1,
-      aux_sym_WS_token1,
-  [8127] = 1,
+      aux_sym_xml_body_token2,
+    STATE(85), 1,
+      aux_sym_xml_body_repeat1,
+  [8035] = 1,
     ACTIONS(1071), 1,
-      aux_sym_WS_token1,
-  [8131] = 1,
+      aux_sym_NL_token1,
+  [8039] = 1,
     ACTIONS(1073), 1,
-      sym_status_code,
-  [8135] = 1,
+      anon_sym_RBRACE_RBRACE,
+  [8043] = 1,
     ACTIONS(1075), 1,
-      sym_http_version,
-  [8139] = 1,
+      aux_sym_NL_token1,
+  [8047] = 1,
     ACTIONS(1077), 1,
       aux_sym_NL_token1,
-  [8143] = 1,
+  [8051] = 1,
     ACTIONS(1079), 1,
-      aux_sym_NL_token1,
-  [8147] = 1,
+      sym_identifier,
+  [8055] = 1,
     ACTIONS(1081), 1,
-      anon_sym_EQ,
-  [8151] = 1,
+      aux_sym_NL_token1,
+  [8059] = 1,
     ACTIONS(1083), 1,
-      aux_sym_NL_token1,
-  [8155] = 1,
+      sym_http_version,
+  [8063] = 1,
     ACTIONS(1085), 1,
-      aux_sym_NL_token1,
-  [8159] = 1,
+      sym_identifier,
+  [8067] = 1,
     ACTIONS(1087), 1,
-      aux_sym_pre_request_script_token1,
-  [8163] = 1,
+      aux_sym_NL_token1,
+  [8071] = 1,
     ACTIONS(1089), 1,
-      aux_sym_pre_request_script_token1,
-  [8167] = 1,
+      aux_sym_NL_token1,
+  [8075] = 1,
     ACTIONS(1091), 1,
-      aux_sym_NL_token1,
-  [8171] = 1,
+      ts_builtin_sym_end,
+  [8079] = 1,
     ACTIONS(1093), 1,
-      aux_sym_multipart_form_data_token1,
-  [8175] = 1,
-    ACTIONS(1021), 1,
-      sym__not_comment,
-  [8179] = 1,
+      sym_identifier,
+  [8083] = 1,
     ACTIONS(1095), 1,
-      aux_sym_NL_token1,
-  [8183] = 1,
+      aux_sym_WS_token1,
+  [8087] = 1,
     ACTIONS(1097), 1,
       aux_sym_NL_token1,
-  [8187] = 1,
+  [8091] = 1,
     ACTIONS(1099), 1,
-      aux_sym_WS_token1,
-  [8191] = 1,
+      aux_sym_multipart_form_data_token1,
+  [8095] = 1,
     ACTIONS(1101), 1,
-      sym_identifier,
-  [8195] = 1,
+      aux_sym_NL_token1,
+  [8099] = 1,
     ACTIONS(1103), 1,
-      aux_sym_NL_token1,
-  [8199] = 1,
+      aux_sym_pre_request_script_token1,
+  [8103] = 1,
     ACTIONS(1105), 1,
-      aux_sym_pre_request_script_token1,
-  [8203] = 1,
+      anon_sym_EQ,
+  [8107] = 1,
     ACTIONS(1107), 1,
-      aux_sym_pre_request_script_token1,
-  [8207] = 1,
+      aux_sym_NL_token1,
+  [8111] = 1,
     ACTIONS(1109), 1,
-      anon_sym_RBRACE_RBRACE,
-  [8211] = 1,
-    ACTIONS(1111), 1,
-      sym_identifier,
-  [8215] = 1,
-    ACTIONS(1113), 1,
-      aux_sym__blank_line_token1,
-  [8219] = 1,
-    ACTIONS(1115), 1,
-      aux_sym_NL_token1,
-  [8223] = 1,
-    ACTIONS(1117), 1,
-      aux_sym_NL_token1,
-  [8227] = 1,
-    ACTIONS(1119), 1,
       aux_sym_WS_token1,
-  [8231] = 1,
+  [8115] = 1,
+    ACTIONS(1111), 1,
+      aux_sym_WS_token1,
+  [8119] = 1,
+    ACTIONS(1113), 1,
+      sym_http_version,
+  [8123] = 1,
+    ACTIONS(1115), 1,
+      aux_sym_WS_token1,
+  [8127] = 1,
+    ACTIONS(1117), 1,
+      aux_sym_pre_request_script_token1,
+  [8131] = 1,
+    ACTIONS(1119), 1,
+      anon_sym_RBRACE_RBRACE,
+  [8135] = 1,
     ACTIONS(1121), 1,
-      anon_sym_RBRACE_RBRACE,
-  [8235] = 1,
+      aux_sym_NL_token1,
+  [8139] = 1,
     ACTIONS(1123), 1,
-      sym_identifier,
-  [8239] = 1,
+      aux_sym_NL_token1,
+  [8143] = 1,
     ACTIONS(1125), 1,
-      anon_sym_RBRACE_RBRACE,
-  [8243] = 1,
+      aux_sym_NL_token1,
+  [8147] = 1,
     ACTIONS(1127), 1,
-      aux_sym_NL_token1,
-  [8247] = 1,
+      aux_sym_WS_token1,
+  [8151] = 1,
     ACTIONS(1129), 1,
-      aux_sym_NL_token1,
-  [8251] = 1,
+      aux_sym_pre_request_script_token1,
+  [8155] = 1,
     ACTIONS(1131), 1,
-      aux_sym_NL_token1,
-  [8255] = 1,
-    ACTIONS(1133), 1,
-      aux_sym_NL_token1,
-  [8259] = 1,
-    ACTIONS(1135), 1,
       aux_sym__blank_line_token1,
-  [8263] = 1,
+  [8159] = 1,
+    ACTIONS(1133), 1,
+      aux_sym_WS_token1,
+  [8163] = 1,
+    ACTIONS(1135), 1,
+      sym_status_code,
+  [8167] = 1,
     ACTIONS(1137), 1,
-      anon_sym_RBRACE_RBRACE,
-  [8267] = 1,
+      anon_sym_COLON,
+  [8171] = 1,
     ACTIONS(1139), 1,
-      aux_sym_NL_token1,
-  [8271] = 1,
-    ACTIONS(1141), 1,
       anon_sym_RBRACE_RBRACE,
-  [8275] = 1,
+  [8175] = 1,
+    ACTIONS(1141), 1,
+      aux_sym__blank_line_token1,
+  [8179] = 1,
     ACTIONS(1143), 1,
-      aux_sym_NL_token1,
-  [8279] = 1,
+      anon_sym_RBRACE_RBRACE,
+  [8183] = 1,
     ACTIONS(1145), 1,
       aux_sym_NL_token1,
-  [8283] = 1,
+  [8187] = 1,
     ACTIONS(1147), 1,
-      sym_identifier,
-  [8287] = 1,
+      aux_sym_NL_token1,
+  [8191] = 1,
     ACTIONS(1149), 1,
       sym_identifier,
-  [8291] = 1,
+  [8195] = 1,
     ACTIONS(1151), 1,
-      sym_identifier,
-  [8295] = 1,
+      sym__not_comment,
+  [8199] = 1,
     ACTIONS(1153), 1,
-      aux_sym_NL_token1,
-  [8299] = 1,
+      sym_identifier,
+  [8203] = 1,
     ACTIONS(1155), 1,
-      sym_http_version,
-  [8303] = 1,
+      anon_sym_RBRACE_RBRACE,
+  [8207] = 1,
     ACTIONS(1157), 1,
-      aux_sym_WS_token1,
-  [8307] = 1,
+      aux_sym_NL_token1,
+  [8211] = 1,
     ACTIONS(1159), 1,
-      sym_identifier,
-  [8311] = 1,
+      anon_sym_RBRACE_RBRACE,
+  [8215] = 1,
     ACTIONS(1161), 1,
-      sym_identifier,
-  [8315] = 1,
+      aux_sym_NL_token1,
+  [8219] = 1,
     ACTIONS(1163), 1,
       aux_sym_NL_token1,
-  [8319] = 1,
+  [8223] = 1,
     ACTIONS(1165), 1,
       aux_sym_WS_token1,
+  [8227] = 1,
+    ACTIONS(1167), 1,
+      sym_identifier,
+  [8231] = 1,
+    ACTIONS(1169), 1,
+      sym_identifier,
+  [8235] = 1,
+    ACTIONS(1171), 1,
+      aux_sym_NL_token1,
+  [8239] = 1,
+    ACTIONS(1173), 1,
+      aux_sym_NL_token1,
+  [8243] = 1,
+    ACTIONS(1175), 1,
+      aux_sym_pre_request_script_token1,
+  [8247] = 1,
+    ACTIONS(1177), 1,
+      sym_identifier,
+  [8251] = 1,
+    ACTIONS(1179), 1,
+      sym_identifier,
+  [8255] = 1,
+    ACTIONS(1181), 1,
+      aux_sym_NL_token1,
+  [8259] = 1,
+    ACTIONS(1183), 1,
+      aux_sym_NL_token1,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(2)] = 0,
-  [SMALL_STATE(3)] = 78,
-  [SMALL_STATE(4)] = 156,
-  [SMALL_STATE(5)] = 234,
-  [SMALL_STATE(6)] = 312,
-  [SMALL_STATE(7)] = 390,
-  [SMALL_STATE(8)] = 468,
-  [SMALL_STATE(9)] = 546,
-  [SMALL_STATE(10)] = 624,
-  [SMALL_STATE(11)] = 702,
-  [SMALL_STATE(12)] = 780,
-  [SMALL_STATE(13)] = 858,
-  [SMALL_STATE(14)] = 936,
-  [SMALL_STATE(15)] = 1014,
-  [SMALL_STATE(16)] = 1092,
-  [SMALL_STATE(17)] = 1170,
-  [SMALL_STATE(18)] = 1248,
-  [SMALL_STATE(19)] = 1326,
-  [SMALL_STATE(20)] = 1404,
-  [SMALL_STATE(21)] = 1482,
-  [SMALL_STATE(22)] = 1560,
-  [SMALL_STATE(23)] = 1638,
-  [SMALL_STATE(24)] = 1716,
-  [SMALL_STATE(25)] = 1794,
-  [SMALL_STATE(26)] = 1872,
-  [SMALL_STATE(27)] = 1950,
-  [SMALL_STATE(28)] = 2028,
-  [SMALL_STATE(29)] = 2106,
-  [SMALL_STATE(30)] = 2184,
-  [SMALL_STATE(31)] = 2254,
-  [SMALL_STATE(32)] = 2324,
-  [SMALL_STATE(33)] = 2394,
-  [SMALL_STATE(34)] = 2464,
-  [SMALL_STATE(35)] = 2534,
-  [SMALL_STATE(36)] = 2604,
-  [SMALL_STATE(37)] = 2674,
-  [SMALL_STATE(38)] = 2744,
-  [SMALL_STATE(39)] = 2814,
-  [SMALL_STATE(40)] = 2884,
-  [SMALL_STATE(41)] = 2954,
-  [SMALL_STATE(42)] = 3024,
-  [SMALL_STATE(43)] = 3094,
-  [SMALL_STATE(44)] = 3164,
-  [SMALL_STATE(45)] = 3234,
-  [SMALL_STATE(46)] = 3304,
-  [SMALL_STATE(47)] = 3374,
-  [SMALL_STATE(48)] = 3444,
-  [SMALL_STATE(49)] = 3514,
-  [SMALL_STATE(50)] = 3584,
-  [SMALL_STATE(51)] = 3654,
-  [SMALL_STATE(52)] = 3724,
-  [SMALL_STATE(53)] = 3794,
-  [SMALL_STATE(54)] = 3864,
-  [SMALL_STATE(55)] = 3934,
-  [SMALL_STATE(56)] = 4004,
-  [SMALL_STATE(57)] = 4074,
-  [SMALL_STATE(58)] = 4144,
-  [SMALL_STATE(59)] = 4214,
-  [SMALL_STATE(60)] = 4260,
-  [SMALL_STATE(61)] = 4324,
-  [SMALL_STATE(62)] = 4370,
-  [SMALL_STATE(63)] = 4416,
-  [SMALL_STATE(64)] = 4480,
-  [SMALL_STATE(65)] = 4531,
-  [SMALL_STATE(66)] = 4564,
-  [SMALL_STATE(67)] = 4601,
-  [SMALL_STATE(68)] = 4638,
-  [SMALL_STATE(69)] = 4689,
-  [SMALL_STATE(70)] = 4740,
-  [SMALL_STATE(71)] = 4771,
-  [SMALL_STATE(72)] = 4826,
-  [SMALL_STATE(73)] = 4877,
-  [SMALL_STATE(74)] = 4908,
-  [SMALL_STATE(75)] = 4939,
-  [SMALL_STATE(76)] = 4970,
-  [SMALL_STATE(77)] = 5021,
-  [SMALL_STATE(78)] = 5072,
-  [SMALL_STATE(79)] = 5123,
-  [SMALL_STATE(80)] = 5174,
-  [SMALL_STATE(81)] = 5229,
-  [SMALL_STATE(82)] = 5255,
-  [SMALL_STATE(83)] = 5285,
-  [SMALL_STATE(84)] = 5311,
-  [SMALL_STATE(85)] = 5337,
-  [SMALL_STATE(86)] = 5363,
-  [SMALL_STATE(87)] = 5389,
-  [SMALL_STATE(88)] = 5414,
-  [SMALL_STATE(89)] = 5439,
-  [SMALL_STATE(90)] = 5464,
-  [SMALL_STATE(91)] = 5489,
-  [SMALL_STATE(92)] = 5514,
-  [SMALL_STATE(93)] = 5539,
-  [SMALL_STATE(94)] = 5564,
-  [SMALL_STATE(95)] = 5589,
-  [SMALL_STATE(96)] = 5614,
-  [SMALL_STATE(97)] = 5639,
-  [SMALL_STATE(98)] = 5664,
-  [SMALL_STATE(99)] = 5698,
-  [SMALL_STATE(100)] = 5732,
-  [SMALL_STATE(101)] = 5766,
-  [SMALL_STATE(102)] = 5800,
-  [SMALL_STATE(103)] = 5834,
-  [SMALL_STATE(104)] = 5868,
-  [SMALL_STATE(105)] = 5902,
-  [SMALL_STATE(106)] = 5936,
-  [SMALL_STATE(107)] = 5970,
-  [SMALL_STATE(108)] = 6004,
-  [SMALL_STATE(109)] = 6038,
-  [SMALL_STATE(110)] = 6072,
-  [SMALL_STATE(111)] = 6106,
-  [SMALL_STATE(112)] = 6140,
-  [SMALL_STATE(113)] = 6174,
-  [SMALL_STATE(114)] = 6208,
-  [SMALL_STATE(115)] = 6242,
-  [SMALL_STATE(116)] = 6276,
-  [SMALL_STATE(117)] = 6310,
-  [SMALL_STATE(118)] = 6344,
-  [SMALL_STATE(119)] = 6378,
-  [SMALL_STATE(120)] = 6412,
-  [SMALL_STATE(121)] = 6446,
-  [SMALL_STATE(122)] = 6476,
-  [SMALL_STATE(123)] = 6510,
-  [SMALL_STATE(124)] = 6536,
-  [SMALL_STATE(125)] = 6555,
-  [SMALL_STATE(126)] = 6574,
-  [SMALL_STATE(127)] = 6593,
-  [SMALL_STATE(128)] = 6612,
-  [SMALL_STATE(129)] = 6630,
-  [SMALL_STATE(130)] = 6648,
-  [SMALL_STATE(131)] = 6666,
-  [SMALL_STATE(132)] = 6684,
-  [SMALL_STATE(133)] = 6702,
-  [SMALL_STATE(134)] = 6720,
-  [SMALL_STATE(135)] = 6738,
-  [SMALL_STATE(136)] = 6756,
-  [SMALL_STATE(137)] = 6774,
-  [SMALL_STATE(138)] = 6791,
-  [SMALL_STATE(139)] = 6808,
-  [SMALL_STATE(140)] = 6825,
-  [SMALL_STATE(141)] = 6842,
-  [SMALL_STATE(142)] = 6859,
-  [SMALL_STATE(143)] = 6876,
-  [SMALL_STATE(144)] = 6893,
-  [SMALL_STATE(145)] = 6910,
-  [SMALL_STATE(146)] = 6927,
-  [SMALL_STATE(147)] = 6944,
-  [SMALL_STATE(148)] = 6961,
-  [SMALL_STATE(149)] = 6978,
-  [SMALL_STATE(150)] = 6995,
-  [SMALL_STATE(151)] = 7012,
-  [SMALL_STATE(152)] = 7029,
-  [SMALL_STATE(153)] = 7046,
-  [SMALL_STATE(154)] = 7063,
-  [SMALL_STATE(155)] = 7087,
-  [SMALL_STATE(156)] = 7111,
-  [SMALL_STATE(157)] = 7133,
-  [SMALL_STATE(158)] = 7157,
-  [SMALL_STATE(159)] = 7179,
-  [SMALL_STATE(160)] = 7200,
-  [SMALL_STATE(161)] = 7221,
-  [SMALL_STATE(162)] = 7242,
-  [SMALL_STATE(163)] = 7265,
-  [SMALL_STATE(164)] = 7286,
-  [SMALL_STATE(165)] = 7307,
-  [SMALL_STATE(166)] = 7328,
-  [SMALL_STATE(167)] = 7349,
-  [SMALL_STATE(168)] = 7370,
-  [SMALL_STATE(169)] = 7391,
-  [SMALL_STATE(170)] = 7412,
-  [SMALL_STATE(171)] = 7433,
-  [SMALL_STATE(172)] = 7453,
-  [SMALL_STATE(173)] = 7473,
-  [SMALL_STATE(174)] = 7491,
-  [SMALL_STATE(175)] = 7509,
-  [SMALL_STATE(176)] = 7527,
-  [SMALL_STATE(177)] = 7545,
-  [SMALL_STATE(178)] = 7563,
-  [SMALL_STATE(179)] = 7581,
-  [SMALL_STATE(180)] = 7599,
-  [SMALL_STATE(181)] = 7617,
-  [SMALL_STATE(182)] = 7635,
-  [SMALL_STATE(183)] = 7653,
-  [SMALL_STATE(184)] = 7671,
-  [SMALL_STATE(185)] = 7689,
-  [SMALL_STATE(186)] = 7700,
-  [SMALL_STATE(187)] = 7711,
-  [SMALL_STATE(188)] = 7728,
-  [SMALL_STATE(189)] = 7739,
-  [SMALL_STATE(190)] = 7750,
-  [SMALL_STATE(191)] = 7760,
-  [SMALL_STATE(192)] = 7770,
-  [SMALL_STATE(193)] = 7780,
-  [SMALL_STATE(194)] = 7790,
-  [SMALL_STATE(195)] = 7800,
-  [SMALL_STATE(196)] = 7814,
-  [SMALL_STATE(197)] = 7824,
-  [SMALL_STATE(198)] = 7834,
-  [SMALL_STATE(199)] = 7844,
-  [SMALL_STATE(200)] = 7854,
-  [SMALL_STATE(201)] = 7862,
-  [SMALL_STATE(202)] = 7872,
-  [SMALL_STATE(203)] = 7880,
-  [SMALL_STATE(204)] = 7890,
-  [SMALL_STATE(205)] = 7898,
-  [SMALL_STATE(206)] = 7906,
-  [SMALL_STATE(207)] = 7916,
-  [SMALL_STATE(208)] = 7926,
-  [SMALL_STATE(209)] = 7931,
-  [SMALL_STATE(210)] = 7938,
-  [SMALL_STATE(211)] = 7945,
-  [SMALL_STATE(212)] = 7952,
-  [SMALL_STATE(213)] = 7959,
-  [SMALL_STATE(214)] = 7966,
-  [SMALL_STATE(215)] = 7973,
-  [SMALL_STATE(216)] = 7980,
-  [SMALL_STATE(217)] = 7987,
-  [SMALL_STATE(218)] = 7994,
-  [SMALL_STATE(219)] = 8001,
-  [SMALL_STATE(220)] = 8006,
-  [SMALL_STATE(221)] = 8013,
-  [SMALL_STATE(222)] = 8020,
-  [SMALL_STATE(223)] = 8027,
-  [SMALL_STATE(224)] = 8034,
-  [SMALL_STATE(225)] = 8041,
-  [SMALL_STATE(226)] = 8046,
-  [SMALL_STATE(227)] = 8053,
-  [SMALL_STATE(228)] = 8060,
-  [SMALL_STATE(229)] = 8067,
-  [SMALL_STATE(230)] = 8074,
-  [SMALL_STATE(231)] = 8081,
-  [SMALL_STATE(232)] = 8088,
-  [SMALL_STATE(233)] = 8095,
-  [SMALL_STATE(234)] = 8099,
-  [SMALL_STATE(235)] = 8103,
-  [SMALL_STATE(236)] = 8107,
-  [SMALL_STATE(237)] = 8111,
-  [SMALL_STATE(238)] = 8115,
-  [SMALL_STATE(239)] = 8119,
-  [SMALL_STATE(240)] = 8123,
-  [SMALL_STATE(241)] = 8127,
-  [SMALL_STATE(242)] = 8131,
-  [SMALL_STATE(243)] = 8135,
-  [SMALL_STATE(244)] = 8139,
-  [SMALL_STATE(245)] = 8143,
-  [SMALL_STATE(246)] = 8147,
-  [SMALL_STATE(247)] = 8151,
-  [SMALL_STATE(248)] = 8155,
-  [SMALL_STATE(249)] = 8159,
-  [SMALL_STATE(250)] = 8163,
-  [SMALL_STATE(251)] = 8167,
-  [SMALL_STATE(252)] = 8171,
-  [SMALL_STATE(253)] = 8175,
-  [SMALL_STATE(254)] = 8179,
-  [SMALL_STATE(255)] = 8183,
-  [SMALL_STATE(256)] = 8187,
-  [SMALL_STATE(257)] = 8191,
-  [SMALL_STATE(258)] = 8195,
-  [SMALL_STATE(259)] = 8199,
-  [SMALL_STATE(260)] = 8203,
-  [SMALL_STATE(261)] = 8207,
-  [SMALL_STATE(262)] = 8211,
-  [SMALL_STATE(263)] = 8215,
-  [SMALL_STATE(264)] = 8219,
-  [SMALL_STATE(265)] = 8223,
-  [SMALL_STATE(266)] = 8227,
-  [SMALL_STATE(267)] = 8231,
-  [SMALL_STATE(268)] = 8235,
-  [SMALL_STATE(269)] = 8239,
-  [SMALL_STATE(270)] = 8243,
-  [SMALL_STATE(271)] = 8247,
-  [SMALL_STATE(272)] = 8251,
-  [SMALL_STATE(273)] = 8255,
-  [SMALL_STATE(274)] = 8259,
-  [SMALL_STATE(275)] = 8263,
-  [SMALL_STATE(276)] = 8267,
-  [SMALL_STATE(277)] = 8271,
-  [SMALL_STATE(278)] = 8275,
-  [SMALL_STATE(279)] = 8279,
-  [SMALL_STATE(280)] = 8283,
-  [SMALL_STATE(281)] = 8287,
-  [SMALL_STATE(282)] = 8291,
-  [SMALL_STATE(283)] = 8295,
-  [SMALL_STATE(284)] = 8299,
-  [SMALL_STATE(285)] = 8303,
-  [SMALL_STATE(286)] = 8307,
-  [SMALL_STATE(287)] = 8311,
-  [SMALL_STATE(288)] = 8315,
-  [SMALL_STATE(289)] = 8319,
+  [SMALL_STATE(3)] = 75,
+  [SMALL_STATE(4)] = 150,
+  [SMALL_STATE(5)] = 225,
+  [SMALL_STATE(6)] = 300,
+  [SMALL_STATE(7)] = 375,
+  [SMALL_STATE(8)] = 450,
+  [SMALL_STATE(9)] = 525,
+  [SMALL_STATE(10)] = 600,
+  [SMALL_STATE(11)] = 675,
+  [SMALL_STATE(12)] = 750,
+  [SMALL_STATE(13)] = 825,
+  [SMALL_STATE(14)] = 900,
+  [SMALL_STATE(15)] = 975,
+  [SMALL_STATE(16)] = 1050,
+  [SMALL_STATE(17)] = 1125,
+  [SMALL_STATE(18)] = 1200,
+  [SMALL_STATE(19)] = 1275,
+  [SMALL_STATE(20)] = 1350,
+  [SMALL_STATE(21)] = 1425,
+  [SMALL_STATE(22)] = 1500,
+  [SMALL_STATE(23)] = 1575,
+  [SMALL_STATE(24)] = 1650,
+  [SMALL_STATE(25)] = 1725,
+  [SMALL_STATE(26)] = 1800,
+  [SMALL_STATE(27)] = 1875,
+  [SMALL_STATE(28)] = 1950,
+  [SMALL_STATE(29)] = 2025,
+  [SMALL_STATE(30)] = 2100,
+  [SMALL_STATE(31)] = 2167,
+  [SMALL_STATE(32)] = 2234,
+  [SMALL_STATE(33)] = 2301,
+  [SMALL_STATE(34)] = 2368,
+  [SMALL_STATE(35)] = 2435,
+  [SMALL_STATE(36)] = 2502,
+  [SMALL_STATE(37)] = 2569,
+  [SMALL_STATE(38)] = 2636,
+  [SMALL_STATE(39)] = 2703,
+  [SMALL_STATE(40)] = 2770,
+  [SMALL_STATE(41)] = 2837,
+  [SMALL_STATE(42)] = 2904,
+  [SMALL_STATE(43)] = 2971,
+  [SMALL_STATE(44)] = 3038,
+  [SMALL_STATE(45)] = 3105,
+  [SMALL_STATE(46)] = 3172,
+  [SMALL_STATE(47)] = 3239,
+  [SMALL_STATE(48)] = 3306,
+  [SMALL_STATE(49)] = 3373,
+  [SMALL_STATE(50)] = 3440,
+  [SMALL_STATE(51)] = 3507,
+  [SMALL_STATE(52)] = 3574,
+  [SMALL_STATE(53)] = 3641,
+  [SMALL_STATE(54)] = 3708,
+  [SMALL_STATE(55)] = 3775,
+  [SMALL_STATE(56)] = 3842,
+  [SMALL_STATE(57)] = 3909,
+  [SMALL_STATE(58)] = 3976,
+  [SMALL_STATE(59)] = 4043,
+  [SMALL_STATE(60)] = 4090,
+  [SMALL_STATE(61)] = 4137,
+  [SMALL_STATE(62)] = 4184,
+  [SMALL_STATE(63)] = 4248,
+  [SMALL_STATE(64)] = 4312,
+  [SMALL_STATE(65)] = 4350,
+  [SMALL_STATE(66)] = 4388,
+  [SMALL_STATE(67)] = 4426,
+  [SMALL_STATE(68)] = 4464,
+  [SMALL_STATE(69)] = 4491,
+  [SMALL_STATE(70)] = 4542,
+  [SMALL_STATE(71)] = 4593,
+  [SMALL_STATE(72)] = 4624,
+  [SMALL_STATE(73)] = 4679,
+  [SMALL_STATE(74)] = 4734,
+  [SMALL_STATE(75)] = 4761,
+  [SMALL_STATE(76)] = 4812,
+  [SMALL_STATE(77)] = 4863,
+  [SMALL_STATE(78)] = 4914,
+  [SMALL_STATE(79)] = 4947,
+  [SMALL_STATE(80)] = 4978,
+  [SMALL_STATE(81)] = 5029,
+  [SMALL_STATE(82)] = 5056,
+  [SMALL_STATE(83)] = 5083,
+  [SMALL_STATE(84)] = 5134,
+  [SMALL_STATE(85)] = 5165,
+  [SMALL_STATE(86)] = 5196,
+  [SMALL_STATE(87)] = 5223,
+  [SMALL_STATE(88)] = 5274,
+  [SMALL_STATE(89)] = 5304,
+  [SMALL_STATE(90)] = 5329,
+  [SMALL_STATE(91)] = 5354,
+  [SMALL_STATE(92)] = 5379,
+  [SMALL_STATE(93)] = 5404,
+  [SMALL_STATE(94)] = 5429,
+  [SMALL_STATE(95)] = 5454,
+  [SMALL_STATE(96)] = 5479,
+  [SMALL_STATE(97)] = 5504,
+  [SMALL_STATE(98)] = 5529,
+  [SMALL_STATE(99)] = 5554,
+  [SMALL_STATE(100)] = 5579,
+  [SMALL_STATE(101)] = 5604,
+  [SMALL_STATE(102)] = 5638,
+  [SMALL_STATE(103)] = 5672,
+  [SMALL_STATE(104)] = 5706,
+  [SMALL_STATE(105)] = 5740,
+  [SMALL_STATE(106)] = 5774,
+  [SMALL_STATE(107)] = 5808,
+  [SMALL_STATE(108)] = 5842,
+  [SMALL_STATE(109)] = 5876,
+  [SMALL_STATE(110)] = 5910,
+  [SMALL_STATE(111)] = 5944,
+  [SMALL_STATE(112)] = 5978,
+  [SMALL_STATE(113)] = 6012,
+  [SMALL_STATE(114)] = 6046,
+  [SMALL_STATE(115)] = 6080,
+  [SMALL_STATE(116)] = 6114,
+  [SMALL_STATE(117)] = 6148,
+  [SMALL_STATE(118)] = 6182,
+  [SMALL_STATE(119)] = 6216,
+  [SMALL_STATE(120)] = 6250,
+  [SMALL_STATE(121)] = 6284,
+  [SMALL_STATE(122)] = 6318,
+  [SMALL_STATE(123)] = 6352,
+  [SMALL_STATE(124)] = 6386,
+  [SMALL_STATE(125)] = 6416,
+  [SMALL_STATE(126)] = 6450,
+  [SMALL_STATE(127)] = 6476,
+  [SMALL_STATE(128)] = 6495,
+  [SMALL_STATE(129)] = 6514,
+  [SMALL_STATE(130)] = 6533,
+  [SMALL_STATE(131)] = 6552,
+  [SMALL_STATE(132)] = 6570,
+  [SMALL_STATE(133)] = 6588,
+  [SMALL_STATE(134)] = 6606,
+  [SMALL_STATE(135)] = 6624,
+  [SMALL_STATE(136)] = 6642,
+  [SMALL_STATE(137)] = 6660,
+  [SMALL_STATE(138)] = 6678,
+  [SMALL_STATE(139)] = 6696,
+  [SMALL_STATE(140)] = 6714,
+  [SMALL_STATE(141)] = 6731,
+  [SMALL_STATE(142)] = 6748,
+  [SMALL_STATE(143)] = 6765,
+  [SMALL_STATE(144)] = 6782,
+  [SMALL_STATE(145)] = 6799,
+  [SMALL_STATE(146)] = 6816,
+  [SMALL_STATE(147)] = 6833,
+  [SMALL_STATE(148)] = 6850,
+  [SMALL_STATE(149)] = 6867,
+  [SMALL_STATE(150)] = 6884,
+  [SMALL_STATE(151)] = 6901,
+  [SMALL_STATE(152)] = 6918,
+  [SMALL_STATE(153)] = 6935,
+  [SMALL_STATE(154)] = 6952,
+  [SMALL_STATE(155)] = 6969,
+  [SMALL_STATE(156)] = 6986,
+  [SMALL_STATE(157)] = 7003,
+  [SMALL_STATE(158)] = 7025,
+  [SMALL_STATE(159)] = 7049,
+  [SMALL_STATE(160)] = 7073,
+  [SMALL_STATE(161)] = 7095,
+  [SMALL_STATE(162)] = 7119,
+  [SMALL_STATE(163)] = 7140,
+  [SMALL_STATE(164)] = 7161,
+  [SMALL_STATE(165)] = 7182,
+  [SMALL_STATE(166)] = 7203,
+  [SMALL_STATE(167)] = 7224,
+  [SMALL_STATE(168)] = 7245,
+  [SMALL_STATE(169)] = 7268,
+  [SMALL_STATE(170)] = 7289,
+  [SMALL_STATE(171)] = 7310,
+  [SMALL_STATE(172)] = 7331,
+  [SMALL_STATE(173)] = 7352,
+  [SMALL_STATE(174)] = 7373,
+  [SMALL_STATE(175)] = 7391,
+  [SMALL_STATE(176)] = 7409,
+  [SMALL_STATE(177)] = 7427,
+  [SMALL_STATE(178)] = 7445,
+  [SMALL_STATE(179)] = 7463,
+  [SMALL_STATE(180)] = 7481,
+  [SMALL_STATE(181)] = 7501,
+  [SMALL_STATE(182)] = 7519,
+  [SMALL_STATE(183)] = 7537,
+  [SMALL_STATE(184)] = 7557,
+  [SMALL_STATE(185)] = 7575,
+  [SMALL_STATE(186)] = 7593,
+  [SMALL_STATE(187)] = 7611,
+  [SMALL_STATE(188)] = 7629,
+  [SMALL_STATE(189)] = 7646,
+  [SMALL_STATE(190)] = 7657,
+  [SMALL_STATE(191)] = 7668,
+  [SMALL_STATE(192)] = 7679,
+  [SMALL_STATE(193)] = 7690,
+  [SMALL_STATE(194)] = 7700,
+  [SMALL_STATE(195)] = 7710,
+  [SMALL_STATE(196)] = 7720,
+  [SMALL_STATE(197)] = 7730,
+  [SMALL_STATE(198)] = 7740,
+  [SMALL_STATE(199)] = 7750,
+  [SMALL_STATE(200)] = 7760,
+  [SMALL_STATE(201)] = 7770,
+  [SMALL_STATE(202)] = 7784,
+  [SMALL_STATE(203)] = 7794,
+  [SMALL_STATE(204)] = 7802,
+  [SMALL_STATE(205)] = 7810,
+  [SMALL_STATE(206)] = 7818,
+  [SMALL_STATE(207)] = 7826,
+  [SMALL_STATE(208)] = 7836,
+  [SMALL_STATE(209)] = 7846,
+  [SMALL_STATE(210)] = 7856,
+  [SMALL_STATE(211)] = 7866,
+  [SMALL_STATE(212)] = 7873,
+  [SMALL_STATE(213)] = 7880,
+  [SMALL_STATE(214)] = 7887,
+  [SMALL_STATE(215)] = 7894,
+  [SMALL_STATE(216)] = 7901,
+  [SMALL_STATE(217)] = 7908,
+  [SMALL_STATE(218)] = 7915,
+  [SMALL_STATE(219)] = 7922,
+  [SMALL_STATE(220)] = 7929,
+  [SMALL_STATE(221)] = 7936,
+  [SMALL_STATE(222)] = 7941,
+  [SMALL_STATE(223)] = 7948,
+  [SMALL_STATE(224)] = 7955,
+  [SMALL_STATE(225)] = 7962,
+  [SMALL_STATE(226)] = 7969,
+  [SMALL_STATE(227)] = 7974,
+  [SMALL_STATE(228)] = 7981,
+  [SMALL_STATE(229)] = 7988,
+  [SMALL_STATE(230)] = 7995,
+  [SMALL_STATE(231)] = 8000,
+  [SMALL_STATE(232)] = 8007,
+  [SMALL_STATE(233)] = 8014,
+  [SMALL_STATE(234)] = 8021,
+  [SMALL_STATE(235)] = 8028,
+  [SMALL_STATE(236)] = 8035,
+  [SMALL_STATE(237)] = 8039,
+  [SMALL_STATE(238)] = 8043,
+  [SMALL_STATE(239)] = 8047,
+  [SMALL_STATE(240)] = 8051,
+  [SMALL_STATE(241)] = 8055,
+  [SMALL_STATE(242)] = 8059,
+  [SMALL_STATE(243)] = 8063,
+  [SMALL_STATE(244)] = 8067,
+  [SMALL_STATE(245)] = 8071,
+  [SMALL_STATE(246)] = 8075,
+  [SMALL_STATE(247)] = 8079,
+  [SMALL_STATE(248)] = 8083,
+  [SMALL_STATE(249)] = 8087,
+  [SMALL_STATE(250)] = 8091,
+  [SMALL_STATE(251)] = 8095,
+  [SMALL_STATE(252)] = 8099,
+  [SMALL_STATE(253)] = 8103,
+  [SMALL_STATE(254)] = 8107,
+  [SMALL_STATE(255)] = 8111,
+  [SMALL_STATE(256)] = 8115,
+  [SMALL_STATE(257)] = 8119,
+  [SMALL_STATE(258)] = 8123,
+  [SMALL_STATE(259)] = 8127,
+  [SMALL_STATE(260)] = 8131,
+  [SMALL_STATE(261)] = 8135,
+  [SMALL_STATE(262)] = 8139,
+  [SMALL_STATE(263)] = 8143,
+  [SMALL_STATE(264)] = 8147,
+  [SMALL_STATE(265)] = 8151,
+  [SMALL_STATE(266)] = 8155,
+  [SMALL_STATE(267)] = 8159,
+  [SMALL_STATE(268)] = 8163,
+  [SMALL_STATE(269)] = 8167,
+  [SMALL_STATE(270)] = 8171,
+  [SMALL_STATE(271)] = 8175,
+  [SMALL_STATE(272)] = 8179,
+  [SMALL_STATE(273)] = 8183,
+  [SMALL_STATE(274)] = 8187,
+  [SMALL_STATE(275)] = 8191,
+  [SMALL_STATE(276)] = 8195,
+  [SMALL_STATE(277)] = 8199,
+  [SMALL_STATE(278)] = 8203,
+  [SMALL_STATE(279)] = 8207,
+  [SMALL_STATE(280)] = 8211,
+  [SMALL_STATE(281)] = 8215,
+  [SMALL_STATE(282)] = 8219,
+  [SMALL_STATE(283)] = 8223,
+  [SMALL_STATE(284)] = 8227,
+  [SMALL_STATE(285)] = 8231,
+  [SMALL_STATE(286)] = 8235,
+  [SMALL_STATE(287)] = 8239,
+  [SMALL_STATE(288)] = 8243,
+  [SMALL_STATE(289)] = 8247,
+  [SMALL_STATE(290)] = 8251,
+  [SMALL_STATE(291)] = 8255,
+  [SMALL_STATE(292)] = 8259,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
   [3] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 0, 0, 0),
-  [5] = {.entry = {.count = 1, .reusable = false}}, SHIFT(162),
-  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(274),
-  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(229),
-  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(229),
-  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(157),
-  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(241),
-  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(216),
-  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(240),
-  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(239),
-  [23] = {.entry = {.count = 1, .reusable = false}}, SHIFT(71),
-  [25] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 5, 0, 10),
-  [27] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 5, 0, 10),
-  [29] = {.entry = {.count = 1, .reusable = false}}, SHIFT(263),
-  [31] = {.entry = {.count = 1, .reusable = false}}, SHIFT(48),
-  [33] = {.entry = {.count = 1, .reusable = false}}, SHIFT(222),
-  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(222),
-  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(235),
-  [39] = {.entry = {.count = 1, .reusable = true}}, SHIFT(232),
-  [41] = {.entry = {.count = 1, .reusable = true}}, SHIFT(231),
-  [43] = {.entry = {.count = 1, .reusable = true}}, SHIFT(230),
-  [45] = {.entry = {.count = 1, .reusable = false}}, SHIFT(224),
-  [47] = {.entry = {.count = 1, .reusable = true}}, SHIFT(252),
-  [49] = {.entry = {.count = 1, .reusable = false}}, SHIFT(67),
-  [51] = {.entry = {.count = 1, .reusable = false}}, SHIFT(65),
-  [53] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 8, 0, 25),
-  [55] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 8, 0, 25),
-  [57] = {.entry = {.count = 1, .reusable = false}}, SHIFT(56),
-  [59] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 4, 0, 4),
-  [61] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 4, 0, 4),
-  [63] = {.entry = {.count = 1, .reusable = false}}, SHIFT(57),
-  [65] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 10, 0, 56),
-  [67] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 10, 0, 56),
-  [69] = {.entry = {.count = 1, .reusable = false}}, SHIFT(34),
-  [71] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 6, 0, 17),
-  [73] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 6, 0, 17),
-  [75] = {.entry = {.count = 1, .reusable = false}}, SHIFT(33),
-  [77] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 7, 0, 12),
-  [79] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 7, 0, 12),
-  [81] = {.entry = {.count = 1, .reusable = false}}, SHIFT(30),
-  [83] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 5, 0, 13),
-  [85] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 5, 0, 13),
-  [87] = {.entry = {.count = 1, .reusable = false}}, SHIFT(44),
-  [89] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 5, 0, 4),
-  [91] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 5, 0, 4),
-  [93] = {.entry = {.count = 1, .reusable = false}}, SHIFT(42),
-  [95] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 9, 0, 47),
-  [97] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 9, 0, 47),
-  [99] = {.entry = {.count = 1, .reusable = false}}, SHIFT(36),
-  [101] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 9, 0, 25),
-  [103] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 9, 0, 25),
-  [105] = {.entry = {.count = 1, .reusable = false}}, SHIFT(38),
-  [107] = {.entry = {.count = 1, .reusable = false}}, SHIFT(41),
-  [109] = {.entry = {.count = 1, .reusable = false}}, SHIFT(40),
-  [111] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 4, 0, 8),
-  [113] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 4, 0, 8),
-  [115] = {.entry = {.count = 1, .reusable = false}}, SHIFT(54),
-  [117] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 5, 0, 12),
-  [119] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 5, 0, 12),
-  [121] = {.entry = {.count = 1, .reusable = false}}, SHIFT(45),
-  [123] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 3, 0, 4),
-  [125] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 3, 0, 4),
-  [127] = {.entry = {.count = 1, .reusable = false}}, SHIFT(51),
-  [129] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 8, 0, 43),
-  [131] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 8, 0, 43),
-  [133] = {.entry = {.count = 1, .reusable = false}}, SHIFT(50),
-  [135] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 6, 0, 12),
-  [137] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 6, 0, 12),
-  [139] = {.entry = {.count = 1, .reusable = false}}, SHIFT(32),
-  [141] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 6, 0, 19),
-  [143] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 6, 0, 19),
-  [145] = {.entry = {.count = 1, .reusable = false}}, SHIFT(47),
-  [147] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 6, 0, 22),
-  [149] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 6, 0, 22),
-  [151] = {.entry = {.count = 1, .reusable = false}}, SHIFT(35),
-  [153] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 8, 0, 38),
-  [155] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 8, 0, 38),
-  [157] = {.entry = {.count = 1, .reusable = false}}, SHIFT(53),
-  [159] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 7, 0, 25),
-  [161] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 7, 0, 25),
-  [163] = {.entry = {.count = 1, .reusable = false}}, SHIFT(39),
-  [165] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 7, 0, 26),
-  [167] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 7, 0, 26),
-  [169] = {.entry = {.count = 1, .reusable = false}}, SHIFT(43),
-  [171] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 8, 0, 36),
-  [173] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 8, 0, 36),
-  [175] = {.entry = {.count = 1, .reusable = false}}, SHIFT(58),
-  [177] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 6, 0, 10),
-  [179] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 6, 0, 10),
-  [181] = {.entry = {.count = 1, .reusable = false}}, SHIFT(37),
-  [183] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 7, 0, 10),
-  [185] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 7, 0, 10),
-  [187] = {.entry = {.count = 1, .reusable = false}}, SHIFT(46),
-  [189] = {.entry = {.count = 1, .reusable = false}}, SHIFT(31),
-  [191] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 7, 0, 30),
-  [193] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 7, 0, 30),
-  [195] = {.entry = {.count = 1, .reusable = false}}, SHIFT(49),
-  [197] = {.entry = {.count = 1, .reusable = false}}, SHIFT(55),
-  [199] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 8, 0, 52),
-  [201] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 8, 0, 52),
-  [203] = {.entry = {.count = 1, .reusable = false}}, SHIFT(52),
-  [205] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 8, 0, 49),
-  [207] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 8, 0, 49),
-  [209] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 7, 0, 42),
-  [211] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 7, 0, 42),
-  [213] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 7, 0, 39),
-  [215] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 7, 0, 39),
-  [217] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 11, 0, 62),
-  [219] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 11, 0, 62),
-  [221] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 7, 0, 46),
-  [223] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 7, 0, 46),
-  [225] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 10, 0, 60),
-  [227] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 10, 0, 60),
-  [229] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 7, 0, 37),
-  [231] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 7, 0, 37),
-  [233] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 10, 0, 61),
-  [235] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 10, 0, 61),
-  [237] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 8, 0, 48),
-  [239] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 8, 0, 48),
-  [241] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 6, 0, 33),
-  [243] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 6, 0, 33),
-  [245] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 6, 0, 34),
-  [247] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 6, 0, 34),
-  [249] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 6, 0, 31),
-  [251] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 6, 0, 31),
-  [253] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 8, 0, 50),
-  [255] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 8, 0, 50),
-  [257] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 7, 0, 44),
-  [259] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 7, 0, 44),
-  [261] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 6, 0, 27),
-  [263] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 6, 0, 27),
-  [265] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 8, 0, 51),
-  [267] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 8, 0, 51),
-  [269] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 9, 0, 59),
-  [271] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 9, 0, 59),
-  [273] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 4, 0, 16),
-  [275] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 4, 0, 16),
-  [277] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_request_repeat4, 2, 0, 24),
-  [279] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_request_repeat4, 2, 0, 24),
-  [281] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_request_repeat4, 2, 0, 24), SHIFT_REPEAT(52),
-  [284] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_request_repeat4, 2, 0, 24), SHIFT_REPEAT(222),
-  [287] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_request_repeat4, 2, 0, 24), SHIFT_REPEAT(222),
-  [290] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_request_repeat4, 2, 0, 24), SHIFT_REPEAT(235),
-  [293] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_request_repeat4, 2, 0, 24), SHIFT_REPEAT(232),
-  [296] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_request_repeat4, 2, 0, 24), SHIFT_REPEAT(231),
-  [299] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_request_repeat4, 2, 0, 24), SHIFT_REPEAT(230),
-  [302] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_request_repeat4, 2, 0, 24), SHIFT_REPEAT(224),
-  [305] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_request_repeat4, 2, 0, 24), SHIFT_REPEAT(252),
-  [308] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_request_repeat4, 2, 0, 24), SHIFT_REPEAT(67),
+  [5] = {.entry = {.count = 1, .reusable = false}}, SHIFT(168),
+  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(271),
+  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(234),
+  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(234),
+  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(158),
+  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(264),
+  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(225),
+  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(258),
+  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(247),
+  [23] = {.entry = {.count = 1, .reusable = false}}, SHIFT(73),
+  [25] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 6, 0, 22),
+  [27] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 6, 0, 22),
+  [29] = {.entry = {.count = 1, .reusable = false}}, SHIFT(266),
+  [31] = {.entry = {.count = 1, .reusable = false}}, SHIFT(45),
+  [33] = {.entry = {.count = 1, .reusable = false}}, SHIFT(224),
+  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(224),
+  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(267),
+  [39] = {.entry = {.count = 1, .reusable = true}}, SHIFT(215),
+  [41] = {.entry = {.count = 1, .reusable = true}}, SHIFT(235),
+  [43] = {.entry = {.count = 1, .reusable = true}}, SHIFT(212),
+  [45] = {.entry = {.count = 1, .reusable = false}}, SHIFT(214),
+  [47] = {.entry = {.count = 1, .reusable = true}}, SHIFT(250),
+  [49] = {.entry = {.count = 1, .reusable = false}}, SHIFT(64),
+  [51] = {.entry = {.count = 1, .reusable = false}}, SHIFT(78),
+  [53] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 7, 0, 30),
+  [55] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 7, 0, 30),
+  [57] = {.entry = {.count = 1, .reusable = false}}, SHIFT(33),
+  [59] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 5, 0, 10),
+  [61] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 5, 0, 10),
+  [63] = {.entry = {.count = 1, .reusable = false}}, SHIFT(44),
+  [65] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 5, 0, 13),
+  [67] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 5, 0, 13),
+  [69] = {.entry = {.count = 1, .reusable = false}}, SHIFT(58),
+  [71] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 7, 0, 25),
+  [73] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 7, 0, 25),
+  [75] = {.entry = {.count = 1, .reusable = false}}, SHIFT(37),
+  [77] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 4, 0, 4),
+  [79] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 4, 0, 4),
+  [81] = {.entry = {.count = 1, .reusable = false}}, SHIFT(39),
+  [83] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 6, 0, 10),
+  [85] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 6, 0, 10),
+  [87] = {.entry = {.count = 1, .reusable = false}}, SHIFT(51),
+  [89] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 5, 0, 12),
+  [91] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 5, 0, 12),
+  [93] = {.entry = {.count = 1, .reusable = false}}, SHIFT(55),
+  [95] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 6, 0, 17),
+  [97] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 6, 0, 17),
+  [99] = {.entry = {.count = 1, .reusable = false}}, SHIFT(48),
+  [101] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 6, 0, 12),
+  [103] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 6, 0, 12),
+  [105] = {.entry = {.count = 1, .reusable = false}}, SHIFT(47),
+  [107] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 6, 0, 19),
+  [109] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 6, 0, 19),
+  [111] = {.entry = {.count = 1, .reusable = false}}, SHIFT(46),
+  [113] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 10, 0, 56),
+  [115] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 10, 0, 56),
+  [117] = {.entry = {.count = 1, .reusable = false}}, SHIFT(41),
+  [119] = {.entry = {.count = 1, .reusable = false}}, SHIFT(31),
+  [121] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 8, 0, 38),
+  [123] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 8, 0, 38),
+  [125] = {.entry = {.count = 1, .reusable = false}}, SHIFT(52),
+  [127] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 4, 0, 8),
+  [129] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 4, 0, 8),
+  [131] = {.entry = {.count = 1, .reusable = false}}, SHIFT(40),
+  [133] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 7, 0, 26),
+  [135] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 7, 0, 26),
+  [137] = {.entry = {.count = 1, .reusable = false}}, SHIFT(36),
+  [139] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 7, 0, 10),
+  [141] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 7, 0, 10),
+  [143] = {.entry = {.count = 1, .reusable = false}}, SHIFT(35),
+  [145] = {.entry = {.count = 1, .reusable = false}}, SHIFT(34),
+  [147] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 9, 0, 47),
+  [149] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 9, 0, 47),
+  [151] = {.entry = {.count = 1, .reusable = false}}, SHIFT(43),
+  [153] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 9, 0, 25),
+  [155] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 9, 0, 25),
+  [157] = {.entry = {.count = 1, .reusable = false}}, SHIFT(49),
+  [159] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 7, 0, 12),
+  [161] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 7, 0, 12),
+  [163] = {.entry = {.count = 1, .reusable = false}}, SHIFT(32),
+  [165] = {.entry = {.count = 1, .reusable = false}}, SHIFT(54),
+  [167] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 5, 0, 4),
+  [169] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 5, 0, 4),
+  [171] = {.entry = {.count = 1, .reusable = false}}, SHIFT(57),
+  [173] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 3, 0, 4),
+  [175] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 3, 0, 4),
+  [177] = {.entry = {.count = 1, .reusable = false}}, SHIFT(38),
+  [179] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 8, 0, 43),
+  [181] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 8, 0, 43),
+  [183] = {.entry = {.count = 1, .reusable = false}}, SHIFT(53),
+  [185] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 8, 0, 36),
+  [187] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 8, 0, 36),
+  [189] = {.entry = {.count = 1, .reusable = false}}, SHIFT(50),
+  [191] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 8, 0, 25),
+  [193] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 8, 0, 25),
+  [195] = {.entry = {.count = 1, .reusable = false}}, SHIFT(56),
+  [197] = {.entry = {.count = 1, .reusable = false}}, SHIFT(30),
+  [199] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 8, 0, 51),
+  [201] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 8, 0, 51),
+  [203] = {.entry = {.count = 1, .reusable = false}}, SHIFT(42),
+  [205] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 6, 0, 33),
+  [207] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 6, 0, 33),
+  [209] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 8, 0, 52),
+  [211] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 8, 0, 52),
+  [213] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 8, 0, 49),
+  [215] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 8, 0, 49),
+  [217] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 8, 0, 50),
+  [219] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 8, 0, 50),
+  [221] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 8, 0, 48),
+  [223] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 8, 0, 48),
+  [225] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 4, 0, 16),
+  [227] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 4, 0, 16),
+  [229] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 5, 0, 21),
+  [231] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 5, 0, 21),
+  [233] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 5, 0, 23),
+  [235] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 5, 0, 23),
+  [237] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 11, 0, 62),
+  [239] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 11, 0, 62),
+  [241] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_request_repeat4, 2, 0, 24),
+  [243] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_request_repeat4, 2, 0, 24),
+  [245] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_request_repeat4, 2, 0, 24), SHIFT_REPEAT(42),
+  [248] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_request_repeat4, 2, 0, 24), SHIFT_REPEAT(224),
+  [251] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_request_repeat4, 2, 0, 24), SHIFT_REPEAT(224),
+  [254] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_request_repeat4, 2, 0, 24), SHIFT_REPEAT(267),
+  [257] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_request_repeat4, 2, 0, 24), SHIFT_REPEAT(215),
+  [260] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_request_repeat4, 2, 0, 24), SHIFT_REPEAT(235),
+  [263] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_request_repeat4, 2, 0, 24), SHIFT_REPEAT(212),
+  [266] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_request_repeat4, 2, 0, 24), SHIFT_REPEAT(214),
+  [269] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_request_repeat4, 2, 0, 24), SHIFT_REPEAT(250),
+  [272] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_request_repeat4, 2, 0, 24), SHIFT_REPEAT(64),
+  [275] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 10, 0, 60),
+  [277] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 10, 0, 60),
+  [279] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 6, 0, 27),
+  [281] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 6, 0, 27),
+  [283] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 7, 0, 46),
+  [285] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 7, 0, 46),
+  [287] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 7, 0, 44),
+  [289] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 7, 0, 44),
+  [291] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 7, 0, 42),
+  [293] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 7, 0, 42),
+  [295] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 7, 0, 39),
+  [297] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 7, 0, 39),
+  [299] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 10, 0, 61),
+  [301] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 10, 0, 61),
+  [303] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 9, 0, 57),
+  [305] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 9, 0, 57),
+  [307] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 7, 0, 37),
+  [309] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 7, 0, 37),
   [311] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 9, 0, 58),
   [313] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 9, 0, 58),
-  [315] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 5, 0, 23),
-  [317] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 5, 0, 23),
-  [319] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 9, 0, 55),
-  [321] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 9, 0, 55),
-  [323] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 5, 0, 21),
-  [325] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 5, 0, 21),
-  [327] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 9, 0, 57),
-  [329] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 9, 0, 57),
-  [331] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_multipart_form_data, 2, 0, 0),
-  [333] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_multipart_form_data, 2, 0, 0),
-  [335] = {.entry = {.count = 1, .reusable = false}}, SHIFT(221),
-  [337] = {.entry = {.count = 1, .reusable = true}}, SHIFT(221),
-  [339] = {.entry = {.count = 1, .reusable = true}}, SHIFT(61),
-  [341] = {.entry = {.count = 1, .reusable = false}}, SHIFT(61),
-  [343] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 1, 0, 0),
-  [345] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_multipart_form_data, 3, 0, 0),
-  [347] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_multipart_form_data, 3, 0, 0),
-  [349] = {.entry = {.count = 1, .reusable = true}}, SHIFT(62),
-  [351] = {.entry = {.count = 1, .reusable = false}}, SHIFT(62),
-  [353] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_multipart_form_data_repeat1, 2, 0, 0),
-  [355] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_multipart_form_data_repeat1, 2, 0, 0),
-  [357] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_multipart_form_data_repeat1, 2, 0, 0), SHIFT_REPEAT(221),
-  [360] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_multipart_form_data_repeat1, 2, 0, 0), SHIFT_REPEAT(221),
-  [363] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_multipart_form_data_repeat1, 2, 0, 0), SHIFT_REPEAT(62),
-  [366] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_multipart_form_data_repeat1, 2, 0, 0), SHIFT_REPEAT(224),
-  [369] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_multipart_form_data_repeat1, 2, 0, 0), SHIFT_REPEAT(62),
+  [315] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 9, 0, 59),
+  [317] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 9, 0, 59),
+  [319] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 6, 0, 31),
+  [321] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 6, 0, 31),
+  [323] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 9, 0, 55),
+  [325] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 9, 0, 55),
+  [327] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 6, 0, 34),
+  [329] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 6, 0, 34),
+  [331] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_multipart_form_data_repeat1, 2, 0, 0),
+  [333] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_multipart_form_data_repeat1, 2, 0, 0),
+  [335] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_multipart_form_data_repeat1, 2, 0, 0), SHIFT_REPEAT(228),
+  [338] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_multipart_form_data_repeat1, 2, 0, 0), SHIFT_REPEAT(228),
+  [341] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_multipart_form_data_repeat1, 2, 0, 0), SHIFT_REPEAT(59),
+  [344] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_multipart_form_data_repeat1, 2, 0, 0), SHIFT_REPEAT(214),
+  [347] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_multipart_form_data_repeat1, 2, 0, 0), SHIFT_REPEAT(59),
+  [350] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_multipart_form_data, 2, 0, 0),
+  [352] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_multipart_form_data, 2, 0, 0),
+  [354] = {.entry = {.count = 1, .reusable = false}}, SHIFT(228),
+  [356] = {.entry = {.count = 1, .reusable = true}}, SHIFT(228),
+  [358] = {.entry = {.count = 1, .reusable = true}}, SHIFT(61),
+  [360] = {.entry = {.count = 1, .reusable = false}}, SHIFT(61),
+  [362] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_multipart_form_data, 3, 0, 0),
+  [364] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_multipart_form_data, 3, 0, 0),
+  [366] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
+  [368] = {.entry = {.count = 1, .reusable = false}}, SHIFT(59),
+  [370] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 1, 0, 0),
   [372] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0),
-  [374] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(162),
-  [377] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(274),
-  [380] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(229),
-  [383] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(229),
-  [386] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(157),
-  [389] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(241),
-  [392] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(216),
-  [395] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(240),
-  [398] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(239),
-  [401] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(71),
-  [404] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 6, 0, 25),
-  [406] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 6, 0, 25),
-  [408] = {.entry = {.count = 1, .reusable = true}}, SHIFT(263),
-  [410] = {.entry = {.count = 1, .reusable = false}}, SHIFT(212),
-  [412] = {.entry = {.count = 1, .reusable = true}}, SHIFT(212),
-  [414] = {.entry = {.count = 1, .reusable = true}}, SHIFT(289),
-  [416] = {.entry = {.count = 1, .reusable = false}}, SHIFT(223),
-  [418] = {.entry = {.count = 1, .reusable = false}}, SHIFT(22),
-  [420] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_request_repeat3, 2, 0, 0),
-  [422] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_request_repeat3, 2, 0, 0),
-  [424] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_request_repeat3, 2, 0, 0), SHIFT_REPEAT(263),
-  [427] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_request_repeat3, 2, 0, 0), SHIFT_REPEAT(65),
-  [430] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__raw_body, 2, 0, 0),
-  [432] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__raw_body, 2, 0, 0),
-  [434] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym__raw_body, 2, 0, 0), SHIFT(253),
-  [437] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__raw_body, 2, 0, 0), SHIFT(253),
-  [440] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym__raw_body, 2, 0, 0), SHIFT(67),
-  [443] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__raw_body, 1, 0, 0),
-  [445] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__raw_body, 1, 0, 0),
-  [447] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym__raw_body, 1, 0, 0), SHIFT(253),
-  [450] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__raw_body, 1, 0, 0), SHIFT(253),
-  [453] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym__raw_body, 1, 0, 0), SHIFT(67),
-  [456] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 4, 0, 10),
-  [458] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 4, 0, 10),
-  [460] = {.entry = {.count = 1, .reusable = false}}, SHIFT(2),
-  [462] = {.entry = {.count = 1, .reusable = false}}, SHIFT(3),
-  [464] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_xml_body_repeat1, 2, 0, 0),
-  [466] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_xml_body_repeat1, 2, 0, 0),
-  [468] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_xml_body_repeat1, 2, 0, 0), SHIFT_REPEAT(70),
-  [471] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__section_content, 1, 0, 0),
-  [473] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym__section_content, 1, 0, 0), SHIFT(162),
-  [476] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__section_content, 1, 0, 0), SHIFT(274),
-  [479] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym__section_content, 1, 0, 0), SHIFT(229),
-  [482] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__section_content, 1, 0, 0), SHIFT(229),
-  [485] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__section_content, 1, 0, 0), SHIFT(241),
-  [488] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__section_content, 1, 0, 0), SHIFT(216),
-  [491] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__section_content, 1, 0, 0), SHIFT(240),
-  [494] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__section_content, 1, 0, 0), SHIFT(239),
-  [497] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym__section_content, 1, 0, 0), SHIFT(71),
-  [500] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 2, 0, 4),
-  [502] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 2, 0, 4),
-  [504] = {.entry = {.count = 1, .reusable = false}}, SHIFT(16),
-  [506] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_graphql_data, 2, 0, 0),
-  [508] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_graphql_data, 2, 0, 0),
-  [510] = {.entry = {.count = 1, .reusable = false}}, SHIFT(70),
-  [512] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_json_body, 2, 0, 0),
-  [514] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_json_body, 2, 0, 0),
-  [516] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_xml_body, 2, 0, 0),
-  [518] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_xml_body, 2, 0, 0),
-  [520] = {.entry = {.count = 1, .reusable = false}}, SHIFT(4),
-  [522] = {.entry = {.count = 1, .reusable = false}}, SHIFT(18),
-  [524] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 4, 0, 12),
-  [526] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 4, 0, 12),
-  [528] = {.entry = {.count = 1, .reusable = false}}, SHIFT(15),
-  [530] = {.entry = {.count = 1, .reusable = false}}, SHIFT(25),
-  [532] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_section, 1, 0, 0),
-  [534] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_graphql_body, 1, 0, 0),
-  [536] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_graphql_body, 1, 0, 0),
-  [538] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment, 2, 0, 0),
-  [540] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_comment, 2, 0, 0),
-  [542] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment, 4, 0, 11),
-  [544] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_comment, 4, 0, 11),
-  [546] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment, 6, 0, 29),
-  [548] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_comment, 6, 0, 29),
-  [550] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment, 7, 0, 41),
-  [552] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_comment, 7, 0, 41),
-  [554] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_raw_body, 1, 0, 0),
-  [556] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_raw_body, 1, 0, 0),
-  [558] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__blank_line, 2, 0, 0),
-  [560] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__blank_line, 2, 0, 0),
-  [562] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_graphql_body, 2, 0, 0),
-  [564] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_graphql_body, 2, 0, 0),
-  [566] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__external_body, 2, 0, 0),
-  [568] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__external_body, 2, 0, 0),
-  [570] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_res_handler_script, 4, 0, 0),
-  [572] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_res_handler_script, 4, 0, 0),
+  [374] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(168),
+  [377] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(271),
+  [380] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(234),
+  [383] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(234),
+  [386] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(158),
+  [389] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(264),
+  [392] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(225),
+  [395] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(258),
+  [398] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(247),
+  [401] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(73),
+  [404] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_raw_body, 1, 0, 0),
+  [406] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_raw_body, 1, 0, 0),
+  [408] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym_raw_body, 1, 0, 0), SHIFT(276),
+  [411] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_raw_body, 1, 0, 0), SHIFT(276),
+  [414] = {.entry = {.count = 1, .reusable = false}}, SHIFT(65),
+  [416] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__raw_body, 1, 0, 0),
+  [418] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__raw_body, 1, 0, 0),
+  [420] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym__raw_body, 1, 0, 0), SHIFT(276),
+  [423] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__raw_body, 1, 0, 0), SHIFT(276),
+  [426] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_raw_body, 2, 0, 0),
+  [428] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_raw_body, 2, 0, 0),
+  [430] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym_raw_body, 2, 0, 0), SHIFT(276),
+  [433] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_raw_body, 2, 0, 0), SHIFT(276),
+  [436] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__raw_body, 2, 0, 0),
+  [438] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__raw_body, 2, 0, 0),
+  [440] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym__raw_body, 2, 0, 0), SHIFT(276),
+  [443] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__raw_body, 2, 0, 0), SHIFT(276),
+  [446] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment, 7, 0, 41),
+  [448] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_comment, 7, 0, 41),
+  [450] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 4, 0, 10),
+  [452] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 4, 0, 10),
+  [454] = {.entry = {.count = 1, .reusable = true}}, SHIFT(266),
+  [456] = {.entry = {.count = 1, .reusable = false}}, SHIFT(218),
+  [458] = {.entry = {.count = 1, .reusable = true}}, SHIFT(218),
+  [460] = {.entry = {.count = 1, .reusable = true}}, SHIFT(255),
+  [462] = {.entry = {.count = 1, .reusable = false}}, SHIFT(216),
+  [464] = {.entry = {.count = 1, .reusable = false}}, SHIFT(4),
+  [466] = {.entry = {.count = 1, .reusable = false}}, SHIFT(28),
+  [468] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_xml_body, 2, 0, 0),
+  [470] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_xml_body, 2, 0, 0),
+  [472] = {.entry = {.count = 1, .reusable = false}}, SHIFT(79),
+  [474] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_section, 1, 0, 0),
+  [476] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__section_content, 1, 0, 0),
+  [478] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym__section_content, 1, 0, 0), SHIFT(168),
+  [481] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__section_content, 1, 0, 0), SHIFT(271),
+  [484] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym__section_content, 1, 0, 0), SHIFT(234),
+  [487] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__section_content, 1, 0, 0), SHIFT(234),
+  [490] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__section_content, 1, 0, 0), SHIFT(264),
+  [493] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__section_content, 1, 0, 0), SHIFT(225),
+  [496] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__section_content, 1, 0, 0), SHIFT(258),
+  [499] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__section_content, 1, 0, 0), SHIFT(247),
+  [502] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym__section_content, 1, 0, 0), SHIFT(73),
+  [505] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 6, 0, 25),
+  [507] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 6, 0, 25),
+  [509] = {.entry = {.count = 1, .reusable = false}}, SHIFT(6),
+  [511] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 4, 0, 12),
+  [513] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 4, 0, 12),
+  [515] = {.entry = {.count = 1, .reusable = false}}, SHIFT(9),
+  [517] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 2, 0, 4),
+  [519] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 2, 0, 4),
+  [521] = {.entry = {.count = 1, .reusable = false}}, SHIFT(25),
+  [523] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_request_repeat3, 2, 0, 0),
+  [525] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_request_repeat3, 2, 0, 0),
+  [527] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_request_repeat3, 2, 0, 0), SHIFT_REPEAT(266),
+  [530] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_request_repeat3, 2, 0, 0), SHIFT_REPEAT(78),
+  [533] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_xml_body_repeat1, 2, 0, 0),
+  [535] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_xml_body_repeat1, 2, 0, 0),
+  [537] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_xml_body_repeat1, 2, 0, 0), SHIFT_REPEAT(79),
+  [540] = {.entry = {.count = 1, .reusable = false}}, SHIFT(7),
+  [542] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment, 6, 0, 29),
+  [544] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_comment, 6, 0, 29),
+  [546] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment, 4, 0, 11),
+  [548] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_comment, 4, 0, 11),
+  [550] = {.entry = {.count = 1, .reusable = false}}, SHIFT(11),
+  [552] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_graphql_data, 2, 0, 0),
+  [554] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_graphql_data, 2, 0, 0),
+  [556] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_json_body, 2, 0, 0),
+  [558] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_json_body, 2, 0, 0),
+  [560] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment, 2, 0, 0),
+  [562] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_comment, 2, 0, 0),
+  [564] = {.entry = {.count = 1, .reusable = false}}, SHIFT(8),
+  [566] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_graphql_body, 1, 0, 0),
+  [568] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_graphql_body, 1, 0, 0),
+  [570] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__blank_line, 2, 0, 0),
+  [572] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__blank_line, 2, 0, 0),
   [574] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__raw_body, 3, 0, 0),
   [576] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__raw_body, 3, 0, 0),
   [578] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_var_comment, 4, 0, 11),
   [580] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_var_comment, 4, 0, 11),
-  [582] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_var_comment, 7, 0, 41),
-  [584] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_var_comment, 7, 0, 41),
-  [586] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_var_comment, 6, 0, 29),
-  [588] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_var_comment, 6, 0, 29),
-  [590] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_request_repeat4, 1, 0, 15),
-  [592] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_request_repeat4, 1, 0, 15),
-  [594] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 4, 0, 13),
-  [596] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 4, 0, 13),
-  [598] = {.entry = {.count = 1, .reusable = false}}, SHIFT(8),
-  [600] = {.entry = {.count = 1, .reusable = false}}, SHIFT(12),
-  [602] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 7, 0, 36),
-  [604] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 7, 0, 36),
-  [606] = {.entry = {.count = 1, .reusable = false}}, SHIFT(24),
-  [608] = {.entry = {.count = 1, .reusable = false}}, SHIFT(26),
-  [610] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 7, 0, 38),
-  [612] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 7, 0, 38),
-  [614] = {.entry = {.count = 1, .reusable = false}}, SHIFT(21),
-  [616] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 6, 0, 26),
-  [618] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 6, 0, 26),
-  [620] = {.entry = {.count = 1, .reusable = false}}, SHIFT(27),
-  [622] = {.entry = {.count = 1, .reusable = false}}, SHIFT(23),
-  [624] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 5, 0, 17),
-  [626] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 5, 0, 17),
-  [628] = {.entry = {.count = 1, .reusable = false}}, SHIFT(6),
+  [582] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_var_comment, 6, 0, 29),
+  [584] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_var_comment, 6, 0, 29),
+  [586] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_raw_body, 3, 0, 0),
+  [588] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_raw_body, 3, 0, 0),
+  [590] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_var_comment, 7, 0, 41),
+  [592] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_var_comment, 7, 0, 41),
+  [594] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_request_repeat4, 1, 0, 15),
+  [596] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_request_repeat4, 1, 0, 15),
+  [598] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_graphql_body, 2, 0, 0),
+  [600] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_graphql_body, 2, 0, 0),
+  [602] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__external_body, 2, 0, 0),
+  [604] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__external_body, 2, 0, 0),
+  [606] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_res_handler_script, 4, 0, 0),
+  [608] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_res_handler_script, 4, 0, 0),
+  [610] = {.entry = {.count = 1, .reusable = false}}, SHIFT(18),
+  [612] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 3, 0, 8),
+  [614] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 3, 0, 8),
+  [616] = {.entry = {.count = 1, .reusable = false}}, SHIFT(16),
+  [618] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 4, 0, 13),
+  [620] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 4, 0, 13),
+  [622] = {.entry = {.count = 1, .reusable = false}}, SHIFT(14),
+  [624] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 9, 0, 56),
+  [626] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 9, 0, 56),
+  [628] = {.entry = {.count = 1, .reusable = false}}, SHIFT(13),
   [630] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 8, 0, 47),
   [632] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 8, 0, 47),
-  [634] = {.entry = {.count = 1, .reusable = false}}, SHIFT(10),
-  [636] = {.entry = {.count = 1, .reusable = false}}, SHIFT(11),
-  [638] = {.entry = {.count = 1, .reusable = false}}, SHIFT(13),
-  [640] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 9, 0, 56),
-  [642] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 9, 0, 56),
-  [644] = {.entry = {.count = 1, .reusable = false}}, SHIFT(5),
-  [646] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 6, 0, 30),
-  [648] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 6, 0, 30),
-  [650] = {.entry = {.count = 1, .reusable = false}}, SHIFT(29),
-  [652] = {.entry = {.count = 1, .reusable = false}}, SHIFT(7),
-  [654] = {.entry = {.count = 1, .reusable = false}}, SHIFT(28),
-  [656] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 5, 0, 19),
-  [658] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 5, 0, 19),
-  [660] = {.entry = {.count = 1, .reusable = false}}, SHIFT(19),
-  [662] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 3, 0, 8),
-  [664] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 3, 0, 8),
-  [666] = {.entry = {.count = 1, .reusable = false}}, SHIFT(14),
-  [668] = {.entry = {.count = 1, .reusable = false}}, SHIFT(9),
+  [634] = {.entry = {.count = 1, .reusable = false}}, SHIFT(20),
+  [636] = {.entry = {.count = 1, .reusable = false}}, SHIFT(21),
+  [638] = {.entry = {.count = 1, .reusable = false}}, SHIFT(23),
+  [640] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 7, 0, 43),
+  [642] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 7, 0, 43),
+  [644] = {.entry = {.count = 1, .reusable = false}}, SHIFT(26),
+  [646] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 7, 0, 38),
+  [648] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 7, 0, 38),
+  [650] = {.entry = {.count = 1, .reusable = false}}, SHIFT(15),
+  [652] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 6, 0, 26),
+  [654] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 6, 0, 26),
+  [656] = {.entry = {.count = 1, .reusable = false}}, SHIFT(17),
+  [658] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 5, 0, 17),
+  [660] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 5, 0, 17),
+  [662] = {.entry = {.count = 1, .reusable = false}}, SHIFT(10),
+  [664] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 7, 0, 36),
+  [666] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 7, 0, 36),
+  [668] = {.entry = {.count = 1, .reusable = false}}, SHIFT(27),
   [670] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 5, 0, 22),
   [672] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 5, 0, 22),
-  [674] = {.entry = {.count = 1, .reusable = false}}, SHIFT(20),
-  [676] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_request_repeat1, 2, 0, 0),
-  [678] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_request_repeat1, 2, 0, 0),
-  [680] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_request_repeat1, 2, 0, 0), SHIFT_REPEAT(212),
-  [683] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_request_repeat1, 2, 0, 0), SHIFT_REPEAT(212),
-  [686] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 7, 0, 43),
-  [688] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 7, 0, 43),
-  [690] = {.entry = {.count = 1, .reusable = false}}, SHIFT(17),
-  [692] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_request_repeat2, 2, 0, 14),
-  [694] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_request_repeat2, 2, 0, 14),
-  [696] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_request_repeat2, 2, 0, 14), SHIFT_REPEAT(223),
-  [699] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_header, 4, 0, 32),
-  [701] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_header, 4, 0, 32),
-  [703] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_request_repeat2, 1, 0, 7),
-  [705] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_request_repeat2, 1, 0, 7),
-  [707] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_header, 5, 0, 20),
-  [709] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_header, 5, 0, 20),
-  [711] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_header, 4, 0, 20),
-  [713] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_header, 4, 0, 20),
-  [715] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_response, 5, 0, 0),
-  [717] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_response, 5, 0, 0),
-  [719] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_header, 3, 0, 20),
-  [721] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_header, 3, 0, 20),
-  [723] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_header, 5, 0, 45),
-  [725] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_header, 5, 0, 45),
-  [727] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_header, 6, 0, 53),
-  [729] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_header, 6, 0, 53),
-  [731] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_response, 6, 0, 0),
-  [733] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_response, 6, 0, 0),
-  [735] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable_declaration, 6, 0, 28),
-  [737] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_variable_declaration, 6, 0, 28),
-  [739] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__section_content, 2, 0, 3),
-  [741] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__section_content, 2, 0, 3),
-  [743] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_section, 2, 0, 3),
-  [745] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_section, 2, 0, 3),
-  [747] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pre_request_script, 4, 0, 0),
-  [749] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pre_request_script, 4, 0, 0),
-  [751] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request_separator, 3, 0, 0),
-  [753] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request_separator, 3, 0, 0),
-  [755] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable_declaration, 7, 0, 40),
-  [757] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_variable_declaration, 7, 0, 40),
-  [759] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request_separator, 3, 0, 5),
-  [761] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request_separator, 3, 0, 5),
+  [674] = {.entry = {.count = 1, .reusable = false}}, SHIFT(2),
+  [676] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 6, 0, 30),
+  [678] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 6, 0, 30),
+  [680] = {.entry = {.count = 1, .reusable = false}}, SHIFT(29),
+  [682] = {.entry = {.count = 1, .reusable = false}}, SHIFT(24),
+  [684] = {.entry = {.count = 1, .reusable = false}}, SHIFT(22),
+  [686] = {.entry = {.count = 1, .reusable = false}}, SHIFT(3),
+  [688] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request, 5, 0, 19),
+  [690] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request, 5, 0, 19),
+  [692] = {.entry = {.count = 1, .reusable = false}}, SHIFT(12),
+  [694] = {.entry = {.count = 1, .reusable = false}}, SHIFT(5),
+  [696] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_request_repeat1, 2, 0, 0),
+  [698] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_request_repeat1, 2, 0, 0),
+  [700] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_request_repeat1, 2, 0, 0), SHIFT_REPEAT(218),
+  [703] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_request_repeat1, 2, 0, 0), SHIFT_REPEAT(218),
+  [706] = {.entry = {.count = 1, .reusable = false}}, SHIFT(19),
+  [708] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_request_repeat2, 2, 0, 14),
+  [710] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_request_repeat2, 2, 0, 14),
+  [712] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_request_repeat2, 2, 0, 14), SHIFT_REPEAT(216),
+  [715] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_header, 5, 0, 45),
+  [717] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_header, 5, 0, 45),
+  [719] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_request_repeat2, 1, 0, 7),
+  [721] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_request_repeat2, 1, 0, 7),
+  [723] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_header, 5, 0, 20),
+  [725] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_header, 5, 0, 20),
+  [727] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_header, 4, 0, 20),
+  [729] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_header, 4, 0, 20),
+  [731] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_header, 4, 0, 32),
+  [733] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_header, 4, 0, 32),
+  [735] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_header, 3, 0, 20),
+  [737] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_header, 3, 0, 20),
+  [739] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_response, 6, 0, 0),
+  [741] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_response, 6, 0, 0),
+  [743] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_response, 5, 0, 0),
+  [745] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_response, 5, 0, 0),
+  [747] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_header, 6, 0, 53),
+  [749] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_header, 6, 0, 53),
+  [751] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__section_content, 1, 0, 2),
+  [753] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__section_content, 1, 0, 2),
+  [755] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request_separator, 2, 0, 0),
+  [757] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request_separator, 2, 0, 0),
+  [759] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_section, 1, 0, 1),
+  [761] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_section, 1, 0, 1),
   [763] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable_declaration, 5, 0, 18),
   [765] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_variable_declaration, 5, 0, 18),
-  [767] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request_separator, 4, 0, 9),
-  [769] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request_separator, 4, 0, 9),
-  [771] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request_separator, 2, 0, 0),
-  [773] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request_separator, 2, 0, 0),
-  [775] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__section_content, 1, 0, 2),
-  [777] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__section_content, 1, 0, 2),
-  [779] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_section, 1, 0, 1),
-  [781] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_section, 1, 0, 1),
-  [783] = {.entry = {.count = 1, .reusable = true}}, SHIFT(181),
-  [785] = {.entry = {.count = 1, .reusable = false}}, SHIFT(181),
-  [787] = {.entry = {.count = 1, .reusable = false}}, SHIFT(133),
-  [789] = {.entry = {.count = 1, .reusable = true}}, SHIFT(159),
-  [791] = {.entry = {.count = 1, .reusable = false}}, SHIFT(131),
-  [793] = {.entry = {.count = 1, .reusable = true}}, SHIFT(164),
-  [795] = {.entry = {.count = 1, .reusable = true}}, SHIFT(176),
-  [797] = {.entry = {.count = 1, .reusable = false}}, SHIFT(176),
-  [799] = {.entry = {.count = 1, .reusable = true}}, SHIFT(226),
-  [801] = {.entry = {.count = 1, .reusable = true}}, SHIFT(283),
-  [803] = {.entry = {.count = 1, .reusable = false}}, SHIFT(149),
-  [805] = {.entry = {.count = 1, .reusable = true}}, SHIFT(161),
-  [807] = {.entry = {.count = 1, .reusable = true}}, SHIFT(184),
-  [809] = {.entry = {.count = 1, .reusable = false}}, SHIFT(142),
-  [811] = {.entry = {.count = 1, .reusable = true}}, SHIFT(172),
-  [813] = {.entry = {.count = 1, .reusable = false}}, SHIFT(172),
-  [815] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_target_url, 1, 0, 0),
-  [817] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym_target_url, 1, 0, 0), SHIFT(285),
-  [820] = {.entry = {.count = 1, .reusable = true}}, SHIFT(180),
-  [822] = {.entry = {.count = 1, .reusable = false}}, SHIFT(130),
-  [824] = {.entry = {.count = 1, .reusable = true}}, SHIFT(183),
-  [826] = {.entry = {.count = 1, .reusable = true}}, SHIFT(182),
-  [828] = {.entry = {.count = 1, .reusable = true}}, SHIFT(174),
-  [830] = {.entry = {.count = 1, .reusable = true}}, SHIFT(170),
-  [832] = {.entry = {.count = 1, .reusable = false}}, SHIFT(170),
-  [834] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_path, 1, 0, 0),
-  [836] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_path, 1, 0, 0),
-  [838] = {.entry = {.count = 1, .reusable = true}}, SHIFT(227),
-  [840] = {.entry = {.count = 1, .reusable = true}}, SHIFT(175),
-  [842] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_path_repeat1, 2, 0, 0), SHIFT_REPEAT(170),
-  [845] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_path_repeat1, 2, 0, 0), SHIFT_REPEAT(170),
-  [848] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_path_repeat1, 2, 0, 0),
-  [850] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_path_repeat1, 2, 0, 0),
-  [852] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_path_repeat1, 2, 0, 0), SHIFT_REPEAT(227),
-  [855] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_target_url_repeat1, 3, 0, 0),
-  [857] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_target_url_repeat1, 3, 0, 0),
-  [859] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__target_url_line, 2, 0, 0), SHIFT_REPEAT(172),
-  [862] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__target_url_line, 2, 0, 0), SHIFT_REPEAT(172),
-  [865] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__target_url_line, 2, 0, 0),
-  [867] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym__target_url_line, 2, 0, 0),
-  [869] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__target_url_line, 2, 0, 0), SHIFT_REPEAT(216),
-  [872] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_path_repeat1, 2, 0, 0), SHIFT_REPEAT(173),
-  [875] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_path_repeat1, 2, 0, 0), SHIFT_REPEAT(173),
-  [878] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_path_repeat1, 2, 0, 0), SHIFT_REPEAT(226),
-  [881] = {.entry = {.count = 1, .reusable = true}}, SHIFT(173),
-  [883] = {.entry = {.count = 1, .reusable = false}}, SHIFT(173),
-  [885] = {.entry = {.count = 1, .reusable = true}}, SHIFT(168),
-  [887] = {.entry = {.count = 1, .reusable = false}}, SHIFT(168),
-  [889] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_value_repeat1, 2, 0, 0), SHIFT_REPEAT(179),
-  [892] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_value_repeat1, 2, 0, 0), SHIFT_REPEAT(179),
-  [895] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_value_repeat1, 2, 0, 0),
-  [897] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_value_repeat1, 2, 0, 0), SHIFT_REPEAT(216),
-  [900] = {.entry = {.count = 1, .reusable = true}}, SHIFT(179),
-  [902] = {.entry = {.count = 1, .reusable = false}}, SHIFT(179),
-  [904] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_value, 1, 0, 0),
-  [906] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable, 4, 0, 11),
-  [908] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_variable, 4, 0, 11),
-  [910] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable, 3, 0, 6),
-  [912] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_variable, 3, 0, 6),
-  [914] = {.entry = {.count = 1, .reusable = true}}, SHIFT(162),
-  [916] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable, 5, 0, 11),
-  [918] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_variable, 5, 0, 11),
-  [920] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable, 4, 0, 6),
-  [922] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_variable, 4, 0, 6),
-  [924] = {.entry = {.count = 1, .reusable = true}}, SHIFT(171),
-  [926] = {.entry = {.count = 1, .reusable = false}}, SHIFT(171),
-  [928] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_target_url, 2, 0, 0),
-  [930] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_target_url, 2, 0, 0), SHIFT(285),
-  [933] = {.entry = {.count = 1, .reusable = true}}, SHIFT(166),
-  [935] = {.entry = {.count = 1, .reusable = true}}, SHIFT(125),
-  [937] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_target_url_repeat1, 2, 0, 0),
-  [939] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_target_url_repeat1, 2, 0, 0), SHIFT_REPEAT(285),
-  [942] = {.entry = {.count = 1, .reusable = true}}, SHIFT(167),
-  [944] = {.entry = {.count = 1, .reusable = true}}, SHIFT(148),
-  [946] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_script_repeat1, 2, 0, 0), SHIFT_REPEAT(203),
-  [949] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_script_repeat1, 2, 0, 0),
-  [951] = {.entry = {.count = 1, .reusable = true}}, SHIFT(163),
-  [953] = {.entry = {.count = 1, .reusable = true}}, SHIFT(84),
-  [955] = {.entry = {.count = 1, .reusable = true}}, SHIFT(165),
-  [957] = {.entry = {.count = 1, .reusable = true}}, SHIFT(94),
-  [959] = {.entry = {.count = 1, .reusable = false}}, SHIFT(207),
-  [961] = {.entry = {.count = 1, .reusable = true}}, SHIFT(260),
-  [963] = {.entry = {.count = 1, .reusable = false}}, SHIFT(203),
-  [965] = {.entry = {.count = 1, .reusable = true}}, SHIFT(249),
-  [967] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_external_body, 3, 0, 35),
-  [969] = {.entry = {.count = 1, .reusable = true}}, SHIFT(277),
-  [971] = {.entry = {.count = 1, .reusable = true}}, SHIFT(185),
-  [973] = {.entry = {.count = 1, .reusable = true}}, SHIFT(269),
-  [975] = {.entry = {.count = 1, .reusable = true}}, SHIFT(197),
-  [977] = {.entry = {.count = 1, .reusable = true}}, SHIFT(267),
-  [979] = {.entry = {.count = 1, .reusable = true}}, SHIFT(190),
-  [981] = {.entry = {.count = 1, .reusable = false}}, SHIFT(126),
-  [983] = {.entry = {.count = 1, .reusable = true}}, SHIFT(282),
-  [985] = {.entry = {.count = 1, .reusable = true}}, SHIFT(234),
-  [987] = {.entry = {.count = 1, .reusable = true}}, SHIFT(191),
-  [989] = {.entry = {.count = 1, .reusable = true}}, SHIFT(246),
-  [991] = {.entry = {.count = 1, .reusable = true}}, SHIFT(169),
-  [993] = {.entry = {.count = 1, .reusable = true}}, SHIFT(132),
-  [995] = {.entry = {.count = 1, .reusable = true}}, SHIFT(276),
-  [997] = {.entry = {.count = 1, .reusable = false}}, SHIFT(257),
-  [999] = {.entry = {.count = 1, .reusable = false}}, SHIFT(217),
-  [1001] = {.entry = {.count = 1, .reusable = true}}, SHIFT(261),
-  [1003] = {.entry = {.count = 1, .reusable = true}}, SHIFT(194),
-  [1005] = {.entry = {.count = 1, .reusable = true}}, SHIFT(275),
-  [1007] = {.entry = {.count = 1, .reusable = true}}, SHIFT(186),
-  [1009] = {.entry = {.count = 1, .reusable = true}}, SHIFT(81),
-  [1011] = {.entry = {.count = 1, .reusable = true}}, SHIFT(284),
-  [1013] = {.entry = {.count = 1, .reusable = true}}, SHIFT(68),
-  [1015] = {.entry = {.count = 1, .reusable = false}}, SHIFT(83),
-  [1017] = {.entry = {.count = 1, .reusable = true}}, SHIFT(287),
-  [1019] = {.entry = {.count = 1, .reusable = true}}, SHIFT(262),
-  [1021] = {.entry = {.count = 1, .reusable = true}}, SHIFT(66),
-  [1023] = {.entry = {.count = 1, .reusable = true}}, SHIFT(238),
-  [1025] = {.entry = {.count = 1, .reusable = true}}, SHIFT(154),
-  [1027] = {.entry = {.count = 1, .reusable = true}}, SHIFT(177),
-  [1029] = {.entry = {.count = 1, .reusable = true}}, SHIFT(280),
-  [1031] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_external_body, 5, 0, 54),
-  [1033] = {.entry = {.count = 1, .reusable = false}}, SHIFT(281),
-  [1035] = {.entry = {.count = 1, .reusable = false}}, SHIFT(211),
-  [1037] = {.entry = {.count = 1, .reusable = false}}, SHIFT(286),
-  [1039] = {.entry = {.count = 1, .reusable = false}}, SHIFT(218),
-  [1041] = {.entry = {.count = 1, .reusable = true}}, SHIFT(243),
-  [1043] = {.entry = {.count = 1, .reusable = true}}, SHIFT(72),
-  [1045] = {.entry = {.count = 1, .reusable = false}}, SHIFT(137),
-  [1047] = {.entry = {.count = 1, .reusable = true}}, SHIFT(268),
-  [1049] = {.entry = {.count = 1, .reusable = true}}, SHIFT(73),
-  [1051] = {.entry = {.count = 1, .reusable = true}}, SHIFT(74),
-  [1053] = {.entry = {.count = 1, .reusable = true}}, SHIFT(75),
-  [1055] = {.entry = {.count = 1, .reusable = true}}, SHIFT(91),
-  [1057] = {.entry = {.count = 1, .reusable = true}}, SHIFT(192),
-  [1059] = {.entry = {.count = 1, .reusable = true}}, SHIFT(158),
-  [1061] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [1063] = {.entry = {.count = 1, .reusable = true}}, SHIFT(95),
-  [1065] = {.entry = {.count = 1, .reusable = true}}, SHIFT(155),
-  [1067] = {.entry = {.count = 1, .reusable = true}}, SHIFT(214),
-  [1069] = {.entry = {.count = 1, .reusable = true}}, SHIFT(156),
-  [1071] = {.entry = {.count = 1, .reusable = true}}, SHIFT(187),
-  [1073] = {.entry = {.count = 1, .reusable = true}}, SHIFT(266),
-  [1075] = {.entry = {.count = 1, .reusable = true}}, SHIFT(244),
-  [1077] = {.entry = {.count = 1, .reusable = true}}, SHIFT(78),
-  [1079] = {.entry = {.count = 1, .reusable = true}}, SHIFT(146),
-  [1081] = {.entry = {.count = 1, .reusable = true}}, SHIFT(160),
-  [1083] = {.entry = {.count = 1, .reusable = true}}, SHIFT(147),
-  [1085] = {.entry = {.count = 1, .reusable = true}}, SHIFT(96),
-  [1087] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_script, 4, 0, 0),
-  [1089] = {.entry = {.count = 1, .reusable = true}}, SHIFT(141),
-  [1091] = {.entry = {.count = 1, .reusable = true}}, SHIFT(144),
-  [1093] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
-  [1095] = {.entry = {.count = 1, .reusable = true}}, SHIFT(64),
-  [1097] = {.entry = {.count = 1, .reusable = true}}, SHIFT(145),
-  [1099] = {.entry = {.count = 1, .reusable = true}}, SHIFT(178),
-  [1101] = {.entry = {.count = 1, .reusable = true}}, SHIFT(213),
-  [1103] = {.entry = {.count = 1, .reusable = true}}, SHIFT(143),
-  [1105] = {.entry = {.count = 1, .reusable = true}}, SHIFT(92),
-  [1107] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_script, 3, 0, 0),
-  [1109] = {.entry = {.count = 1, .reusable = true}}, SHIFT(196),
-  [1111] = {.entry = {.count = 1, .reusable = true}}, SHIFT(205),
-  [1113] = {.entry = {.count = 1, .reusable = true}}, SHIFT(88),
-  [1115] = {.entry = {.count = 1, .reusable = true}}, SHIFT(138),
-  [1117] = {.entry = {.count = 1, .reusable = true}}, SHIFT(153),
-  [1119] = {.entry = {.count = 1, .reusable = true}}, SHIFT(215),
-  [1121] = {.entry = {.count = 1, .reusable = true}}, SHIFT(198),
-  [1123] = {.entry = {.count = 1, .reusable = true}}, SHIFT(202),
-  [1125] = {.entry = {.count = 1, .reusable = true}}, SHIFT(193),
-  [1127] = {.entry = {.count = 1, .reusable = true}}, SHIFT(124),
-  [1129] = {.entry = {.count = 1, .reusable = true}}, SHIFT(127),
-  [1131] = {.entry = {.count = 1, .reusable = true}}, SHIFT(128),
-  [1133] = {.entry = {.count = 1, .reusable = true}}, SHIFT(135),
-  [1135] = {.entry = {.count = 1, .reusable = true}}, SHIFT(150),
-  [1137] = {.entry = {.count = 1, .reusable = true}}, SHIFT(189),
-  [1139] = {.entry = {.count = 1, .reusable = true}}, SHIFT(136),
-  [1141] = {.entry = {.count = 1, .reusable = true}}, SHIFT(188),
-  [1143] = {.entry = {.count = 1, .reusable = true}}, SHIFT(85),
-  [1145] = {.entry = {.count = 1, .reusable = true}}, SHIFT(86),
-  [1147] = {.entry = {.count = 1, .reusable = true}}, SHIFT(256),
-  [1149] = {.entry = {.count = 1, .reusable = true}}, SHIFT(210),
-  [1151] = {.entry = {.count = 1, .reusable = true}}, SHIFT(200),
-  [1153] = {.entry = {.count = 1, .reusable = true}}, SHIFT(206),
-  [1155] = {.entry = {.count = 1, .reusable = true}}, SHIFT(254),
-  [1157] = {.entry = {.count = 1, .reusable = true}}, SHIFT(195),
-  [1159] = {.entry = {.count = 1, .reusable = true}}, SHIFT(209),
-  [1161] = {.entry = {.count = 1, .reusable = true}}, SHIFT(204),
-  [1163] = {.entry = {.count = 1, .reusable = true}}, SHIFT(134),
-  [1165] = {.entry = {.count = 1, .reusable = true}}, SHIFT(242),
+  [767] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pre_request_script, 4, 0, 0),
+  [769] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pre_request_script, 4, 0, 0),
+  [771] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__section_content, 2, 0, 3),
+  [773] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__section_content, 2, 0, 3),
+  [775] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable_declaration, 7, 0, 40),
+  [777] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_variable_declaration, 7, 0, 40),
+  [779] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_section, 2, 0, 3),
+  [781] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_section, 2, 0, 3),
+  [783] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request_separator, 3, 0, 0),
+  [785] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request_separator, 3, 0, 0),
+  [787] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request_separator, 3, 0, 5),
+  [789] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request_separator, 3, 0, 5),
+  [791] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable_declaration, 6, 0, 28),
+  [793] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_variable_declaration, 6, 0, 28),
+  [795] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_request_separator, 4, 0, 9),
+  [797] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_request_separator, 4, 0, 9),
+  [799] = {.entry = {.count = 1, .reusable = true}}, SHIFT(187),
+  [801] = {.entry = {.count = 1, .reusable = false}}, SHIFT(187),
+  [803] = {.entry = {.count = 1, .reusable = true}}, SHIFT(211),
+  [805] = {.entry = {.count = 1, .reusable = true}}, SHIFT(251),
+  [807] = {.entry = {.count = 1, .reusable = true}}, SHIFT(177),
+  [809] = {.entry = {.count = 1, .reusable = false}}, SHIFT(177),
+  [811] = {.entry = {.count = 1, .reusable = false}}, SHIFT(143),
+  [813] = {.entry = {.count = 1, .reusable = true}}, SHIFT(162),
+  [815] = {.entry = {.count = 1, .reusable = false}}, SHIFT(134),
+  [817] = {.entry = {.count = 1, .reusable = true}}, SHIFT(164),
+  [819] = {.entry = {.count = 1, .reusable = false}}, SHIFT(136),
+  [821] = {.entry = {.count = 1, .reusable = true}}, SHIFT(173),
+  [823] = {.entry = {.count = 1, .reusable = false}}, SHIFT(152),
+  [825] = {.entry = {.count = 1, .reusable = true}}, SHIFT(178),
+  [827] = {.entry = {.count = 1, .reusable = false}}, SHIFT(133),
+  [829] = {.entry = {.count = 1, .reusable = true}}, SHIFT(184),
+  [831] = {.entry = {.count = 1, .reusable = true}}, SHIFT(179),
+  [833] = {.entry = {.count = 1, .reusable = true}}, SHIFT(170),
+  [835] = {.entry = {.count = 1, .reusable = false}}, SHIFT(170),
+  [837] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_path, 1, 0, 0),
+  [839] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_path, 1, 0, 0),
+  [841] = {.entry = {.count = 1, .reusable = true}}, SHIFT(213),
+  [843] = {.entry = {.count = 1, .reusable = true}}, SHIFT(183),
+  [845] = {.entry = {.count = 1, .reusable = false}}, SHIFT(183),
+  [847] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_target_url, 1, 0, 0),
+  [849] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym_target_url, 1, 0, 0), SHIFT(248),
+  [852] = {.entry = {.count = 1, .reusable = true}}, SHIFT(181),
+  [854] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_path_repeat1, 2, 0, 0), SHIFT_REPEAT(170),
+  [857] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_path_repeat1, 2, 0, 0), SHIFT_REPEAT(170),
+  [860] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_path_repeat1, 2, 0, 0),
+  [862] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_path_repeat1, 2, 0, 0),
+  [864] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_path_repeat1, 2, 0, 0), SHIFT_REPEAT(213),
+  [867] = {.entry = {.count = 1, .reusable = true}}, SHIFT(182),
+  [869] = {.entry = {.count = 1, .reusable = true}}, SHIFT(174),
+  [871] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_path_repeat1, 2, 0, 0), SHIFT_REPEAT(175),
+  [874] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_path_repeat1, 2, 0, 0), SHIFT_REPEAT(175),
+  [877] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_path_repeat1, 2, 0, 0), SHIFT_REPEAT(211),
+  [880] = {.entry = {.count = 1, .reusable = true}}, SHIFT(167),
+  [882] = {.entry = {.count = 1, .reusable = false}}, SHIFT(167),
+  [884] = {.entry = {.count = 1, .reusable = true}}, SHIFT(185),
+  [886] = {.entry = {.count = 1, .reusable = false}}, SHIFT(185),
+  [888] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_value, 1, 0, 0),
+  [890] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_target_url_repeat1, 3, 0, 0),
+  [892] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_target_url_repeat1, 3, 0, 0),
+  [894] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__target_url_line, 2, 0, 0), SHIFT_REPEAT(183),
+  [897] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__target_url_line, 2, 0, 0), SHIFT_REPEAT(183),
+  [900] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__target_url_line, 2, 0, 0),
+  [902] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym__target_url_line, 2, 0, 0),
+  [904] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__target_url_line, 2, 0, 0), SHIFT_REPEAT(225),
+  [907] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_value_repeat1, 2, 0, 0), SHIFT_REPEAT(185),
+  [910] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_value_repeat1, 2, 0, 0), SHIFT_REPEAT(185),
+  [913] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_value_repeat1, 2, 0, 0),
+  [915] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_value_repeat1, 2, 0, 0), SHIFT_REPEAT(225),
+  [918] = {.entry = {.count = 1, .reusable = true}}, SHIFT(175),
+  [920] = {.entry = {.count = 1, .reusable = false}}, SHIFT(175),
+  [922] = {.entry = {.count = 1, .reusable = true}}, SHIFT(168),
+  [924] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable, 5, 0, 11),
+  [926] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_variable, 5, 0, 11),
+  [928] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable, 4, 0, 6),
+  [930] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_variable, 4, 0, 6),
+  [932] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable, 3, 0, 6),
+  [934] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_variable, 3, 0, 6),
+  [936] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable, 4, 0, 11),
+  [938] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_variable, 4, 0, 11),
+  [940] = {.entry = {.count = 1, .reusable = true}}, SHIFT(180),
+  [942] = {.entry = {.count = 1, .reusable = false}}, SHIFT(180),
+  [944] = {.entry = {.count = 1, .reusable = false}}, SHIFT(207),
+  [946] = {.entry = {.count = 1, .reusable = true}}, SHIFT(288),
+  [948] = {.entry = {.count = 1, .reusable = true}}, SHIFT(165),
+  [950] = {.entry = {.count = 1, .reusable = true}}, SHIFT(82),
+  [952] = {.entry = {.count = 1, .reusable = true}}, SHIFT(172),
+  [954] = {.entry = {.count = 1, .reusable = true}}, SHIFT(129),
+  [956] = {.entry = {.count = 1, .reusable = true}}, SHIFT(163),
+  [958] = {.entry = {.count = 1, .reusable = true}}, SHIFT(91),
+  [960] = {.entry = {.count = 1, .reusable = true}}, SHIFT(171),
+  [962] = {.entry = {.count = 1, .reusable = true}}, SHIFT(149),
+  [964] = {.entry = {.count = 1, .reusable = false}}, SHIFT(209),
+  [966] = {.entry = {.count = 1, .reusable = true}}, SHIFT(265),
+  [968] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_target_url, 2, 0, 0),
+  [970] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_target_url, 2, 0, 0), SHIFT(248),
+  [973] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_script_repeat1, 2, 0, 0), SHIFT_REPEAT(209),
+  [976] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_script_repeat1, 2, 0, 0),
+  [978] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_target_url_repeat1, 2, 0, 0),
+  [980] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_target_url_repeat1, 2, 0, 0), SHIFT_REPEAT(248),
+  [983] = {.entry = {.count = 1, .reusable = false}}, SHIFT(284),
+  [985] = {.entry = {.count = 1, .reusable = false}}, SHIFT(219),
+  [987] = {.entry = {.count = 1, .reusable = true}}, SHIFT(84),
+  [989] = {.entry = {.count = 1, .reusable = false}}, SHIFT(289),
+  [991] = {.entry = {.count = 1, .reusable = false}}, SHIFT(229),
+  [993] = {.entry = {.count = 1, .reusable = true}}, SHIFT(176),
+  [995] = {.entry = {.count = 1, .reusable = true}}, SHIFT(277),
+  [997] = {.entry = {.count = 1, .reusable = true}}, SHIFT(71),
+  [999] = {.entry = {.count = 1, .reusable = true}}, SHIFT(269),
+  [1001] = {.entry = {.count = 1, .reusable = true}}, SHIFT(161),
+  [1003] = {.entry = {.count = 1, .reusable = true}}, SHIFT(253),
+  [1005] = {.entry = {.count = 1, .reusable = true}}, SHIFT(169),
+  [1007] = {.entry = {.count = 1, .reusable = false}}, SHIFT(130),
+  [1009] = {.entry = {.count = 1, .reusable = true}}, SHIFT(285),
+  [1011] = {.entry = {.count = 1, .reusable = true}}, SHIFT(270),
+  [1013] = {.entry = {.count = 1, .reusable = true}}, SHIFT(199),
+  [1015] = {.entry = {.count = 1, .reusable = true}}, SHIFT(272),
+  [1017] = {.entry = {.count = 1, .reusable = true}}, SHIFT(197),
+  [1019] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_external_body, 5, 0, 54),
+  [1021] = {.entry = {.count = 1, .reusable = true}}, SHIFT(138),
+  [1023] = {.entry = {.count = 1, .reusable = true}}, SHIFT(245),
+  [1025] = {.entry = {.count = 1, .reusable = true}}, SHIFT(237),
+  [1027] = {.entry = {.count = 1, .reusable = true}}, SHIFT(198),
+  [1029] = {.entry = {.count = 1, .reusable = true}}, SHIFT(275),
+  [1031] = {.entry = {.count = 1, .reusable = true}}, SHIFT(66),
+  [1033] = {.entry = {.count = 1, .reusable = false}}, SHIFT(243),
+  [1035] = {.entry = {.count = 1, .reusable = false}}, SHIFT(223),
+  [1037] = {.entry = {.count = 1, .reusable = true}}, SHIFT(74),
+  [1039] = {.entry = {.count = 1, .reusable = true}}, SHIFT(257),
+  [1041] = {.entry = {.count = 1, .reusable = true}}, SHIFT(69),
+  [1043] = {.entry = {.count = 1, .reusable = false}}, SHIFT(86),
+  [1045] = {.entry = {.count = 1, .reusable = true}}, SHIFT(290),
+  [1047] = {.entry = {.count = 1, .reusable = true}}, SHIFT(278),
+  [1049] = {.entry = {.count = 1, .reusable = true}}, SHIFT(191),
+  [1051] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_external_body, 3, 0, 35),
+  [1053] = {.entry = {.count = 1, .reusable = true}}, SHIFT(242),
+  [1055] = {.entry = {.count = 1, .reusable = true}}, SHIFT(77),
+  [1057] = {.entry = {.count = 1, .reusable = true}}, SHIFT(280),
+  [1059] = {.entry = {.count = 1, .reusable = true}}, SHIFT(192),
+  [1061] = {.entry = {.count = 1, .reusable = true}}, SHIFT(260),
+  [1063] = {.entry = {.count = 1, .reusable = true}}, SHIFT(193),
+  [1065] = {.entry = {.count = 1, .reusable = false}}, SHIFT(147),
+  [1067] = {.entry = {.count = 1, .reusable = true}}, SHIFT(240),
+  [1069] = {.entry = {.count = 1, .reusable = true}}, SHIFT(85),
+  [1071] = {.entry = {.count = 1, .reusable = true}}, SHIFT(145),
+  [1073] = {.entry = {.count = 1, .reusable = true}}, SHIFT(195),
+  [1075] = {.entry = {.count = 1, .reusable = true}}, SHIFT(155),
+  [1077] = {.entry = {.count = 1, .reusable = true}}, SHIFT(95),
+  [1079] = {.entry = {.count = 1, .reusable = true}}, SHIFT(206),
+  [1081] = {.entry = {.count = 1, .reusable = true}}, SHIFT(93),
+  [1083] = {.entry = {.count = 1, .reusable = true}}, SHIFT(254),
+  [1085] = {.entry = {.count = 1, .reusable = true}}, SHIFT(233),
+  [1087] = {.entry = {.count = 1, .reusable = true}}, SHIFT(139),
+  [1089] = {.entry = {.count = 1, .reusable = true}}, SHIFT(137),
+  [1091] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [1093] = {.entry = {.count = 1, .reusable = true}}, SHIFT(217),
+  [1095] = {.entry = {.count = 1, .reusable = true}}, SHIFT(201),
+  [1097] = {.entry = {.count = 1, .reusable = true}}, SHIFT(153),
+  [1099] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
+  [1101] = {.entry = {.count = 1, .reusable = true}}, SHIFT(202),
+  [1103] = {.entry = {.count = 1, .reusable = true}}, SHIFT(146),
+  [1105] = {.entry = {.count = 1, .reusable = true}}, SHIFT(166),
+  [1107] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
+  [1109] = {.entry = {.count = 1, .reusable = true}}, SHIFT(268),
+  [1111] = {.entry = {.count = 1, .reusable = true}}, SHIFT(186),
+  [1113] = {.entry = {.count = 1, .reusable = true}}, SHIFT(291),
+  [1115] = {.entry = {.count = 1, .reusable = true}}, SHIFT(160),
+  [1117] = {.entry = {.count = 1, .reusable = true}}, SHIFT(100),
+  [1119] = {.entry = {.count = 1, .reusable = true}}, SHIFT(194),
+  [1121] = {.entry = {.count = 1, .reusable = true}}, SHIFT(131),
+  [1123] = {.entry = {.count = 1, .reusable = true}}, SHIFT(141),
+  [1125] = {.entry = {.count = 1, .reusable = true}}, SHIFT(150),
+  [1127] = {.entry = {.count = 1, .reusable = true}}, SHIFT(188),
+  [1129] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_script, 4, 0, 0),
+  [1131] = {.entry = {.count = 1, .reusable = true}}, SHIFT(89),
+  [1133] = {.entry = {.count = 1, .reusable = true}}, SHIFT(157),
+  [1135] = {.entry = {.count = 1, .reusable = true}}, SHIFT(283),
+  [1137] = {.entry = {.count = 1, .reusable = true}}, SHIFT(159),
+  [1139] = {.entry = {.count = 1, .reusable = true}}, SHIFT(196),
+  [1141] = {.entry = {.count = 1, .reusable = true}}, SHIFT(142),
+  [1143] = {.entry = {.count = 1, .reusable = true}}, SHIFT(200),
+  [1145] = {.entry = {.count = 1, .reusable = true}}, SHIFT(128),
+  [1147] = {.entry = {.count = 1, .reusable = true}}, SHIFT(127),
+  [1149] = {.entry = {.count = 1, .reusable = true}}, SHIFT(205),
+  [1151] = {.entry = {.count = 1, .reusable = true}}, SHIFT(67),
+  [1153] = {.entry = {.count = 1, .reusable = true}}, SHIFT(256),
+  [1155] = {.entry = {.count = 1, .reusable = true}}, SHIFT(190),
+  [1157] = {.entry = {.count = 1, .reusable = true}}, SHIFT(135),
+  [1159] = {.entry = {.count = 1, .reusable = true}}, SHIFT(189),
+  [1161] = {.entry = {.count = 1, .reusable = true}}, SHIFT(81),
+  [1163] = {.entry = {.count = 1, .reusable = true}}, SHIFT(68),
+  [1165] = {.entry = {.count = 1, .reusable = true}}, SHIFT(222),
+  [1167] = {.entry = {.count = 1, .reusable = true}}, SHIFT(220),
+  [1169] = {.entry = {.count = 1, .reusable = true}}, SHIFT(204),
+  [1171] = {.entry = {.count = 1, .reusable = true}}, SHIFT(156),
+  [1173] = {.entry = {.count = 1, .reusable = true}}, SHIFT(154),
+  [1175] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_script, 3, 0, 0),
+  [1177] = {.entry = {.count = 1, .reusable = true}}, SHIFT(232),
+  [1179] = {.entry = {.count = 1, .reusable = true}}, SHIFT(203),
+  [1181] = {.entry = {.count = 1, .reusable = true}}, SHIFT(75),
+  [1183] = {.entry = {.count = 1, .reusable = true}}, SHIFT(99),
 };
 
 #ifdef __cplusplus

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -47,6 +47,7 @@ struct TSLexer {
   uint32_t (*get_column)(TSLexer *);
   bool (*is_at_included_range_start)(const TSLexer *);
   bool (*eof)(const TSLexer *);
+  void (*log)(const TSLexer *, const char *, ...);
 };
 
 typedef enum {

--- a/test/corpus/body.txt
+++ b/test/corpus/body.txt
@@ -253,6 +253,31 @@ Content-Type: application/json
     body: (external_body
       path: (path)))))
 
+=========================================
+External body file and response handler
+=========================================
+
+POST https://example.com/api/v1/users/new
+Content-Type: application/json
+
+< ./user.json
+
+> ./script.js
+
+---
+
+(document
+  (section
+  request: (request
+    method: (method)
+    url: (target_url)
+    header: (header
+      name: (header_entity)
+      value: (value))
+    body: (external_body
+      path: (path))
+    (res_handler_script
+      (path)))))
 
 ===================
 Raw body text


### PR DESCRIPTION
as mentioned [here](https://github.com/rest-nvim/tree-sitter-http/pull/40#issuecomment-2321944190)

empty lines between an intended body and things that follow body (currently just response handler scripts) are currently being captured as (raw_body). this change requires a raw body to start with a non-empty line