### PR TITLE
feat: add rust bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
-bindings
 build
 testfile
 log.html
+target
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,18 +9,16 @@ edition = "2018"
 license = "MIT"
 
 build = "bindings/rust/build.rs"
-include = [
-  "bindings/rust/*",
-  "grammar.js",
-  "queries/*",
-  "src/*",
-]
+include = ["bindings/rust/*", "grammar.js", "queries/*", "src/*"]
 
 [lib]
 path = "bindings/rust/lib.rs"
 
 [dependencies]
 tree-sitter-language = "0.1.0"
+
+[dev-dependencies]
+tree-sitter = "0.25"
 
 [build-dependencies]
 cc = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.0.1"
 keywords = ["incremental", "parsing", "http"]
 categories = ["parsing", "text-editors"]
 repository = "https://github.com/tree-sitter/tree-sitter-javascript"
-edition = "2018"
+edition = "2024"
 license = "MIT"
 
 build = "bindings/rust/build.rs"
@@ -15,7 +15,7 @@ include = ["bindings/rust/*", "grammar.js", "queries/*", "src/*"]
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter-language = "0.1.0"
+tree-sitter-language = "0.1"
 
 [dev-dependencies]
 tree-sitter = "0.25"

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -1,0 +1,9 @@
+fn main() {
+    // Tell Cargo to rerun this build script if parser.c changes
+    println!("cargo:rerun-if-changed=src/parser.c");
+
+    cc::Build::new()
+        .file("src/parser.c")
+        .include("src/tree_sitter")
+        .compile("tree-sitter-http");
+}

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -1,6 +1,6 @@
 use tree_sitter_language::LanguageFn;
 
-extern "C" {
+unsafe extern "C" {
     fn tree_sitter_http() -> *const ();
 }
 

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -1,0 +1,27 @@
+use tree_sitter_language::LanguageFn;
+
+extern "C" {
+    fn tree_sitter_http() -> *const ();
+}
+
+/// The tree-sitter [`LanguageFn`][LanguageFn] for this grammar.
+///
+/// [LanguageFn]: https://docs.rs/tree-sitter-language/*/tree_sitter_language/struct.LanguageFn.html
+pub const LANGUAGE: LanguageFn = unsafe { LanguageFn::from_raw(tree_sitter_http) };
+
+/// The syntax highlighting query for this language.
+pub const HIGHLIGHTS_QUERY: &str = include_str!("../../queries/highlights.scm");
+
+/// The injections query for this language.
+pub const INJECTIONS_QUERY: &str = include_str!("../../queries/injections.scm");
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_can_load_grammar() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&super::LANGUAGE.into())
+            .expect("Error loading Rust parser");
+    }
+}


### PR DESCRIPTION
Thanks for this tree sitter implementation. It seems to be quite common to have bindings for many language (as I can see in other tree sitter extensions).
It would be nice to add rust bindings (inspired by the `tree-sitter-rust` plugin itself).